### PR TITLE
chore: release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0](https://github.com/jdx/pitchfork/compare/v2.6.0...v2.7.0) - 2026-04-26
+
+### Added
+
+- *(supervisor)* run daemons as a configured user ([#384](https://github.com/jdx/pitchfork/pull/384))
+- *(watch)* impl poll mode ([#353](https://github.com/jdx/pitchfork/pull/353))
+- *(cli)* stop / restart --all-global / --all-local ([#385](https://github.com/jdx/pitchfork/pull/385))
+- version check in IPC ([#354](https://github.com/jdx/pitchfork/pull/354))
+
+### Fixed
+
+- pass error when failed to parse toml ([#386](https://github.com/jdx/pitchfork/pull/386))
+
+### Other
+
+- *(deps)* update rust crate xx to v2.5.4 ([#378](https://github.com/jdx/pitchfork/pull/378))
+- *(deps)* lock file maintenance ([#371](https://github.com/jdx/pitchfork/pull/371))
+- *(deps)* update rust crate xx to v2.5.4 ([#363](https://github.com/jdx/pitchfork/pull/363))
+- *(deps)* update rust crate hyper-rustls to v0.27.9 ([#359](https://github.com/jdx/pitchfork/pull/359))
+- *(deps)* update rust crate rmcp to v1.5.0 ([#364](https://github.com/jdx/pitchfork/pull/364))
+- *(deps)* update rust crate libc to v0.2.185 ([#360](https://github.com/jdx/pitchfork/pull/360))
+- *(deps)* update rust crate tokio to v1.52.1 ([#365](https://github.com/jdx/pitchfork/pull/365))
+- *(deps)* update rust crate uuid to v1.23.1 ([#362](https://github.com/jdx/pitchfork/pull/362))
+- *(deps)* update rust crate rustls to v0.23.38 ([#361](https://github.com/jdx/pitchfork/pull/361))
+- *(deps)* update rust crate clap to v4.6.1 ([#358](https://github.com/jdx/pitchfork/pull/358))
+- *(deps)* update rust crate axum to v0.8.9 ([#357](https://github.com/jdx/pitchfork/pull/357))
+
 ## [2.6.0](https://github.com/jdx/pitchfork/compare/v2.5.0...v2.6.0) - 2026-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,7 +2547,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.6.0"
+version = "2.7.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2141,7 +2141,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.6.0",
+  "version": "2.7.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.6.0
+**Version**: 2.7.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.6.0"
+version "2.7.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.6.0 -> 2.7.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.7.0](https://github.com/jdx/pitchfork/compare/v2.6.0...v2.7.0) - 2026-04-26

### Added

- *(supervisor)* run daemons as a configured user ([#384](https://github.com/jdx/pitchfork/pull/384))
- *(watch)* impl poll mode ([#353](https://github.com/jdx/pitchfork/pull/353))
- *(cli)* stop / restart --all-global / --all-local ([#385](https://github.com/jdx/pitchfork/pull/385))
- version check in IPC ([#354](https://github.com/jdx/pitchfork/pull/354))

### Fixed

- pass error when failed to parse toml ([#386](https://github.com/jdx/pitchfork/pull/386))

### Other

- *(deps)* update rust crate xx to v2.5.4 ([#378](https://github.com/jdx/pitchfork/pull/378))
- *(deps)* lock file maintenance ([#371](https://github.com/jdx/pitchfork/pull/371))
- *(deps)* update rust crate xx to v2.5.4 ([#363](https://github.com/jdx/pitchfork/pull/363))
- *(deps)* update rust crate hyper-rustls to v0.27.9 ([#359](https://github.com/jdx/pitchfork/pull/359))
- *(deps)* update rust crate rmcp to v1.5.0 ([#364](https://github.com/jdx/pitchfork/pull/364))
- *(deps)* update rust crate libc to v0.2.185 ([#360](https://github.com/jdx/pitchfork/pull/360))
- *(deps)* update rust crate tokio to v1.52.1 ([#365](https://github.com/jdx/pitchfork/pull/365))
- *(deps)* update rust crate uuid to v1.23.1 ([#362](https://github.com/jdx/pitchfork/pull/362))
- *(deps)* update rust crate rustls to v0.23.38 ([#361](https://github.com/jdx/pitchfork/pull/361))
- *(deps)* update rust crate clap to v4.6.1 ([#358](https://github.com/jdx/pitchfork/pull/358))
- *(deps)* update rust crate axum to v0.8.9 ([#357](https://github.com/jdx/pitchfork/pull/357))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: only bumps the `pitchfork-cli` version and regenerates changelog/docs metadata, with no runtime code changes.
> 
> **Overview**
> Updates project metadata for the `v2.7.0` release.
> 
> Bumps `pitchfork-cli` from `2.6.0` to `2.7.0` across `Cargo.toml`, `Cargo.lock`, and the generated CLI docs (`docs/cli/*` and `pitchfork.usage.kdl`), and adds the `2.7.0` entry to `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e93c44b79f7f5fc496e3f8f08f03fa04da1e63bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->