### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0](https://github.com/jdx/pitchfork/compare/v2.3.0...v2.4.0) - 2026-04-09
+
+### Added
+
+- add mcp tools ([#311](https://github.com/jdx/pitchfork/pull/311))
+- impl container mode ([#305](https://github.com/jdx/pitchfork/pull/305))
+
+### Fixed
+
+- use correct base dir for `.config/pitchfork.toml` case ([#307](https://github.com/jdx/pitchfork/pull/307))
+- use FSEvent on macos to avoid `Too many files` ([#301](https://github.com/jdx/pitchfork/pull/301))
+
+### Other
+
+- *(deps)* lock file maintenance ([#310](https://github.com/jdx/pitchfork/pull/310))
+
 ## [2.3.0](https://github.com/jdx/pitchfork/compare/v2.2.0...v2.3.0) - 2026-03-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,7 +2077,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1909,7 +1909,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.3.0",
+  "version": "2.4.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.3.0
+**Version**: 2.4.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.3.0"
+version "2.4.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.3.0 -> 2.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.4.0](https://github.com/jdx/pitchfork/compare/v2.3.0...v2.4.0) - 2026-04-09

### Added

- add mcp tools ([#311](https://github.com/jdx/pitchfork/pull/311))
- impl container mode ([#305](https://github.com/jdx/pitchfork/pull/305))

### Fixed

- use correct base dir for `.config/pitchfork.toml` case ([#307](https://github.com/jdx/pitchfork/pull/307))
- use FSEvent on macos to avoid `Too many files` ([#301](https://github.com/jdx/pitchfork/pull/301))

### Other

- *(deps)* lock file maintenance ([#310](https://github.com/jdx/pitchfork/pull/310))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates version metadata and the changelog, without changing runtime code paths.
> 
> **Overview**
> Bumps `pitchfork-cli` from **2.3.0** to **2.4.0** in `Cargo.toml`/`Cargo.lock` and adds the `2.4.0` entry to `CHANGELOG.md` documenting the release contents (MCP tools, container mode, and a few fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7647a481d38dee7a8aec812d89e17653d141d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->