### PR TITLE
feat: version check in IPC

### DIFF
--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -29,13 +29,50 @@ impl IpcClient {
         let id = Uuid::new_v4().to_string();
         let client = Self::connect_(&id, "main").await?;
         trace!("Connected to IPC socket");
-        let rsp = client.request(IpcRequest::Connect).await?;
-        if !rsp.is_ok() {
-            return Err(IpcError::UnexpectedResponse {
-                expected: "Ok".to_string(),
-                actual: format!("{rsp:?}"),
+        let client_version = env!("CARGO_PKG_VERSION").to_string();
+
+        // Try ConnectV2 first (supervisor that knows about it will return ConnectOk with its version).
+        // If the supervisor is older and doesn't recognize ConnectV2, it will return Error,
+        // and we fall back to the legacy Connect handshake.
+        let rsp = client
+            .request(IpcRequest::ConnectV2 {
+                version: client_version.clone(),
+            })
+            .await?;
+        match rsp {
+            IpcResponse::ConnectOk {
+                version: supervisor_version,
+            } => {
+                if supervisor_version != client_version {
+                    warn!(
+                        "CLI version {client_version} differs from supervisor version {supervisor_version}. \
+                         Restart the supervisor with: pitchfork supervisor start --force"
+                    );
+                }
             }
-            .into());
+            IpcResponse::Error(_) => {
+                // Old supervisor doesn't recognize ConnectV2 — fall back to legacy Connect
+                debug!("Supervisor did not recognize ConnectV2, falling back to legacy Connect");
+                let rsp = client.request(IpcRequest::Connect).await?;
+                if !rsp.is_ok() {
+                    return Err(IpcError::UnexpectedResponse {
+                        expected: "Ok".to_string(),
+                        actual: format!("{rsp:?}"),
+                    }
+                    .into());
+                }
+                warn!(
+                    "Supervisor is running an older version. \
+                     Restart the supervisor with: pitchfork supervisor start --force"
+                );
+            }
+            _ => {
+                return Err(IpcError::UnexpectedResponse {
+                    expected: "ConnectOk or Error".to_string(),
+                    actual: format!("{rsp:?}"),
+                }
+                .into());
+            }
         }
         debug!("Connected to IPC main");
         Ok(client)

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -28,6 +28,12 @@ pub(crate) mod server;
 #[allow(clippy::large_enum_variant)]
 pub enum IpcRequest {
     Connect,
+    /// Versioned connect handshake (v2): client sends its version so the supervisor can
+    /// detect mismatches. Kept as a separate variant so the wire format of `Connect`
+    /// (unit variant) stays unchanged for backward compatibility with older supervisors.
+    ConnectV2 {
+        version: String,
+    },
     Clean,
     Stop {
         id: DaemonId,
@@ -56,6 +62,10 @@ pub enum IpcRequest {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, strum::Display, strum::EnumIs)]
 pub enum IpcResponse {
     Ok,
+    /// Successful connect handshake, includes supervisor version for mismatch detection
+    ConnectOk {
+        version: String,
+    },
     Yes,
     No,
     Error(String),

--- a/src/supervisor/ipc_handlers.rs
+++ b/src/supervisor/ipc_handlers.rs
@@ -7,6 +7,8 @@ use crate::Result;
 use crate::ipc::server::IpcServer;
 use crate::ipc::{IpcRequest, IpcResponse};
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 impl Supervisor {
     /// Main IPC connection watch loop - reads and dispatches requests
     pub(crate) async fn conn_watch(&self, mut ipc: IpcServer) -> ! {
@@ -39,8 +41,22 @@ impl Supervisor {
                 return Ok(IpcResponse::Error(format!("Invalid request: {error}")));
             }
             IpcRequest::Connect => {
-                debug!("received connect message");
+                debug!("received connect message (legacy, no version info)");
                 IpcResponse::Ok
+            }
+            IpcRequest::ConnectV2 {
+                version: client_version,
+            } => {
+                debug!("received connect message (client version: {client_version})");
+                if client_version != VERSION {
+                    warn!(
+                        "Client version {client_version} differs from supervisor version {VERSION}. \
+                            Restart the supervisor with: pitchfork supervisor start --force"
+                    );
+                }
+                IpcResponse::ConnectOk {
+                    version: VERSION.to_string(),
+                }
             }
             IpcRequest::Stop { id } => {
                 // id is already DaemonId, no validation needed


### PR DESCRIPTION
Add version handshake to IPC protocol to detect client/supervisor mismatch. In detail, client sends its version on connect and compares with the supervisor's version; warns the user to run `pitchfork supervisor start --force` if they differ