### PR TITLE
chore: release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0](https://github.com/jdx/pitchfork/compare/v2.5.0...v2.6.0) - 2026-04-12
+
+### Added
+
+- *(proxy)* auto start when visiting the proxied URL ([#347](https://github.com/jdx/pitchfork/pull/347))
+
+### Fixed
+
+- some issues related to sudo supervisor ([#323](https://github.com/jdx/pitchfork/pull/323))
+- *(port)* should fail when ready_port is in use ([#350](https://github.com/jdx/pitchfork/pull/350))
+- *(deps)* update rcgen to 0.14 ([#349](https://github.com/jdx/pitchfork/pull/349))
+- *(deps)* update reqwest to 0.13 ([#348](https://github.com/jdx/pitchfork/pull/348))
+- detect port conflicts on loopback addresses, not just 0.0.0.0 ([#345](https://github.com/jdx/pitchfork/pull/345))
+- narrow REAPED_STATUSES cfg to non-Linux unix only ([#346](https://github.com/jdx/pitchfork/pull/346))
+- *(deps)* update rust crate ratatui to 0.30 ([#331](https://github.com/jdx/pitchfork/pull/331))
+- *(deps)* update rust crate toml to v1 ([#344](https://github.com/jdx/pitchfork/pull/344))
+- *(deps)* update rust crate strum to 0.28 ([#334](https://github.com/jdx/pitchfork/pull/334))
+- *(deps)* update rust crate notify-debouncer-full to 0.7 ([#330](https://github.com/jdx/pitchfork/pull/330))
+- *(deps)* update rust crate nix to 0.31 ([#329](https://github.com/jdx/pitchfork/pull/329))
+- *(deps)* update rust crate listeners to 0.5 ([#328](https://github.com/jdx/pitchfork/pull/328))
+- *(deps)* update rust crate sysinfo to 0.38 ([#335](https://github.com/jdx/pitchfork/pull/335))
+- *(deps)* update rust crate cron to 0.16 ([#324](https://github.com/jdx/pitchfork/pull/324))
+- *(deps)* update rust crate crossterm to 0.29 ([#325](https://github.com/jdx/pitchfork/pull/325))
+
+### Other
+
+- *(deps)* update rust crate rmcp to v1.4.0 ([#327](https://github.com/jdx/pitchfork/pull/327))
+
 ## [2.5.0](https://github.com/jdx/pitchfork/compare/v2.4.0...v2.5.0) - 2026-04-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,7 +2505,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2081,7 +2081,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.5.0",
+  "version": "2.6.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.5.0
+**Version**: 2.6.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.5.0"
+version "2.6.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.5.0 -> 2.6.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.6.0](https://github.com/jdx/pitchfork/compare/v2.5.0...v2.6.0) - 2026-04-12

### Added

- *(proxy)* auto start when visiting the proxied URL ([#347](https://github.com/jdx/pitchfork/pull/347))

### Fixed

- some issues related to sudo supervisor ([#323](https://github.com/jdx/pitchfork/pull/323))
- *(port)* should fail when ready_port is in use ([#350](https://github.com/jdx/pitchfork/pull/350))
- *(deps)* update rcgen to 0.14 ([#349](https://github.com/jdx/pitchfork/pull/349))
- *(deps)* update reqwest to 0.13 ([#348](https://github.com/jdx/pitchfork/pull/348))
- detect port conflicts on loopback addresses, not just 0.0.0.0 ([#345](https://github.com/jdx/pitchfork/pull/345))
- narrow REAPED_STATUSES cfg to non-Linux unix only ([#346](https://github.com/jdx/pitchfork/pull/346))
- *(deps)* update rust crate ratatui to 0.30 ([#331](https://github.com/jdx/pitchfork/pull/331))
- *(deps)* update rust crate toml to v1 ([#344](https://github.com/jdx/pitchfork/pull/344))
- *(deps)* update rust crate strum to 0.28 ([#334](https://github.com/jdx/pitchfork/pull/334))
- *(deps)* update rust crate notify-debouncer-full to 0.7 ([#330](https://github.com/jdx/pitchfork/pull/330))
- *(deps)* update rust crate nix to 0.31 ([#329](https://github.com/jdx/pitchfork/pull/329))
- *(deps)* update rust crate listeners to 0.5 ([#328](https://github.com/jdx/pitchfork/pull/328))
- *(deps)* update rust crate sysinfo to 0.38 ([#335](https://github.com/jdx/pitchfork/pull/335))
- *(deps)* update rust crate cron to 0.16 ([#324](https://github.com/jdx/pitchfork/pull/324))
- *(deps)* update rust crate crossterm to 0.29 ([#325](https://github.com/jdx/pitchfork/pull/325))

### Other

- *(deps)* update rust crate rmcp to v1.4.0 ([#327](https://github.com/jdx/pitchfork/pull/327))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the crate version and updates release notes, with no runtime code changes.
> 
> **Overview**
> Prepares the `pitchfork-cli` **v2.6.0** release by bumping the package version from `2.5.0` to `2.6.0` in `Cargo.toml`/`Cargo.lock`.
> 
> Updates `CHANGELOG.md` with the `2.6.0` release notes (proxy auto-start behavior, several fixes, and dependency updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faea6c5282b5dc1cd217f33e8d4b987c460f2b66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->