### PR TITLE
fix(deps): update rcgen to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -109,15 +109,15 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -745,9 +745,9 @@ checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -2233,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
@@ -2512,6 +2512,7 @@ dependencies = [
  "tower-http",
  "urlencoding",
  "uuid",
+ "x509-parser",
  "xx",
 ]
 
@@ -2725,9 +2726,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
  "pem",
  "ring",
@@ -4847,9 +4848,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -4859,7 +4860,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["proxy-tls"]
-proxy-tls = ["rcgen", "tokio-rustls", "rustls-pemfile"]
+proxy-tls = ["rcgen", "tokio-rustls", "rustls-pemfile", "x509-parser"]
 
 [dependencies]
 auto-launcher = "0.6.0"
@@ -68,12 +68,13 @@ hyper-util = { version = "0.1", features = [
     "tokio",
 ] }
 http-body-util = "0.1"
-rcgen = { version = "0.13", optional = true, features = ["x509-parser"] }
+rcgen = { version = "0.14", optional = true, features = ["x509-parser"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["ring", "tls12"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 # Force hyper-rustls (pulled in by reqwest) to use ring instead of aws-lc-rs.
 hyper-rustls = { version = "0.27", default-features = false, features = ["ring", "http1", "http2", "tls12"] }
 rustls-pemfile = { version = "2", optional = true }
+x509-parser = { version = "0.18", optional = true }
 tokio-stream = "0.1"
 async-stream = "0.3"
 urlencoding = "2"

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -490,10 +490,8 @@ pub fn generate_ca(cert_path: &std::path::Path, key_path: &std::path::Path) -> c
 /// acceptable.
 #[cfg(feature = "proxy-tls")]
 struct SniCertResolver {
-    /// The CA key pair (used to sign leaf certs).
-    ca_key: rcgen::KeyPair,
-    /// The CA certificate (used as issuer for leaf certs).
-    ca_cert: rcgen::Certificate,
+    /// The CA issuer (key + parsed cert params, used to sign leaf certs).
+    issuer: rcgen::Issuer<'static, rcgen::KeyPair>,
     /// Directory where per-domain PEM files are cached on disk.
     host_certs_dir: std::path::PathBuf,
     /// L1 cache: domain → certified key (in-memory).
@@ -517,8 +515,6 @@ impl std::fmt::Debug for SniCertResolver {
 impl SniCertResolver {
     /// Load the CA from disk and prepare the resolver.
     fn new(ca_cert_path: &std::path::Path, ca_key_path: &std::path::Path) -> crate::Result<Self> {
-        use rcgen::CertificateParams;
-
         let ca_key_pem = std::fs::read_to_string(ca_key_path)
             .map_err(|e| miette::miette!("Failed to read CA key {}: {e}", ca_key_path.display()))?;
         let ca_cert_pem = std::fs::read_to_string(ca_cert_path).map_err(|e| {
@@ -533,19 +529,9 @@ impl SniCertResolver {
         let ca_key = rcgen::KeyPair::from_pem(&ca_key_pem)
             .map_err(|e| miette::miette!("Failed to parse CA key: {e}"))?;
 
-        // Parse the actual CA cert from disk using rcgen's from_ca_cert_pem.
-        // We use `self_signed` here only to reconstruct the in-memory
-        // `rcgen::Certificate` object that is needed to sign leaf certs via
-        // `signed_by`.  The resulting object is used solely as the issuer
-        // reference for leaf cert signing — it is never serialised back to
-        // disk, so the new serial number / timestamps it carries do not matter.
-        // Leaf certs signed by this object will chain to the on-disk CA that
-        // browsers/OS have already trusted, because the public key and subject
-        // are identical.
-        let ca_cert = CertificateParams::from_ca_cert_pem(&ca_cert_pem)
-            .map_err(|e| miette::miette!("Failed to parse CA cert params: {e}"))?
-            .self_signed(&ca_key)
-            .map_err(|e| miette::miette!("Failed to reconstruct CA cert: {e}"))?;
+        // Parse the CA cert + key into an Issuer for signing leaf certs.
+        let issuer = rcgen::Issuer::from_ca_cert_pem(&ca_cert_pem, ca_key)
+            .map_err(|e| miette::miette!("Failed to parse CA cert: {e}"))?;
 
         // Ensure the host-certs directory exists
         let host_certs_dir = ca_cert_path
@@ -556,8 +542,7 @@ impl SniCertResolver {
             .map_err(|e| miette::miette!("Failed to create host-certs dir: {e}"))?;
 
         Ok(Self {
-            ca_key,
-            ca_cert,
+            issuer,
             host_certs_dir,
             cache: std::sync::Mutex::new(std::collections::HashMap::new()),
             pending: std::sync::Mutex::new(std::collections::HashSet::new()),
@@ -698,42 +683,14 @@ impl SniCertResolver {
             miette::bail!("No certificates found in {}", path.display());
         }
 
-        // Check that the first certificate has not expired.
-        // rcgen's CertificateParams::not_after is a `time::OffsetDateTime`.
-        // We compare it against the current UTC time to detect expired certs.
+        // Check that the first certificate has not expired using x509-parser.
         {
-            use rcgen::CertificateParams;
-            // Re-parse the PEM to get the validity period.
-            // CertificateParams::from_ca_cert_pem works for any DER-encoded cert.
-            let first_pem_block: String = {
-                let lines: Vec<&str> = pem
-                    .lines()
-                    .skip_while(|l| !l.starts_with("-----BEGIN CERTIFICATE-----"))
-                    .take_while(|l| !l.starts_with("-----END CERTIFICATE-----"))
-                    .collect();
-                if lines.is_empty() {
-                    String::new()
-                } else {
-                    // Re-attach the END line that take_while dropped
-                    let end_line = "-----END CERTIFICATE-----";
-                    format!("{}\n{end_line}", lines.join("\n"))
-                }
-            };
-            if first_pem_block.is_empty() {
-                // Could not extract a PEM block — treat as corrupt and force regeneration.
-                miette::bail!(
-                    "Could not extract PEM certificate block from {} — will regenerate",
-                    path.display()
-                );
-            }
-            // Propagate parse errors so the caller can fall through to regeneration
-            // rather than silently serving a cert whose expiry we cannot verify.
-            let params = CertificateParams::from_ca_cert_pem(&first_pem_block).map_err(|e| {
-                miette::miette!("Failed to parse cert params from {}: {e}", path.display())
+            let (_, cert) = x509_parser::parse_x509_certificate(&cert_ders[0]).map_err(|e| {
+                miette::miette!("Failed to parse certificate from {}: {e}", path.display())
             })?;
             use chrono::Utc;
             let now_ts = Utc::now().timestamp();
-            let not_after_ts = params.not_after.unix_timestamp();
+            let not_after_ts = cert.validity().not_after.timestamp();
             if not_after_ts < now_ts {
                 miette::bail!(
                     "Cached certificate at {} has expired — will regenerate",
@@ -807,7 +764,7 @@ impl SniCertResolver {
         let leaf_key = rcgen::KeyPair::generate()
             .map_err(|e| miette::miette!("Failed to generate leaf key: {e}"))?;
         let leaf_cert = params
-            .signed_by(&leaf_key, &self.ca_cert, &self.ca_key)
+            .signed_by(&leaf_key, &self.issuer)
             .map_err(|e| miette::miette!("Failed to sign leaf cert for '{domain}': {e}"))?;
 
         // Convert to rustls types


### PR DESCRIPTION
## Summary
- Updates rcgen from 0.13 to 0.14
- Migrates from `CertificateParams::from_ca_cert_pem()` to `Issuer::from_ca_cert_pem()` (rcgen 0.14 moved issuer logic into a dedicated `Issuer` type)
- `signed_by()` now takes `&Issuer` instead of separate `&Certificate` + `&KeyPair` args
- Switched cached cert expiry check to use x509-parser directly instead of rcgen's removed `CertificateParams::from_ca_cert_pem`

Closes #332

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo nextest run` — 400 passed, 0 failed
- [x] Proxy TLS cert generation and caching paths exercised by `test_e2e_proxy` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes on-the-fly TLS certificate signing and cached-cert validation logic in the proxy, which could break HTTPS interception if parsing/signing behavior differs. Dependency upgrades in the ASN.1/X.509 stack may also affect certificate handling edge cases.
> 
> **Overview**
> Upgrades the proxy TLS stack to `rcgen` `0.14` and updates the SNI cert resolver to use `rcgen::Issuer` for CA-based leaf signing (replacing the previous reconstructed `Certificate` + `KeyPair` issuer flow).
> 
> Adds `x509-parser` to the `proxy-tls` feature and switches the on-disk cached certificate expiry check to parse the first cert’s `not_after` directly via `x509-parser`, avoiding removed/changed `rcgen` APIs. Lockfile updates reflect the bumped ASN.1/X.509-related transitive dependencies (`asn1-rs`, `der-parser`, `oid-registry`, `x509-parser`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b485fd207639c0792c4a9b6ff8176ab90880d56f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->