### PR TITLE
feat(supervisor): run daemons as a configured user

### DIFF
--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -276,7 +276,7 @@
           ]
         },
         "user": {
-          "description": "Unix user to run this daemon as. Overrides `settings.supervisor.run_user` when set.",
+          "description": "Unix user to run this daemon as. Overrides `settings.supervisor.user` when set.",
           "type": [
             "string",
             "null"
@@ -604,15 +604,15 @@
             "null"
           ]
         },
-        "run_user": {
-          "description": "Default user to run daemon processes as",
+        "stop_timeout": {
+          "description": "Maximum time to wait for daemon to stop gracefully",
           "type": [
             "string",
             "null"
           ]
         },
-        "stop_timeout": {
-          "description": "Maximum time to wait for daemon to stop gracefully",
+        "user": {
+          "description": "Default user to run daemon processes as",
           "type": [
             "string",
             "null"

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -275,6 +275,13 @@
             "exec node server.js"
           ]
         },
+        "user": {
+          "description": "Unix user to run this daemon as. Overrides `settings.supervisor.run_user` when set.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "watch": {
           "description": "File patterns to watch for changes",
           "type": "array",
@@ -592,6 +599,13 @@
         },
         "restart_delay": {
           "description": "Delay between stop and start during restart",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run_user": {
+          "description": "Default user to run daemon processes as",
           "type": [
             "string",
             "null"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -136,6 +136,37 @@ REDIS_URL = "redis://localhost:6379"
 LOG_LEVEL = "debug"
 ```
 
+### `user`
+
+Unix user to run the daemon process as. This overrides `[settings.supervisor] run_user` for this daemon. Values may be usernames or numeric UIDs.
+
+```toml
+[settings.supervisor]
+run_user = "conner"
+
+[daemons.api]
+run = "npm run server"
+
+[daemons.postgres]
+run = "postgres -D /var/lib/postgres"
+user = "postgres"
+
+[daemons.low-port-web]
+run = "python -m http.server 80"
+user = "root"
+
+[daemons.worker]
+run = "./worker"
+user = "501"
+```
+
+**Behavior:**
+- If `user` is set, the daemon runs as that user.
+- Otherwise, if `[settings.supervisor] run_user` is set, the daemon runs as that user.
+- Otherwise, if the supervisor was started as root via `sudo`, daemons run as the sudo-calling user from `SUDO_UID`/`SUDO_GID`.
+- If no run user can be derived, the daemon runs as the supervisor's current user.
+- Switching to another user requires the supervisor to have root privileges; otherwise startup fails.
+
 ### `retry`
 
 Number of retry attempts on failure, or `true` for infinite retries. Default: `0`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -138,11 +138,11 @@ LOG_LEVEL = "debug"
 
 ### `user`
 
-Unix user to run the daemon process as. This overrides `[settings.supervisor] run_user` for this daemon. Values may be usernames or numeric UIDs.
+Unix user to run the daemon process as. This overrides `[settings.supervisor] user` for this daemon. Values may be usernames or numeric UIDs.
 
 ```toml
 [settings.supervisor]
-run_user = "conner"
+user = "app"
 
 [daemons.api]
 run = "npm run server"
@@ -162,7 +162,8 @@ user = "501"
 
 **Behavior:**
 - If `user` is set, the daemon runs as that user.
-- Otherwise, if `[settings.supervisor] run_user` is set, the daemon runs as that user.
+- Otherwise, if `[settings.supervisor] user` is set, the daemon runs as that user.
+- When the supervisor is running as root and `[settings.supervisor] user` is set, the default state directory, logs, and IPC sockets are stored under that user's state directory unless `PITCHFORK_STATE_DIR` overrides it. Pitchfork also chowns those state files to the configured user so non-root clients can read and write them.
 - Otherwise, if the supervisor was started as root via `sudo`, daemons run as the sudo-calling user from `SUDO_UID`/`SUDO_GID`.
 - If no run user can be derived, the daemon runs as the supervisor's current user.
 - Switching to another user requires the supervisor to have root privileges; otherwise startup fails.

--- a/docs/reference/file-locations.md
+++ b/docs/reference/file-locations.md
@@ -10,9 +10,9 @@ Pitchfork resolves key directories as follows:
 |-----------|-----------------|
 | **Home** | `SUDO_USER`'s home (when euid=0) → `dirs::home_dir()` → `/tmp` |
 | **Config** | `PITCHFORK_CONFIG_DIR` env → `~/.config/pitchfork` |
-| **State** | `PITCHFORK_STATE_DIR` env → (sudo) `~/.local/state/pitchfork` · (non-sudo) `dirs::state_dir()/pitchfork` → `~/.local/state/pitchfork` |
+| **State** | `PITCHFORK_STATE_DIR` env → (root + `settings.supervisor.user`) configured user's `~/.local/state/pitchfork` → (sudo) `SUDO_USER`'s `~/.local/state/pitchfork` → (non-sudo) `dirs::state_dir()/pitchfork` → `~/.local/state/pitchfork` |
 
-> **Note:** Under `sudo` (euid=0), the home directory (`~`) is resolved from `SUDO_USER` via the system password database, and `dirs::state_dir()` is bypassed to ensure all paths stay consistent with non-sudo invocations. On macOS `dirs::state_dir()` returns `None`, so the fallback `~/.local/state` is always used.
+> **Note:** Under root (euid=0), `settings.supervisor.user` controls the default state directory owner and location when set. Otherwise, `sudo` invocations resolve `~` from `SUDO_USER` via the system password database, and `dirs::state_dir()` is bypassed to keep paths consistent with non-sudo invocations. On macOS `dirs::state_dir()` returns `None`, so the fallback `~/.local/state` is always used.
 
 ## Configuration Files
 

--- a/settings.toml
+++ b/settings.toml
@@ -473,6 +473,22 @@ where PID 1 must reap zombie processes to prevent process table exhaustion.
 Can also be enabled via the `--container` CLI flag on `pitchfork supervisor run`.
 """
 
+[supervisor.run_user]
+type = "String"
+env = "PITCHFORK_RUN_USER"
+default = ""
+description = "Default user to run daemon processes as"
+docs = """
+Default Unix user for daemon processes spawned by the supervisor.
+
+When set, all daemons run as this user unless an individual daemon sets
+`user = "..."`. The value may be a username (for example `"postgres"`) or
+a numeric UID (for example `"501"`).
+
+If unset and the supervisor is running as root via `sudo`, daemons default to
+the sudo-calling user from `SUDO_UID`/`SUDO_GID` instead of running as root.
+"""
+
 [supervisor.cpu_violation_threshold]
 type = "Integer"
 env = "PITCHFORK_CPU_VIOLATION_THRESHOLD"

--- a/settings.toml
+++ b/settings.toml
@@ -473,9 +473,9 @@ where PID 1 must reap zombie processes to prevent process table exhaustion.
 Can also be enabled via the `--container` CLI flag on `pitchfork supervisor run`.
 """
 
-[supervisor.run_user]
+[supervisor.user]
 type = "String"
-env = "PITCHFORK_RUN_USER"
+env = "PITCHFORK_USER"
 default = ""
 description = "Default user to run daemon processes as"
 docs = """

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -128,6 +128,9 @@ pub struct Daemon {
     ///   Any daemon that relied on the global setting would silently stop using mise after a downgrade.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub mise: Option<bool>,
+    /// Unix user to run this daemon as.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub user: Option<String>,
     /// Memory limit for the daemon process (e.g. "50MB", "1GiB")
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub memory_limit: Option<MemoryLimit>,
@@ -177,6 +180,9 @@ pub struct RunOptions {
     /// Whether to proxy this daemon (None = inherit global proxy.enable setting).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub proxy: Option<bool>,
+    /// Unix user to run this daemon as.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub user: Option<String>,
     /// Memory limit for the daemon process (e.g. "50MB", "1GiB")
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub memory_limit: Option<MemoryLimit>,
@@ -219,6 +225,7 @@ impl Default for Daemon {
             watch: Vec::new(),
             watch_base_dir: None,
             mise: None,
+            user: None,
             memory_limit: None,
             cpu_limit: None,
         }
@@ -258,6 +265,7 @@ impl Daemon {
             mise: self.mise,
             slug: self.slug.clone(),
             proxy: self.proxy,
+            user: self.user.clone(),
             memory_limit: self.memory_limit,
             cpu_limit: self.cpu_limit,
         }
@@ -293,6 +301,7 @@ impl Default for RunOptions {
             mise: None,
             slug: None,
             proxy: None,
+            user: None,
             memory_limit: None,
             cpu_limit: None,
         }

--- a/src/daemon_list.rs
+++ b/src/daemon_list.rs
@@ -116,6 +116,7 @@ fn build_daemon_list(
             watch: vec![],
             watch_base_dir: None,
             mise: daemon_config.mise,
+            user: daemon_config.user.clone(),
             active_port: None,
             slug: None,
             proxy: None,

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -275,6 +275,7 @@ mod tests {
             hooks: None,
             path: None,
             mise: None,
+            user: None,
             memory_limit: None,
             cpu_limit: None,
         }

--- a/src/env.rs
+++ b/src/env.rs
@@ -49,6 +49,12 @@ pub static PITCHFORK_STATE_DIR: Lazy<PathBuf> = Lazy::new(|| {
     if let Some(p) = var_path("PITCHFORK_STATE_DIR") {
         return p;
     }
+    #[cfg(unix)]
+    if nix::unistd::Uid::effective().is_root()
+        && let Some(home) = configured_supervisor_user_home_dir()
+    {
+        return home.join(".local").join("state").join("pitchfork");
+    }
     // Under sudo, dirs::state_dir() would resolve against root's HOME,
     // bypassing our SUDO_USER correction. Use HOME_DIR directly instead.
     #[cfg(unix)]
@@ -108,4 +114,22 @@ fn home_dir_for_user(username: &str) -> Option<PathBuf> {
         .ok()
         .flatten()
         .map(|u| u.dir)
+}
+
+#[cfg(unix)]
+fn configured_supervisor_user_home_dir() -> Option<PathBuf> {
+    let user = crate::settings::settings().supervisor.user.trim();
+    if user.is_empty() {
+        return None;
+    }
+
+    if user.chars().all(|c| c.is_ascii_digit()) {
+        let uid = user.parse::<u32>().ok()?;
+        return nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+            .ok()
+            .flatten()
+            .map(|u| u.dir);
+    }
+
+    home_dir_for_user(user)
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -93,32 +93,19 @@ impl IpcServer {
 
         let listener = listener_result.into_diagnostic()?;
 
-        // When the supervisor is started with `sudo`, the socket file and directory
+        // When the supervisor is started as root, the socket file and directory
         // are owned by root with restrictive permissions (0600/0700). Non-root CLI
-        // clients need to connect to this socket.
+        // clients and configured daemon users need to connect to this socket.
         //
-        // If SUDO_UID/SUDO_GID are available, chown the socket back to the
-        // original user so permissions stay tight (0700/0600) but the real user
-        // owns the files.
-        //
-        // If not running via sudo, the socket is already owned by the current
-        // user with restrictive permissions (set by the umask above), so no
-        // permission change is needed.
-        //
-        // Guard: only act when euid==0 to avoid stale SUDO_UID/SUDO_GID values
-        // inherited into non-sudo environments.
+        // Prefer `[settings.supervisor] run_user`, then SUDO_UID/SUDO_GID, so
+        // permissions stay tight (0700/0600) while the intended runtime user
+        // owns the socket.
         #[cfg(unix)]
         {
-            if nix::unistd::Uid::effective().is_root() {
-                if let (Ok(uid_s), Ok(gid_s)) =
-                    (std::env::var("SUDO_UID"), std::env::var("SUDO_GID"))
-                {
-                    if let (Ok(uid), Ok(gid)) = (uid_s.parse::<u32>(), gid_s.parse::<u32>()) {
-                        let _ = chown_path(&env::IPC_SOCK_DIR, uid, gid);
-                        let _ = chown_path(&env::IPC_SOCK_MAIN, uid, gid);
-                        debug!("chowned IPC socket to uid={uid} gid={gid}");
-                    }
-                }
+            if let Some((uid, gid)) = crate::supervisor::state_owner_ids() {
+                let _ = chown_path(&env::IPC_SOCK_DIR, uid, gid);
+                let _ = chown_path(&env::IPC_SOCK_MAIN, uid, gid);
+                debug!("chowned IPC socket to uid={uid} gid={gid}");
             }
         }
 

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -97,7 +97,7 @@ impl IpcServer {
         // are owned by root with restrictive permissions (0600/0700). Non-root CLI
         // clients and configured daemon users need to connect to this socket.
         //
-        // Prefer `[settings.supervisor] run_user`, then SUDO_UID/SUDO_GID, so
+        // Prefer `[settings.supervisor] user`, then SUDO_UID/SUDO_GID, so
         // permissions stay tight (0700/0600) while the intended runtime user
         // owns the socket.
         #[cfg(unix)]

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -166,6 +166,9 @@ struct PitchforkTomlDaemonRaw {
     pub hooks: Option<PitchforkTomlHooks>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub mise: Option<bool>,
+    /// Unix user to run this daemon as.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub user: Option<String>,
     /// Memory limit for the daemon process (e.g. "50MB", "1GiB")
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub memory_limit: Option<MemoryLimit>,
@@ -874,6 +877,7 @@ impl PitchforkToml {
                 env: raw_daemon.env,
                 hooks: raw_daemon.hooks,
                 mise: raw_daemon.mise,
+                user: raw_daemon.user,
                 memory_limit: raw_daemon.memory_limit,
                 cpu_limit: raw_daemon.cpu_limit,
                 path: Some(path.to_path_buf()),
@@ -985,6 +989,7 @@ impl PitchforkToml {
                     env: daemon.env.clone(),
                     hooks: daemon.hooks.clone(),
                     mise: daemon.mise,
+                    user: daemon.user.clone(),
                     memory_limit: daemon.memory_limit,
                     cpu_limit: daemon.cpu_limit,
                 };
@@ -1187,6 +1192,8 @@ pub struct PitchforkTomlDaemon {
     /// Wrap this daemon's command with `mise x --` for tool/env setup.
     /// Overrides the global `settings.general.mise` when set.
     pub mise: Option<bool>,
+    /// Unix user to run this daemon as. Overrides `settings.supervisor.run_user` when set.
+    pub user: Option<String>,
     /// Memory limit for the daemon process (e.g. "50MB", "1GiB").
     /// The supervisor periodically monitors RSS and kills the process if it exceeds the limit.
     pub memory_limit: Option<MemoryLimit>,
@@ -1219,6 +1226,7 @@ impl Default for PitchforkTomlDaemon {
             env: None,
             hooks: None,
             mise: None,
+            user: None,
             memory_limit: None,
             cpu_limit: None,
             path: None,
@@ -1269,6 +1277,7 @@ impl PitchforkTomlDaemon {
             mise: self.mise,
             slug: None,
             proxy: None,
+            user: self.user.clone(),
             memory_limit: self.memory_limit,
             cpu_limit: self.cpu_limit,
         }
@@ -1430,5 +1439,59 @@ impl<'de> Deserialize<'de> for Retry {
         }
 
         deserializer.deserialize_any(RetryVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_daemon_user_parses_and_flows_to_run_options() {
+        let pt = PitchforkToml::parse_str(
+            r#"
+[daemons.api]
+run = "node server.js"
+user = "postgres"
+"#,
+            Path::new("/tmp/my-project/pitchfork.toml"),
+        )
+        .unwrap();
+
+        let id = DaemonId::new("my-project", "api");
+        let daemon = pt.daemons.get(&id).unwrap();
+        assert_eq!(daemon.user.as_deref(), Some("postgres"));
+
+        let opts = daemon.to_run_options(&id, vec!["node".to_string(), "server.js".to_string()]);
+        assert_eq!(opts.user.as_deref(), Some("postgres"));
+    }
+
+    #[test]
+    fn test_daemon_user_write_roundtrip() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pitchfork.toml");
+        let mut pt = PitchforkToml::new(path.clone());
+        pt.namespace = Some("test-project".to_string());
+        pt.daemons.insert(
+            DaemonId::new("test-project", "api"),
+            PitchforkTomlDaemon {
+                run: "node server.js".to_string(),
+                user: Some("postgres".to_string()),
+                ..PitchforkTomlDaemon::default()
+            },
+        );
+
+        pt.write().unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("user = \"postgres\""));
+
+        let parsed = PitchforkToml::read(&path).unwrap();
+        let daemon = parsed
+            .daemons
+            .get(&DaemonId::new("test-project", "api"))
+            .unwrap();
+        assert_eq!(daemon.user.as_deref(), Some("postgres"));
     }
 }

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -1192,7 +1192,7 @@ pub struct PitchforkTomlDaemon {
     /// Wrap this daemon's command with `mise x --` for tool/env setup.
     /// Overrides the global `settings.general.mise` when set.
     pub mise: Option<bool>,
-    /// Unix user to run this daemon as. Overrides `settings.supervisor.run_user` when set.
+    /// Unix user to run this daemon as. Overrides `settings.supervisor.user` when set.
     pub user: Option<String>,
     /// Memory limit for the daemon process (e.g. "50MB", "1GiB").
     /// The supervisor periodically monitors RSS and kills the process if it exceeds the limit.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -134,7 +134,7 @@ mod tests {
         // Test supervisor settings
         assert_eq!(settings.supervisor.ready_check_interval, "500ms");
         assert_eq!(settings.supervisor.file_watch_debounce, "1s");
-        assert_eq!(settings.supervisor.run_user, "");
+        assert_eq!(settings.supervisor.user, "");
     }
 
     #[test]
@@ -512,7 +512,7 @@ auto_start = true
 bind_port = 8080
 
 [settings.supervisor]
-run_user = "postgres"
+user = "postgres"
 "#;
 
         // Parse the [settings] section as SettingsPartial
@@ -528,7 +528,7 @@ run_user = "postgres"
         assert_eq!(settings.general.log_level, "debug");
         assert!(settings.web.auto_start);
         assert_eq!(settings.web.bind_port, 8080);
-        assert_eq!(settings.supervisor.run_user, "postgres");
+        assert_eq!(settings.supervisor.user, "postgres");
         assert_eq!(settings.general.interval, "10s");
         assert_eq!(settings.ipc.connect_attempts, 5);
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -134,6 +134,7 @@ mod tests {
         // Test supervisor settings
         assert_eq!(settings.supervisor.ready_check_interval, "500ms");
         assert_eq!(settings.supervisor.file_watch_debounce, "1s");
+        assert_eq!(settings.supervisor.run_user, "");
     }
 
     #[test]
@@ -509,6 +510,9 @@ log_level = "debug"
 [settings.web]
 auto_start = true
 bind_port = 8080
+
+[settings.supervisor]
+run_user = "postgres"
 "#;
 
         // Parse the [settings] section as SettingsPartial
@@ -524,6 +528,7 @@ bind_port = 8080
         assert_eq!(settings.general.log_level, "debug");
         assert!(settings.web.auto_start);
         assert_eq!(settings.web.bind_port, 8080);
+        assert_eq!(settings.supervisor.run_user, "postgres");
         assert_eq!(settings.general.interval, "10s");
         assert_eq!(settings.ipc.connect_attempts, 5);
 

--- a/src/state_file.rs
+++ b/src/state_file.rs
@@ -285,6 +285,7 @@ mod tests {
                 watch: vec![],
                 watch_base_dir: None,
                 mise: None,
+                user: Some("postgres".to_string()),
                 active_port: None,
                 slug: None,
                 proxy: None,
@@ -304,6 +305,11 @@ mod tests {
                 .daemons
                 .contains_key(&DaemonId::new("project", "test"))
         );
+        let daemon = parsed
+            .daemons
+            .get(&DaemonId::new("project", "test"))
+            .unwrap();
+        assert_eq!(daemon.user.as_deref(), Some("postgres"));
     }
 
     #[test]

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -1017,10 +1017,10 @@ impl Supervisor {
 
 #[cfg(unix)]
 fn resolve_effective_run_identity(daemon_user: Option<&str>) -> Result<RunIdentity> {
-    let settings_run_user = settings().supervisor.run_user.trim();
+    let settings_user = settings().supervisor.user.trim();
     let daemon_user = daemon_user.map(str::trim).filter(|user| !user.is_empty());
-    let settings_run_user = (!settings_run_user.is_empty()).then_some(settings_run_user);
-    let configured = daemon_user.or(settings_run_user);
+    let settings_user = (!settings_user.is_empty()).then_some(settings_user);
+    let configured = daemon_user.or(settings_user);
     let current_uid = nix::unistd::Uid::effective().as_raw();
     let current_gid = nix::unistd::Gid::effective().as_raw();
     resolve_run_identity(
@@ -1043,7 +1043,7 @@ fn resolve_run_identity(
     let current_uid = nix::unistd::Uid::from_raw(current_uid);
     let current_gid = nix::unistd::Gid::from_raw(current_gid);
     if let Some(user) = configured {
-        let identity = resolve_configured_run_user(user)?;
+        let identity = resolve_configured_user(user)?;
         ensure_can_use_identity(user, &identity, current_uid, current_gid)?;
         if identity.matches(current_uid, current_gid) {
             return Ok(RunIdentity::Inherit);
@@ -1061,7 +1061,7 @@ fn resolve_run_identity(
 }
 
 #[cfg(unix)]
-fn resolve_configured_run_user(user: &str) -> Result<RunIdentity> {
+fn resolve_configured_user(user: &str) -> Result<RunIdentity> {
     if user.chars().all(|c| c.is_ascii_digit()) {
         let uid = user
             .parse::<u32>()
@@ -1488,8 +1488,8 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_configured_run_user_root_name() {
-        let identity = resolve_configured_run_user("root").unwrap();
+    fn test_resolve_configured_user_root_name() {
+        let identity = resolve_configured_user("root").unwrap();
         let RunIdentity::Switch { uid, username, .. } = identity else {
             panic!("expected identity switch");
         };
@@ -1501,8 +1501,8 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_configured_run_user_root_uid() {
-        let identity = resolve_configured_run_user("0").unwrap();
+    fn test_resolve_configured_user_root_uid() {
+        let identity = resolve_configured_user("0").unwrap();
         let RunIdentity::Switch { uid, username, .. } = identity else {
             panic!("expected identity switch");
         };
@@ -1514,8 +1514,8 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_configured_run_user_missing_user_fails() {
-        let err = resolve_configured_run_user("pitchfork-user-that-should-not-exist")
+    fn test_resolve_configured_user_missing_user_fails() {
+        let err = resolve_configured_user("pitchfork-user-that-should-not-exist")
             .unwrap_err()
             .to_string();
         assert!(err.contains("does not exist"));

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -40,7 +40,7 @@ enum RunIdentity {
     Switch {
         uid: nix::unistd::Uid,
         gid: nix::unistd::Gid,
-        username: Option<String>,
+        username: Option<CString>,
     },
 }
 
@@ -1069,26 +1069,28 @@ fn resolve_configured_run_user(user: &str) -> Result<RunIdentity> {
         let user_record = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
             .into_diagnostic()?
             .ok_or_else(|| miette::miette!("run user UID '{}' does not exist", user))?;
-        return Ok(run_identity_from_user_record(user_record));
+        return run_identity_from_user_record(user_record);
     }
 
     let user_record = nix::unistd::User::from_name(user)
         .into_diagnostic()?
         .ok_or_else(|| miette::miette!("run user '{}' does not exist", user))?;
-    Ok(run_identity_from_user_record(user_record))
+    run_identity_from_user_record(user_record)
 }
 
 #[cfg(unix)]
-fn run_identity_from_user_record(user: nix::unistd::User) -> RunIdentity {
-    RunIdentity::Switch {
+fn run_identity_from_user_record(user: nix::unistd::User) -> Result<RunIdentity> {
+    let username = CString::new(user.name)
+        .map_err(|e| miette::miette!("run user name contains an interior nul byte: {}", e))?;
+    Ok(RunIdentity::Switch {
         uid: user.uid,
         gid: user.gid,
-        username: Some(user.name),
-    }
+        username: Some(username),
+    })
 }
 
 #[cfg(unix)]
-fn run_identity_from_raw_ids(uid: u32, gid: u32, username: Option<String>) -> RunIdentity {
+fn run_identity_from_raw_ids(uid: u32, gid: u32, username: Option<CString>) -> RunIdentity {
     RunIdentity::Switch {
         uid: nix::unistd::Uid::from_raw(uid),
         gid: nix::unistd::Gid::from_raw(gid),
@@ -1103,7 +1105,7 @@ fn resolve_sudo_identity(sudo_uid: Option<&str>, sudo_gid: Option<&str>) -> Opti
     let username = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
         .ok()
         .flatten()
-        .map(|u| u.name);
+        .and_then(|u| CString::new(u.name).ok());
     Some(run_identity_from_raw_ids(uid, gid, username))
 }
 
@@ -1139,8 +1141,9 @@ fn apply_run_identity(identity: &RunIdentity) -> std::io::Result<()> {
         return Ok(());
     };
     if let Some(username) = username {
-        let username = CString::new(username.as_str()).map_err(std::io::Error::other)?;
-        initgroups_for_user(&username, *gid)?;
+        initgroups_for_user(username, *gid)?;
+    } else {
+        setgroups_to_primary(*gid)?;
     }
     nix::unistd::setgid(*gid).map_err(nix_to_io_error)?;
     nix::unistd::setuid(*uid).map_err(nix_to_io_error)?;
@@ -1151,6 +1154,21 @@ fn apply_run_identity(identity: &RunIdentity) -> std::io::Result<()> {
 impl RunIdentity {
     fn matches(&self, uid: nix::unistd::Uid, gid: nix::unistd::Gid) -> bool {
         matches!(self, RunIdentity::Switch { uid: u, gid: g, .. } if *u == uid && *g == gid)
+    }
+}
+
+#[cfg(unix)]
+fn setgroups_to_primary(gid: nix::unistd::Gid) -> std::io::Result<()> {
+    let groups = [gid.as_raw() as libc::gid_t];
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    let group_count = groups.len();
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    let group_count = groups.len() as libc::c_int;
+    let rc = unsafe { libc::setgroups(group_count, groups.as_ptr()) };
+    if rc == -1 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
     }
 }
 
@@ -1186,7 +1204,7 @@ fn initgroups_for_user(username: &CString, gid: nix::unistd::Gid) -> std::io::Re
 
 #[cfg(unix)]
 fn nix_to_io_error(err: nix::errno::Errno) -> std::io::Error {
-    std::io::Error::other(err.to_string())
+    std::io::Error::from_raw_os_error(err as i32)
 }
 
 /// Check if multiple ports are available and optionally auto-bump to find available ports.
@@ -1476,7 +1494,10 @@ mod tests {
             panic!("expected identity switch");
         };
         assert_eq!(uid.as_raw(), 0);
-        assert_eq!(username.as_deref(), Some("root"));
+        assert_eq!(
+            username.as_deref().and_then(|s| s.to_str().ok()),
+            Some("root")
+        );
     }
 
     #[test]
@@ -1486,7 +1507,10 @@ mod tests {
             panic!("expected identity switch");
         };
         assert_eq!(uid.as_raw(), 0);
-        assert_eq!(username.as_deref(), Some("root"));
+        assert_eq!(
+            username.as_deref().and_then(|s| s.to_str().ok()),
+            Some("root")
+        );
     }
 
     #[test]

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -19,6 +19,8 @@ use miette::IntoDiagnostic;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::ffi::CString;
 use std::iter::once;
 use std::sync::atomic;
 use std::time::Duration;
@@ -30,6 +32,17 @@ use tokio::time;
 /// Cache for compiled regex patterns to avoid recompilation on daemon restarts
 static REGEX_CACHE: Lazy<std::sync::Mutex<HashMap<String, Regex>>> =
     Lazy::new(|| std::sync::Mutex::new(HashMap::new()));
+
+#[cfg(unix)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RunIdentity {
+    Inherit,
+    Switch {
+        uid: nix::unistd::Uid,
+        gid: nix::unistd::Gid,
+        username: Option<String>,
+    },
+}
 
 /// Get or compile a regex pattern, caching the result for future use
 pub(crate) fn get_or_compile_regex(pattern: &str) -> Option<Regex> {
@@ -258,6 +271,15 @@ impl Supervisor {
         if let Some(parent) = log_path.parent() {
             xx::file::mkdirp(parent)?;
         }
+        #[cfg(unix)]
+        let run_identity = match resolve_effective_run_identity(opts.user.as_deref()) {
+            Ok(identity) => identity,
+            Err(e) => {
+                return Ok(IpcResponse::DaemonFailed {
+                    error: e.to_string(),
+                });
+            }
+        };
         info!("run: spawning daemon {id} with args: {args:?}");
         let mut cmd = tokio::process::Command::new("sh");
         cmd.args(&args)
@@ -295,11 +317,11 @@ impl Supervisor {
 
         #[cfg(unix)]
         {
+            let run_identity = run_identity.clone();
             unsafe {
                 cmd.pre_exec(move || {
-                    if libc::setsid() == -1 {
-                        return Err(std::io::Error::last_os_error());
-                    }
+                    nix::unistd::setsid().map_err(nix_to_io_error)?;
+                    apply_run_identity(&run_identity)?;
                     Ok(())
                 });
             }
@@ -344,6 +366,7 @@ impl Supervisor {
                         o.watch = Some(opts.watch.clone());
                         o.watch_base_dir = opts.watch_base_dir.clone();
                         o.mise = opts.mise;
+                        o.user = opts.user.clone();
                         o.memory_limit = opts.memory_limit;
                         o.cpu_limit = opts.cpu_limit;
                     })
@@ -992,6 +1015,180 @@ impl Supervisor {
     }
 }
 
+#[cfg(unix)]
+fn resolve_effective_run_identity(daemon_user: Option<&str>) -> Result<RunIdentity> {
+    let settings_run_user = settings().supervisor.run_user.trim();
+    let daemon_user = daemon_user.map(str::trim).filter(|user| !user.is_empty());
+    let settings_run_user = (!settings_run_user.is_empty()).then_some(settings_run_user);
+    let configured = daemon_user.or(settings_run_user);
+    let current_uid = nix::unistd::Uid::effective().as_raw();
+    let current_gid = nix::unistd::Gid::effective().as_raw();
+    resolve_run_identity(
+        configured,
+        current_uid,
+        current_gid,
+        std::env::var("SUDO_UID").ok().as_deref(),
+        std::env::var("SUDO_GID").ok().as_deref(),
+    )
+}
+
+#[cfg(unix)]
+fn resolve_run_identity(
+    configured: Option<&str>,
+    current_uid: u32,
+    current_gid: u32,
+    sudo_uid: Option<&str>,
+    sudo_gid: Option<&str>,
+) -> Result<RunIdentity> {
+    let current_uid = nix::unistd::Uid::from_raw(current_uid);
+    let current_gid = nix::unistd::Gid::from_raw(current_gid);
+    if let Some(user) = configured {
+        let identity = resolve_configured_run_user(user)?;
+        ensure_can_use_identity(user, &identity, current_uid, current_gid)?;
+        if identity.matches(current_uid, current_gid) {
+            return Ok(RunIdentity::Inherit);
+        }
+        return Ok(identity);
+    }
+
+    if current_uid.is_root()
+        && let Some(identity) = resolve_sudo_identity(sudo_uid, sudo_gid)
+    {
+        return Ok(identity);
+    }
+
+    Ok(RunIdentity::Inherit)
+}
+
+#[cfg(unix)]
+fn resolve_configured_run_user(user: &str) -> Result<RunIdentity> {
+    if user.chars().all(|c| c.is_ascii_digit()) {
+        let uid = user
+            .parse::<u32>()
+            .map_err(|e| miette::miette!("invalid run user UID '{}': {}", user, e))?;
+        let user_record = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+            .into_diagnostic()?
+            .ok_or_else(|| miette::miette!("run user UID '{}' does not exist", user))?;
+        return Ok(run_identity_from_user_record(user_record));
+    }
+
+    let user_record = nix::unistd::User::from_name(user)
+        .into_diagnostic()?
+        .ok_or_else(|| miette::miette!("run user '{}' does not exist", user))?;
+    Ok(run_identity_from_user_record(user_record))
+}
+
+#[cfg(unix)]
+fn run_identity_from_user_record(user: nix::unistd::User) -> RunIdentity {
+    RunIdentity::Switch {
+        uid: user.uid,
+        gid: user.gid,
+        username: Some(user.name),
+    }
+}
+
+#[cfg(unix)]
+fn run_identity_from_raw_ids(uid: u32, gid: u32, username: Option<String>) -> RunIdentity {
+    RunIdentity::Switch {
+        uid: nix::unistd::Uid::from_raw(uid),
+        gid: nix::unistd::Gid::from_raw(gid),
+        username,
+    }
+}
+
+#[cfg(unix)]
+fn resolve_sudo_identity(sudo_uid: Option<&str>, sudo_gid: Option<&str>) -> Option<RunIdentity> {
+    let uid = sudo_uid?.parse::<u32>().ok()?;
+    let gid = sudo_gid?.parse::<u32>().ok()?;
+    let username = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+        .ok()
+        .flatten()
+        .map(|u| u.name);
+    Some(run_identity_from_raw_ids(uid, gid, username))
+}
+
+#[cfg(unix)]
+fn ensure_can_use_identity(
+    configured_user: &str,
+    identity: &RunIdentity,
+    current_uid: nix::unistd::Uid,
+    current_gid: nix::unistd::Gid,
+) -> Result<()> {
+    let RunIdentity::Switch { uid, gid, .. } = identity else {
+        return Ok(());
+    };
+    if *uid == current_uid && *gid == current_gid {
+        return Ok(());
+    }
+    if current_uid.is_root() {
+        return Ok(());
+    }
+    Err(miette::miette!(
+        "daemon is configured to run as '{}', but the supervisor is running as uid={} gid={}. Restart the supervisor with sudo to switch to uid={} gid={}, or choose a user matching the supervisor.",
+        configured_user,
+        current_uid.as_raw(),
+        current_gid.as_raw(),
+        uid.as_raw(),
+        gid.as_raw()
+    ))
+}
+
+#[cfg(unix)]
+fn apply_run_identity(identity: &RunIdentity) -> std::io::Result<()> {
+    let RunIdentity::Switch { uid, gid, username } = identity else {
+        return Ok(());
+    };
+    if let Some(username) = username {
+        let username = CString::new(username.as_str()).map_err(std::io::Error::other)?;
+        initgroups_for_user(&username, *gid)?;
+    }
+    nix::unistd::setgid(*gid).map_err(nix_to_io_error)?;
+    nix::unistd::setuid(*uid).map_err(nix_to_io_error)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+impl RunIdentity {
+    fn matches(&self, uid: nix::unistd::Uid, gid: nix::unistd::Gid) -> bool {
+        matches!(self, RunIdentity::Switch { uid: u, gid: g, .. } if *u == uid && *g == gid)
+    }
+}
+
+#[cfg(unix)]
+fn initgroups_for_user(username: &CString, gid: nix::unistd::Gid) -> std::io::Result<()> {
+    let gid = gid.as_raw();
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos"
+    ))]
+    let base_gid = i32::try_from(gid)
+        .map_err(|_| std::io::Error::other(format!("gid {gid} is out of range")))?;
+
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos"
+    )))]
+    let base_gid = gid as libc::gid_t;
+
+    // SAFETY: `username` is a valid nul-terminated C string and `base_gid`
+    // is derived from a resolved system account or sudo-provided gid.
+    let rc = unsafe { libc::initgroups(username.as_ptr(), base_gid) };
+    if rc == -1 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn nix_to_io_error(err: nix::errno::Errno) -> std::io::Error {
+    std::io::Error::other(err.to_string())
+}
+
 /// Check if multiple ports are available and optionally auto-bump to find available ports.
 ///
 /// All ports are bumped by the same offset to maintain relative port spacing.
@@ -1244,4 +1441,73 @@ fn is_daemon_slug_target(id: &DaemonId) -> bool {
         let daemon_name = entry.daemon.as_deref().unwrap_or(slug);
         id.name() == daemon_name
     })
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_run_identity_empty_without_sudo() {
+        let identity = resolve_run_identity(None, 501, 20, None, None).unwrap();
+        assert_eq!(identity, RunIdentity::Inherit);
+    }
+
+    #[test]
+    fn test_resolve_run_identity_sudo_fallback() {
+        let identity = resolve_run_identity(None, 0, 0, Some("501"), Some("20")).unwrap();
+        let RunIdentity::Switch { uid, gid, .. } = identity else {
+            panic!("expected identity switch");
+        };
+        assert_eq!(uid.as_raw(), 501);
+        assert_eq!(gid.as_raw(), 20);
+    }
+
+    #[test]
+    fn test_resolve_run_identity_ignores_stale_sudo_when_not_root() {
+        let identity = resolve_run_identity(None, 501, 20, Some("0"), Some("0")).unwrap();
+        assert_eq!(identity, RunIdentity::Inherit);
+    }
+
+    #[test]
+    fn test_resolve_configured_run_user_root_name() {
+        let identity = resolve_configured_run_user("root").unwrap();
+        let RunIdentity::Switch { uid, username, .. } = identity else {
+            panic!("expected identity switch");
+        };
+        assert_eq!(uid.as_raw(), 0);
+        assert_eq!(username.as_deref(), Some("root"));
+    }
+
+    #[test]
+    fn test_resolve_configured_run_user_root_uid() {
+        let identity = resolve_configured_run_user("0").unwrap();
+        let RunIdentity::Switch { uid, username, .. } = identity else {
+            panic!("expected identity switch");
+        };
+        assert_eq!(uid.as_raw(), 0);
+        assert_eq!(username.as_deref(), Some("root"));
+    }
+
+    #[test]
+    fn test_resolve_configured_run_user_missing_user_fails() {
+        let err = resolve_configured_run_user("pitchfork-user-that-should-not-exist")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("does not exist"));
+    }
+
+    #[test]
+    fn test_resolve_run_identity_requires_root_for_user_switch() {
+        let err = resolve_run_identity(Some("root"), 501, 20, None, None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Restart the supervisor with sudo"));
+    }
+
+    #[test]
+    fn test_resolve_run_identity_same_user_is_noop() {
+        let identity = resolve_run_identity(Some("root"), 0, 0, Some("501"), Some("20")).unwrap();
+        assert_eq!(identity, RunIdentity::Inherit);
+    }
 }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -108,6 +108,8 @@ pub fn start_in_background() -> Result<()> {
         .append(true)
         .open(log_file)
         .into_diagnostic()?;
+    #[cfg(unix)]
+    fix_state_dir_permissions();
     cmd!(&*env::PITCHFORK_BIN, "supervisor", "run")
         .stdout_null()
         .stderr_file(stderr_file)
@@ -162,6 +164,8 @@ impl Supervisor {
                 .build(),
         )
         .await?;
+        #[cfg(unix)]
+        fix_state_dir_permissions();
 
         // If this is a boot start, automatically start boot_start daemons
         if is_boot {
@@ -581,7 +585,7 @@ impl Supervisor {
 /// Fix ownership on the state directory so non-root users can access files
 /// created by a `sudo`-started supervisor.
 ///
-/// When `[settings.supervisor] run_user` or `SUDO_UID`/`SUDO_GID` are set, we
+/// When `[settings.supervisor] user` or `SUDO_UID`/`SUDO_GID` are set, we
 /// `chown` the state directory and safe subdirectories back to that non-root
 /// runtime user. This is strictly better than `chmod 0o666` because it does not
 /// widen the permission bits — the files stay owner-only (0o600/0o700) but the
@@ -592,17 +596,23 @@ impl Supervisor {
 /// generated it. Changing its ownership or permissions would expose the CA
 /// private key to other local users.
 ///
-/// If neither `run_user` nor `SUDO_UID`/`SUDO_GID` are available (e.g. direct
+/// If neither `user` nor `SUDO_UID`/`SUDO_GID` are available (e.g. direct
 /// root login), we fall back to relaxing permissions on only the `sock/` and
 /// `logs/` subdirectories (plus `state.toml`) so CLI clients can still function.
 #[cfg(unix)]
 fn fix_state_dir_permissions() {
     let state_dir = &*env::PITCHFORK_STATE_DIR;
-    if !state_dir.exists() {
-        return;
-    }
-
     if let Some((uid, gid)) = state_owner_ids() {
+        if !state_dir.exists()
+            && let Err(err) = fs::create_dir_all(state_dir)
+        {
+            warn!(
+                "failed to create state directory for ownership fix at {}: {err}",
+                state_dir.display()
+            );
+            return;
+        }
+
         // Best path: chown back to the runtime user. Permissions stay tight.
         chown_recursive(state_dir, uid, gid, true);
         debug!(
@@ -610,6 +620,10 @@ fn fix_state_dir_permissions() {
             state_dir.display()
         );
     } else {
+        if !state_dir.exists() {
+            return;
+        }
+
         // Fallback: relax permissions on safe subdirectories only.
         // proxy/ is never touched.
         chmod_safe_subtrees(state_dir);
@@ -626,11 +640,11 @@ pub(crate) fn state_owner_ids() -> Option<(u32, u32)> {
         return None;
     }
 
-    let run_user = settings().supervisor.run_user.trim();
-    if !run_user.is_empty() {
-        return resolve_run_user_ids(run_user).or_else(|| {
+    let user = settings().supervisor.user.trim();
+    if !user.is_empty() {
+        return resolve_supervisor_user_ids(user).or_else(|| {
             warn!(
-                "failed to resolve supervisor.run_user '{run_user}' for state ownership; falling back to SUDO_UID/SUDO_GID"
+                "failed to resolve supervisor.user '{user}' for state ownership; falling back to SUDO_UID/SUDO_GID"
             );
             parse_sudo_ids()
         });
@@ -640,7 +654,7 @@ pub(crate) fn state_owner_ids() -> Option<(u32, u32)> {
 }
 
 #[cfg(unix)]
-fn resolve_run_user_ids(user: &str) -> Option<(u32, u32)> {
+fn resolve_supervisor_user_ids(user: &str) -> Option<(u32, u32)> {
     let user_record = if user.chars().all(|c| c.is_ascii_digit()) {
         let uid = user.parse::<u32>().ok()?;
         nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -581,20 +581,20 @@ impl Supervisor {
 /// Fix ownership on the state directory so non-root users can access files
 /// created by a `sudo`-started supervisor.
 ///
-/// When `SUDO_UID`/`SUDO_GID` are set (i.e. the supervisor was launched via
-/// `sudo`), we `chown` the state directory and safe subdirectories back to the
-/// original user. This is strictly better than `chmod 0o666` because it does
-/// not widen the permission bits — the files stay owner-only (0o600/0o700) but
-/// the *owner* is the real user, not root.
+/// When `[settings.supervisor] run_user` or `SUDO_UID`/`SUDO_GID` are set, we
+/// `chown` the state directory and safe subdirectories back to that non-root
+/// runtime user. This is strictly better than `chmod 0o666` because it does not
+/// widen the permission bits — the files stay owner-only (0o600/0o700) but the
+/// *owner* is the user that daemon processes and CLI clients need to share.
 ///
 /// **Security**: The `proxy/` subtree is intentionally skipped. It contains
 /// `ca-key.pem` which must remain `0o600` and owned by the process that
 /// generated it. Changing its ownership or permissions would expose the CA
 /// private key to other local users.
 ///
-/// If `SUDO_UID`/`SUDO_GID` are not available (e.g. direct root login), we
-/// fall back to relaxing permissions on only the `sock/` and `logs/`
-/// subdirectories (plus `state.toml`) so CLI clients can still function.
+/// If neither `run_user` nor `SUDO_UID`/`SUDO_GID` are available (e.g. direct
+/// root login), we fall back to relaxing permissions on only the `sock/` and
+/// `logs/` subdirectories (plus `state.toml`) so CLI clients can still function.
 #[cfg(unix)]
 fn fix_state_dir_permissions() {
     let state_dir = &*env::PITCHFORK_STATE_DIR;
@@ -602,11 +602,8 @@ fn fix_state_dir_permissions() {
         return;
     }
 
-    // Try to recover the original (pre-sudo) user identity
-    let sudo_ids = parse_sudo_ids();
-
-    if let Some((uid, gid)) = sudo_ids {
-        // Best path: chown back to the original user. Permissions stay tight.
+    if let Some((uid, gid)) = state_owner_ids() {
+        // Best path: chown back to the runtime user. Permissions stay tight.
         chown_recursive(state_dir, uid, gid, true);
         debug!(
             "chowned state directory to uid={uid} gid={gid} at {}",
@@ -621,6 +618,39 @@ fn fix_state_dir_permissions() {
             state_dir.display()
         );
     }
+}
+
+#[cfg(unix)]
+pub(crate) fn state_owner_ids() -> Option<(u32, u32)> {
+    if !nix::unistd::Uid::effective().is_root() {
+        return None;
+    }
+
+    let run_user = settings().supervisor.run_user.trim();
+    if !run_user.is_empty() {
+        return resolve_run_user_ids(run_user).or_else(|| {
+            warn!(
+                "failed to resolve supervisor.run_user '{run_user}' for state ownership; falling back to SUDO_UID/SUDO_GID"
+            );
+            parse_sudo_ids()
+        });
+    }
+
+    parse_sudo_ids()
+}
+
+#[cfg(unix)]
+fn resolve_run_user_ids(user: &str) -> Option<(u32, u32)> {
+    let user_record = if user.chars().all(|c| c.is_ascii_digit()) {
+        let uid = user.parse::<u32>().ok()?;
+        nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+            .ok()
+            .flatten()
+    } else {
+        nix::unistd::User::from_name(user).ok().flatten()
+    }?;
+
+    Some((user_record.uid.as_raw(), user_record.gid.as_raw()))
 }
 
 /// Parse `SUDO_UID` and `SUDO_GID` environment variables into numeric IDs.

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -56,6 +56,8 @@ pub(crate) struct UpsertDaemonOpts {
     pub watch: Option<Vec<String>>,
     pub watch_base_dir: Option<PathBuf>,
     pub mise: Option<bool>,
+    /// Unix user to run this daemon as
+    pub user: Option<String>,
     /// Memory limit for the daemon process
     pub memory_limit: Option<MemoryLimit>,
     /// CPU usage limit as a percentage
@@ -112,6 +114,7 @@ impl UpsertDaemonOpts {
                 watch: None,
                 watch_base_dir: None,
                 mise: None,
+                user: None,
                 memory_limit: None,
                 cpu_limit: None,
             },
@@ -210,6 +213,7 @@ impl Supervisor {
                 .watch_base_dir
                 .or(existing.and_then(|d| d.watch_base_dir.clone())),
             mise: opts.mise.or(existing.and_then(|d| d.mise)),
+            user: opts.user.or(existing.and_then(|d| d.user.clone())),
             proxy: opts.proxy.or(existing.and_then(|d| d.proxy)),
             // active_port is intentionally NOT inherited from the existing daemon.
             // When a daemon restarts, the new process has not yet bound a port, so

--- a/tests/test_e2e_proxy.rs
+++ b/tests/test_e2e_proxy.rs
@@ -184,7 +184,7 @@ run = "sleep 60"
 /// This is the canonical "slug beats same-name" scenario:
 /// - proj-c has a daemon named "frontend" with slug "frontend-slug"
 /// - proj-d has a daemon named "frontend" (no slug)
-/// Querying "frontend-slug" must resolve to proj-c/frontend, not proj-d/frontend.
+///   Querying "frontend-slug" must resolve to proj-c/frontend, not proj-d/frontend.
 #[test]
 fn test_slug_priority_over_same_name() {
     let env = TestEnv::new();


### PR DESCRIPTION
Adds support for running daemon processes as a configured unix user with `[settings.supervisor] run_user = "..."` as a global default and `user = "..."` as a per-daemon override. Values can be usernames or numeric UIDs.

Precedence is:

1. daemon `user`
2. supervisor `run_user`
3. `SUDO_UID` / `SUDO_GID` when the supervisor is running as root via `sudo`
4. inherited supervisor identity

Examples:

```toml
[settings.supervisor]
run_user = "conner"

[daemons.api]
run = "npm run dev"

[daemons.postgres]
run = "postgres -D /var/lib/postgres"
user = "postgres"

[daemons.low-port-web]
run = "python -m http.server 80"
user = "root"

[daemons.worker]
run = "./worker"
user = "501"
```