### PR TITLE
fix: narrow REAPED_STATUSES cfg to non-Linux unix only

### DIFF
--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -48,7 +48,7 @@ use tokio::{signal, time};
 ///
 /// On Linux this map is unused because the reaper uses `waitid` with `WNOWAIT`
 /// to peek before reaping, which avoids the race entirely.
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 pub(crate) static REAPED_STATUSES: Lazy<Mutex<HashMap<u32, i32>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 


### PR DESCRIPTION
## Summary
- `REAPED_STATUSES` was declared with `#[cfg(unix)]` but only written/read behind `#[cfg(all(unix, not(target_os = "linux")))]`
- On Linux CI, this caused a `dead_code` warning that fails `clippy -D warnings`
- Narrowed the declaration's cfg gate to match its actual usage

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes on Linux without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens a `cfg` gate for a static used exclusively on non-Linux Unix, reducing Linux-only `dead_code`/clippy warnings without changing runtime behavior on supported paths.
> 
> **Overview**
> Narrowed the `REAPED_STATUSES` static’s compile-time `cfg` from `#[cfg(unix)]` to `#[cfg(all(unix, not(target_os = "linux")))]` so it is only compiled on platforms where it’s actually used.
> 
> This avoids Linux `dead_code` warnings (and resulting `clippy -D warnings` failures) while leaving Linux zombie-reaping behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d5337047b6b2c04b192fd44a10ff5263d15a799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->