### PR TITLE
chore(deps): bump communique to 1.0.3

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -151,54 +151,54 @@ version = "0.9.129"
 backend = "cargo:cargo-nextest"
 
 [[tools.communique]]
-version = "1.0.1"
+version = "1.0.3"
 backend = "github:jdx/communique"
 
 [tools.communique."platforms.linux-arm64"]
-checksum = "sha256:7be8c2a327212b41e7d39c9866f49c09c26beddfcdfbde1289804c836c45797b"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318499"
+checksum = "sha256:b8425a0193c0c14f45c7d2454bc3d7ce6203930765f912fe75fff83a8eb04c14"
+url = "https://github.com/jdx/communique/releases/download/v1.0.3/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/403764139"
 
 [tools.communique."platforms.linux-arm64-musl"]
-checksum = "sha256:7be8c2a327212b41e7d39c9866f49c09c26beddfcdfbde1289804c836c45797b"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318499"
+checksum = "sha256:b8425a0193c0c14f45c7d2454bc3d7ce6203930765f912fe75fff83a8eb04c14"
+url = "https://github.com/jdx/communique/releases/download/v1.0.3/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/403764139"
 
 [tools.communique."platforms.linux-x64"]
-checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
+checksum = "sha256:ec51b288886506409b6526044fe9bbcea7b07d2088729ae70f9ffcbeabf82871"
+url = "https://github.com/jdx/communique/releases/download/v1.0.3/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/403764051"
 provenance = "github-attestations"
 
 [tools.communique."platforms.linux-x64-baseline"]
-checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
+checksum = "sha256:ec51b288886506409b6526044fe9bbcea7b07d2088729ae70f9ffcbeabf82871"
+url = "https://github.com/jdx/communique/releases/download/v1.0.3/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/403764051"
 
 [tools.communique."platforms.linux-x64-musl"]
-checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
+checksum = "sha256:ec51b288886506409b6526044fe9bbcea7b07d2088729ae70f9ffcbeabf82871"
+url = "https://github.com/jdx/communique/releases/download/v1.0.3/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/403764051"
 
 [tools.communique."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
+checksum = "sha256:ec51b288886506409b6526044fe9bbcea7b07d2088729ae70f9ffcbeabf82871"
+url = "https://github.com/jdx/communique/releases/download/v1.0.3/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/403764051"
 
 [tools.communique."platforms.macos-arm64"]
-checksum = "sha256:9adcd413f3377b98aa12df003ffa4c24f084e7bea549104e29088a3b79892dd8"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318491"
+checksum = "sha256:4efa78274b808b90b6bd2a40d3454c761f331211a891c3afce1815da19853d9f"
+url = "https://github.com/jdx/communique/releases/download/v1.0.3/communique-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/403764017"
 
 [tools.communique."platforms.windows-x64"]
-checksum = "sha256:2474f4ed704c9a94bb9dd357452275b8efe92df132ab81b642055c858441a905"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400319696"
+checksum = "sha256:7747987ad9f5b212198699422dfb65da955ed21f125a4626c2f90d4d045abf67"
+url = "https://github.com/jdx/communique/releases/download/v1.0.3/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/403765157"
 
 [tools.communique."platforms.windows-x64-baseline"]
-checksum = "sha256:2474f4ed704c9a94bb9dd357452275b8efe92df132ab81b642055c858441a905"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400319696"
+checksum = "sha256:7747987ad9f5b212198699422dfb65da955ed21f125a4626c2f90d4d045abf67"
+url = "https://github.com/jdx/communique/releases/download/v1.0.3/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/403765157"
 
 [[tools.hk]]
 version = "1.36.0"


### PR DESCRIPTION
## Summary

Refreshes the `communique` entry in `mise.lock` from its prior pin to 1.0.3 so enhance-release picks up the UTF-8 char-boundary fix from [jdx/communique#113](https://github.com/jdx/communique/pull/113).

The prior truncation sliced release bodies at byte 3072 with no regard for UTF-8 char boundaries, which [crashed](https://github.com/endevco/aube/actions/runs/24854719507/job/72767529235) enhance-release for [aube v1.0.0](https://github.com/endevco/aube/releases/tag/v1.0.0) because one of the recent-release style samples had an em-dash `—` straddling the cutoff.

## Test plan

- [x] Refreshed URLs, checksums, and asset IDs for all platforms in the existing `[[tools.communique]]` block
- [ ] CI green on the release-enhancement job for the next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a pinned dev tool binary in `mise.lock` only, with refreshed download URLs/checksums and no application logic changes.
> 
> **Overview**
> Bumps the `communique` tool pin in `mise.lock` from `1.0.1` to `1.0.3`, updating the associated per-platform asset URLs, API asset IDs, and SHA256 checksums.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6974e86754729e0761b666031a49e1836e40db32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->