### PR TITLE
ci: skip autofix on release-plz PRs to avoid push race

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,8 +19,12 @@ env:
 
 jobs:
   autofix:
-    # Only run on pull requests, skip on push to avoid wasted CI time
-    if: github.event_name == 'pull_request' && github.actor != 'renovate[bot]' && github.actor != 'mend[bot]'
+    # Only run on pull requests, skip on push to avoid wasted CI time.
+    # Skip release-plz PRs — release-plz.yml's "Squash generated docs" step
+    # already runs `mise run render ::: lint-fix` and amends it into the
+    # release commit; running autofix here causes a race that breaks the
+    # squash step's force-with-lease push (stale info).
+    if: github.event_name == 'pull_request' && github.actor != 'renovate[bot]' && github.actor != 'mend[bot]' && !startsWith(github.head_ref, 'release-plz-')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/mise.lock
+++ b/mise.lock
@@ -201,44 +201,44 @@ url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964430"
 
 [[tools.hk]]
-version = "1.36.0"
+version = "1.44.1"
 backend = "aqua:jdx/hk"
 
 [tools.hk."platforms.linux-arm64"]
-checksum = "sha256:51cf51e2035038ee64d772e71f8daf4978380ef82faffee2b12c413f009341ab"
-url = "https://github.com/jdx/hk/releases/download/v1.36.0/hk-aarch64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:248fae1d0cbc859c67f9e867e67e0cf69e5f93404c62c96efbe83f9ffe691442"
+url = "https://github.com/jdx/hk/releases/download/v1.44.1/hk-aarch64-unknown-linux-gnu.tar.gz"
 
 [tools.hk."platforms.linux-arm64-musl"]
-checksum = "sha256:51cf51e2035038ee64d772e71f8daf4978380ef82faffee2b12c413f009341ab"
-url = "https://github.com/jdx/hk/releases/download/v1.36.0/hk-aarch64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:248fae1d0cbc859c67f9e867e67e0cf69e5f93404c62c96efbe83f9ffe691442"
+url = "https://github.com/jdx/hk/releases/download/v1.44.1/hk-aarch64-unknown-linux-gnu.tar.gz"
 
 [tools.hk."platforms.linux-x64"]
-checksum = "sha256:d20fa0be3f1135abc74471670306ae0353ad2336804595362293f0c8460952e7"
-url = "https://github.com/jdx/hk/releases/download/v1.36.0/hk-x86_64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:6c50ef086268b5470a0da421505f0694d6cefcc8271abb8b50f2e4e4ded35eb6"
+url = "https://github.com/jdx/hk/releases/download/v1.44.1/hk-x86_64-unknown-linux-gnu.tar.gz"
 
 [tools.hk."platforms.linux-x64-baseline"]
-checksum = "sha256:d20fa0be3f1135abc74471670306ae0353ad2336804595362293f0c8460952e7"
-url = "https://github.com/jdx/hk/releases/download/v1.36.0/hk-x86_64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:6c50ef086268b5470a0da421505f0694d6cefcc8271abb8b50f2e4e4ded35eb6"
+url = "https://github.com/jdx/hk/releases/download/v1.44.1/hk-x86_64-unknown-linux-gnu.tar.gz"
 
 [tools.hk."platforms.linux-x64-musl"]
