### PR TITLE
chore: release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.1](https://github.com/jdx/pitchfork/compare/v2.4.0...v2.4.1) - 2026-04-10
+
+### Other
+
+- update inconsistencies in docs ([#312](https://github.com/jdx/pitchfork/pull/312))
+
 ## [2.4.0](https://github.com/jdx/pitchfork/compare/v2.3.0...v2.4.0) - 2026-04-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,7 +2077,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.4.0"
+version = "2.4.1"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1909,7 +1909,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.4.0",
+  "version": "2.4.1",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.4.0
+**Version**: 2.4.1
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.4.0"
+version "2.4.1"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.4.0 -> 2.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.4.1](https://github.com/jdx/pitchfork/compare/v2.4.0...v2.4.1) - 2026-04-10

### Other

- update inconsistencies in docs ([#312](https://github.com/jdx/pitchfork/pull/312))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version numbers and generated CLI docs are updated, with no functional code changes.
> 
> **Overview**
> Bumps `pitchfork-cli` version from `2.4.0` to `2.4.1` across `Cargo.toml`, `Cargo.lock`, and the usage/doc generation outputs (`pitchfork.usage.kdl`, `docs/cli/*`).
> 
> Updates `CHANGELOG.md` with the `2.4.1` release entry noting documentation inconsistency fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23672a29f48c71798d235c2fb43418567b734865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->