### PR TITLE
fix(test): avoid race in watch test PID polling

### DIFF
--- a/tests/test_e2e_watch.rs
+++ b/tests/test_e2e_watch.rs
@@ -285,10 +285,12 @@ ready_port = {}
     fs::write(lib_dir.join("helper.ts"), "export const x = 1;").unwrap();
 
     // Poll for daemon restart after lib file change (up to 10 seconds)
+    // Wait for PID to change AND daemon to be running again (not mid-restart)
     let mut pid_after_first_change = original_pid;
     for _ in 0..20 {
-        pid_after_first_change = env.get_daemon_pid("glob_watch_test");
-        if pid_after_first_change != original_pid {
+        let current_pid = env.get_daemon_pid("glob_watch_test");
+        if current_pid != original_pid && current_pid.is_some() {
+            pid_after_first_change = current_pid;
             break;
         }
         env.sleep(Duration::from_millis(500));
@@ -310,11 +312,13 @@ ready_port = {}
     // Modify config file
     fs::write(config_dir.join("app.json"), r#"{"port": 9090}"#).unwrap();
 
-    // Poll for daemon restart after config change (up to 5 seconds)
+    // Poll for daemon restart after config change (up to 10 seconds)
+    // Wait for PID to change AND daemon to be running again (not mid-restart)
     let mut pid_after_second_change = pid_after_first_change;
-    for _ in 0..10 {
-        pid_after_second_change = env.get_daemon_pid("glob_watch_test");
-        if pid_after_second_change != pid_after_first_change {
+    for _ in 0..20 {
+        let current_pid = env.get_daemon_pid("glob_watch_test");
+        if current_pid != pid_after_first_change && current_pid.is_some() {
+            pid_after_second_change = current_pid;
             break;
         }
         env.sleep(Duration::from_millis(500));
@@ -387,10 +391,12 @@ ready_port = {}
     fs::write(&watched_file, "modified").unwrap();
 
     // Poll for daemon restart by checking PID change (up to 10 seconds)
+    // Wait for PID to change AND daemon to be running again (not mid-restart)
     let mut new_pid = original_pid;
     for _ in 0..20 {
-        new_pid = env.get_daemon_pid("relative_watch_test");
-        if new_pid != original_pid {
+        let current_pid = env.get_daemon_pid("relative_watch_test");
+        if current_pid != original_pid && current_pid.is_some() {
+            new_pid = current_pid;
             break;
         }
         env.sleep(Duration::from_millis(500));


### PR DESCRIPTION
## Summary
- Fixes the flaky `test_watch_glob_patterns` failure seen on [CI run 24894483416](https://github.com/jdx/pitchfork/actions/runs/24894483416/job/72895405163) (unrelated to the PR it surfaced on).
- Root cause: two polling loops in `tests/test_e2e_watch.rs` broke as soon as the observed PID differed from the previous one. If the poll landed mid-restart (after kill, before respawn) the PID was `None`, satisfying `!=` but then failing the subsequent `assert!(pid.is_some())`.
- Fix: match the pattern already used in `test_watch_triggers_daemon_restart` — only break when the PID has changed **and** is `Some`. Same fix applied to `test_watch_relative_paths` which had the identical bug.

## Test plan
- [x] `cargo nextest run -p pitchfork-cli --test test_e2e_watch` — all 5 tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that tighten polling conditions and timeouts to avoid transient `None` PIDs during daemon restarts.
> 
> **Overview**
> Improves reliability of the watch-related E2E tests by changing PID polling loops to only succeed when the PID has *changed and is present* (`Some`), avoiding false positives when the poll hits mid-restart.
> 
> Also increases the config-change restart polling window in `test_watch_glob_patterns` (from ~5s to ~10s) to reduce flakiness on slower CI runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aad6a48275569912de9e8c1575a3b2364729b58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->