### PR TITLE
chore: release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0](https://github.com/jdx/pitchfork/compare/v2.6.0...v2.7.0) - 2026-04-20
+
+### Added
+
+- version check in IPC ([#354](https://github.com/jdx/pitchfork/pull/354))
+
+### Other
+
+- *(deps)* lock file maintenance ([#371](https://github.com/jdx/pitchfork/pull/371))
+- *(deps)* update rust crate xx to v2.5.4 ([#363](https://github.com/jdx/pitchfork/pull/363))
+- *(deps)* update rust crate hyper-rustls to v0.27.9 ([#359](https://github.com/jdx/pitchfork/pull/359))
+- *(deps)* update rust crate rmcp to v1.5.0 ([#364](https://github.com/jdx/pitchfork/pull/364))
+- *(deps)* update rust crate libc to v0.2.185 ([#360](https://github.com/jdx/pitchfork/pull/360))
+- *(deps)* update rust crate tokio to v1.52.1 ([#365](https://github.com/jdx/pitchfork/pull/365))
+- *(deps)* update rust crate uuid to v1.23.1 ([#362](https://github.com/jdx/pitchfork/pull/362))
+- *(deps)* update rust crate rustls to v0.23.38 ([#361](https://github.com/jdx/pitchfork/pull/361))
+- *(deps)* update rust crate clap to v4.6.1 ([#358](https://github.com/jdx/pitchfork/pull/358))
+- *(deps)* update rust crate axum to v0.8.9 ([#357](https://github.com/jdx/pitchfork/pull/357))
+
 ## [2.6.0](https://github.com/jdx/pitchfork/compare/v2.5.0...v2.6.0) - 2026-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,7 +2503,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.6.0"
+version = "2.7.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2081,7 +2081,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.6.0",
+  "version": "2.7.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.6.0
+**Version**: 2.7.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.6.0"
+version "2.7.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.6.0 -> 2.7.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.7.0](https://github.com/jdx/pitchfork/compare/v2.6.0...v2.7.0) - 2026-04-20

### Added

- version check in IPC ([#354](https://github.com/jdx/pitchfork/pull/354))

### Other

- *(deps)* lock file maintenance ([#371](https://github.com/jdx/pitchfork/pull/371))
- *(deps)* update rust crate xx to v2.5.4 ([#363](https://github.com/jdx/pitchfork/pull/363))
- *(deps)* update rust crate hyper-rustls to v0.27.9 ([#359](https://github.com/jdx/pitchfork/pull/359))
- *(deps)* update rust crate rmcp to v1.5.0 ([#364](https://github.com/jdx/pitchfork/pull/364))
- *(deps)* update rust crate libc to v0.2.185 ([#360](https://github.com/jdx/pitchfork/pull/360))
- *(deps)* update rust crate tokio to v1.52.1 ([#365](https://github.com/jdx/pitchfork/pull/365))
- *(deps)* update rust crate uuid to v1.23.1 ([#362](https://github.com/jdx/pitchfork/pull/362))
- *(deps)* update rust crate rustls to v0.23.38 ([#361](https://github.com/jdx/pitchfork/pull/361))
- *(deps)* update rust crate clap to v4.6.1 ([#358](https://github.com/jdx/pitchfork/pull/358))
- *(deps)* update rust crate axum to v0.8.9 ([#357](https://github.com/jdx/pitchfork/pull/357))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the crate version and updates the changelog/lockfile metadata, with no code changes.
> 
> **Overview**
> Publishes release `v2.7.0` by bumping `pitchfork-cli` from `2.6.0` to `2.7.0` in `Cargo.toml` and `Cargo.lock`.
> 
> Updates `CHANGELOG.md` with the `2.7.0` release notes (IPC version check and dependency update entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fee3ed49421e5c866c245a2a7526eb26355803bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->