### PR TITLE
feat!: basically support cron

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom 7.1.3",
+ "once_cell",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +964,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1000,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1301,6 +1328,7 @@ dependencies = [
  "clap_usage",
  "comfy-table",
  "console",
+ "cron",
  "dirs",
  "duct 0.13.7",
  "exec",
@@ -2129,7 +2157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f"
 dependencies = [
  "itertools 0.14.0",
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ clap = { version = "4", features = ["derive"] }
 clap_usage = "2"
 comfy-table = "7.1.3"
 console = "0.15"
+cron = "0.12"
 dirs = "5"
 duct = "0.13"
 exponential-backoff = "2"

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,8 +2,15 @@ import { defineConfig } from "vitepress";
 
 import spec from "../cli/commands.json";
 
-function getCommands(cmd): string[][] {
-  const commands = [];
+interface Cmd {
+  name: string;
+  full_cmd: string[];
+  subcommands: Record<string, Cmd>;
+  hide?: boolean;
+}
+
+function getCommands(cmd: Cmd): string[][] {
+  const commands: string[][] = [];
   for (const [name, sub] of Object.entries(cmd.subcommands)) {
     if (sub.hide) continue;
     commands.push(sub.full_cmd);
@@ -29,6 +36,7 @@ export default defineConfig({
     sidebar: [
       { text: "Getting Started", link: "/getting-started" },
       { text: "Integration with mise", link: "/mise" },
+      { text: "Cron Scheduling", link: "/cron" },
       {
         text: "CLI Reference",
         link: "/cli",

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -1,0 +1,92 @@
+# Cron Scheduling
+
+Pitchfork supports cron-based scheduling for daemons, allowing you to run commands on a schedule with flexible retrigger behaviors.
+
+## Configuration
+
+Add a `cron` section to your daemon configuration in `pitchfork.toml`:
+
+```toml
+[daemons.my-task]
+run = "./scripts/my-script.sh"
+cron = { schedule = "0 2 * * *", retrigger = "finish" } # Run at 2 AM every day
+```
+
+## Retrigger Behavior
+
+The `retrigger` field controls what happens when the scheduled time arrives:
+
+### `finish` (Default)
+
+Retrigger the command only if the previous execution has finished (whether it succeeded or failed). If the previous command is still running, do nothing.
+
+**Use case:** Long-running tasks that should not overlap, like backups or data processing jobs.
+
+```toml
+[daemons.backup]
+run = "./backup.sh"
+cron = { schedule = "0 2 * * *", retrigger = "finish" }
+```
+
+### `always`
+
+Always retrigger the command at the scheduled time. If the previous command is still running, stop it first, then start a new execution.
+
+**Use case:** Health checks or monitoring tasks where you always want the latest execution.
+
+```toml
+[daemons.health-check]
+run = "curl -f http://localhost:8080/health"
+cron = { schedule = "*/5 * * * *", retrigger = "always" }
+```
+
+### `success`
+
+Retrigger the command only if the previous execution finished successfully (exit code 0). If the previous command failed or is still running, do nothing.
+
+**Use case:** Chained tasks where the next execution should only run if the previous one succeeded.
+
+```toml
+[daemons.process-data]
+run = "./process.sh"
+cron = { schedule = "0 * * * *", retrigger = "success" }
+```
+
+### `fail`
+
+Retrigger the command only if the previous execution failed (non-zero exit code). If the previous command succeeded or is still running, do nothing.
+
+**Use case:** Retry logic for tasks that may fail temporarily.
+
+```toml
+[daemons.retry-task]
+run = "./flaky-task.sh"
+cron = { schedule = "*/10 * * * *", retrigger = "fail" }
+```
+
+## Starting Cron Daemons
+
+Cron daemons are started like regular daemons:
+
+```bash
+# Start a specific cron daemon
+pitchfork start my-cron-task
+
+# Start all daemons (including cron ones)
+pitchfork start --all
+```
+
+Once started, the supervisor will automatically trigger the daemon according to its cron schedule and retrigger policy.
+
+## Monitoring
+
+You can monitor cron daemons like any other daemon:
+
+```bash
+# View status of all daemons
+pitchfork status
+
+# View logs
+pitchfork logs my-cron-task
+```
+

--- a/src/cli/config/add.rs
+++ b/src/cli/config/add.rs
@@ -34,6 +34,7 @@ impl Add {
             PitchforkTomlDaemon {
                 run: shell_words::join(&self.args),
                 auto,
+                cron: None,
                 path: None,
             },
         );

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -32,6 +32,8 @@ impl Run {
                 force: self.force,
                 dir: env::CWD.clone(),
                 autostop: false,
+                cron_schedule: None,
+                cron_retrigger: None,
             })
             .await?;
 

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -69,6 +69,8 @@ impl Start {
                             .parent()
                             .map(|p| p.to_path_buf())
                             .unwrap_or_default(),
+                        cron_schedule: daemon.cron.as_ref().map(|c| c.schedule.clone()),
+                        cron_retrigger: daemon.cron.as_ref().map(|c| c.retrigger),
                     })
                     .await?;
                 if !started.is_empty() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,4 +1,5 @@
 use crate::daemon_status::DaemonStatus;
+use crate::pitchfork_toml::CronRetrigger;
 use std::fmt::Display;
 use std::path::PathBuf;
 
@@ -11,6 +12,12 @@ pub struct Daemon {
     pub status: DaemonStatus,
     pub dir: Option<PathBuf>,
     pub autostop: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cron_schedule: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cron_retrigger: Option<CronRetrigger>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub last_exit_success: Option<bool>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -21,6 +28,8 @@ pub struct RunOptions {
     pub shell_pid: Option<u32>,
     pub dir: PathBuf,
     pub autostop: bool,
+    pub cron_schedule: Option<String>,
+    pub cron_retrigger: Option<CronRetrigger>,
 }
 
 impl Display for Daemon {

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -72,8 +72,34 @@ pub struct PitchforkTomlDaemon {
     pub run: String,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub auto: Vec<PitchforkTomlAuto>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cron: Option<PitchforkTomlCron>,
     #[serde(skip)]
     pub path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PitchforkTomlCron {
+    pub schedule: String,
+    #[serde(default = "default_retrigger")]
+    pub retrigger: CronRetrigger,
+}
+
+fn default_retrigger() -> CronRetrigger {
+    CronRetrigger::Finish
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CronRetrigger {
+    /// Retrigger if the previous command is finished (success or error)
+    Finish,
+    /// Always retrigger, stop the previous command if running
+    Always,
+    /// Retrigger only if the previous command succeeded
+    Success,
+    /// Retrigger only if the previous command failed
+    Fail,
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
Here are some points:

- In the function `stop`, killing processes will not return error. This is because in cron works, the process may exit at the exact time. And this should not lead to an error.
- In the function `run`, if the pid of current daemon != the monitored pid, just return from the function, to avoid the status of old process overlaps the status of new process.

PS: my english is not good and I hope you understand my words. sorry.

Now the cron feature basically runs, and I will work on more details.