-checksum = "sha256:d20fa0be3f1135abc74471670306ae0353ad2336804595362293f0c8460952e7"
-url = "https://github.com/jdx/hk/releases/download/v1.36.0/hk-x86_64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:6c50ef086268b5470a0da421505f0694d6cefcc8271abb8b50f2e4e4ded35eb6"
+url = "https://github.com/jdx/hk/releases/download/v1.44.1/hk-x86_64-unknown-linux-gnu.tar.gz"
 
 [tools.hk."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:d20fa0be3f1135abc74471670306ae0353ad2336804595362293f0c8460952e7"
-url = "https://github.com/jdx/hk/releases/download/v1.36.0/hk-x86_64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:6c50ef086268b5470a0da421505f0694d6cefcc8271abb8b50f2e4e4ded35eb6"
+url = "https://github.com/jdx/hk/releases/download/v1.44.1/hk-x86_64-unknown-linux-gnu.tar.gz"
 
 [tools.hk."platforms.macos-arm64"]
-checksum = "sha256:553ff3c7c18d91f1c1dcdbae44315db0324b52336b5a02ed5b9c382f08499b3b"
-url = "https://github.com/jdx/hk/releases/download/v1.36.0/hk-aarch64-apple-darwin.tar.gz"
+checksum = "sha256:c8e317df71ef6f2faa646db1e433b2208e2a4de54a6298e0c510f27d8191924b"
+url = "https://github.com/jdx/hk/releases/download/v1.44.1/hk-aarch64-apple-darwin.tar.gz"
 
 [tools.hk."platforms.windows-x64"]
-checksum = "sha256:1f12218ccad806a3f49bcf521f86b6825fbd89486e830c1c04f72e3796f84589"
-url = "https://github.com/jdx/hk/releases/download/v1.36.0/hk-x86_64-pc-windows-msvc.zip"
+checksum = "sha256:1ded329d70266fc3c4fe319ca48678614532ea7187ffd785d820e01bcdbf7f58"
+url = "https://github.com/jdx/hk/releases/download/v1.44.1/hk-x86_64-pc-windows-msvc.zip"
 
 [tools.hk."platforms.windows-x64-baseline"]
-checksum = "sha256:1f12218ccad806a3f49bcf521f86b6825fbd89486e830c1c04f72e3796f84589"
-url = "https://github.com/jdx/hk/releases/download/v1.36.0/hk-x86_64-pc-windows-msvc.zip"
+checksum = "sha256:1ded329d70266fc3c4fe319ca48678614532ea7187ffd785d820e01bcdbf7f58"
+url = "https://github.com/jdx/hk/releases/download/v1.44.1/hk-x86_64-pc-windows-msvc.zip"
 
 [[tools.node]]
 version = "24.14.0"


### PR DESCRIPTION
## Summary

- `release-plz.yml`'s "Squash generated docs" step runs `mise render + lint-fix` then amends + `--force-with-lease` push. The same PR branch also triggers `autofix.ci`, which independently runs the same render+lint-fix and pushes a fixup commit. When autofix lands between the squash step's fetch and push, the lease check fails with `(stale info)` and the release-plz workflow errors out.
- Filter `release-plz-*` head refs out of autofix; the squash step already covers that work, so autofix on these PRs is redundant.
- Also bumps `hk` in `mise.lock` from 1.36.0 → 1.44.1 (`mise.toml` was already `latest`). 1.36.0's `hk run --from-hook ...` arg is gone in newer hk and broke local pre-commit hooks.

Repro: https://github.com/jdx/pitchfork/actions/runs/24960538182/job/73086296016 — fetch shows remote at `4d1be05`, then `[autofix.ci]` lands `e93c44b`, then `git push --force-with-lease` rejects with `(stale info)`.

## Test plan
- [ ] Next release-plz workflow run completes the squash step without `(stale info)`.
- [ ] No autofix.ci run starts on the next `release-plz-*` PR.
- [ ] Local `git commit` on a fresh checkout works without the `--from-hook` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow job filtering and a dev-tool lockfile version bump, with no production code impact.
> 
> **Overview**
> Prevents `autofix.ci` from running on `release-plz-*` pull requests by extending the workflow `if:` condition, avoiding a race with `release-plz.yml`'s doc-squash step and its `git push --force-with-lease`.
> 
> Updates `mise.lock` to bump `hk` from `1.36.0` to `1.44.1` (including platform URLs/checksums) to align the locked tool with the configured `latest` and keep local hooks working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f36f0b3b47e03cbf3b4b7b6c1993212fbdba84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->