### PR TITLE
chore(release): append en.dev sponsor blurb to release notes

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -56,6 +56,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      - name: Append en.dev sponsor blurb
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          TAG: ${{ needs.release-plz-release.outputs.tag }}
+        run: |
+          {
+            gh release view "$TAG" --json body --jq .body
+            cat <<'EOF'
+
+          ## 💚 Sponsor pitchfork
+
+          pitchfork is built by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev) — an independent studio shipping developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, pitchfork, and more. Development is sustained by sponsorships.
+
+          If pitchfork has a place in your dev workflow, please consider [sponsoring at en.dev](https://en.dev). Individual and company sponsorships are what keep the project healthy and moving forward.
+          EOF
+          } > /tmp/release-notes.md
+          gh release edit "$TAG" --notes-file /tmp/release-notes.md
 
   release-plz-pr:
     name: Release PR


### PR DESCRIPTION
## Summary

- Appends a **Sponsor pitchfork** section to every GitHub Release body, run after `communique generate` in the `enhance-release` job in [`.github/workflows/release-plz.yml`](.github/workflows/release-plz.yml).
- Same pattern as [mise#9272](https://github.com/jdx/mise/pull/9272), adapted for pitchfork.

## What it looks like

Rendered at the bottom of each release body:

> ## 💚 Sponsor pitchfork
>
> pitchfork is built by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev) — an independent studio shipping developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, pitchfork, and more. Development is sustained by sponsorships.
>
> If pitchfork has a place in your dev workflow, please consider [sponsoring at en.dev](https://en.dev). Individual and company sponsorships are what keep the project healthy and moving forward.

## Test plan

- [x] \`actionlint\` + \`yamllint\` pass on the modified workflow
- [ ] Next tagged release produces a GitHub Release whose body ends with the sponsor section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that edits GitHub Release bodies via `gh release edit`; main risk is malformed/duplicated release notes if the script or `gh` call fails.
> 
> **Overview**
> After `communique generate` in the `enhance-release` job, the workflow now fetches the current release body for the new tag and re-edits the GitHub Release to append a **“Sponsor pitchfork”** section with en.dev sponsorship links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c5d49f39ba9c42cb3819fffb79bf120434a7e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->