### PR TITLE
ci: fall back to existing release-plz PR

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -100,9 +100,8 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - name: Squash generated docs into release PR
         run: |
-          if [ -n "${{ steps.release-plz.outputs.pr }}" ]; then
-            PR_BRANCH=$(echo '${{ steps.release-plz.outputs.pr }}' | jq -r '.head_branch // empty')
-          else
+          PR_BRANCH=$(echo '${{ steps.release-plz.outputs.pr }}' | jq -r '.head_branch // empty')
+          if [ -z "$PR_BRANCH" ]; then
             PR_BRANCH=$(gh pr list --state open --base main --json headRefName,updatedAt --jq 'sort_by(.updatedAt) | reverse | map(select(.headRefName | startswith("release-plz-")))[0].headRefName // empty' 2>/dev/null || true)
           fi
           if [ -z "$PR_BRANCH" ]; then


### PR DESCRIPTION
## Summary

- Parse the release-plz action PR output into `PR_BRANCH` first.
- Fall back to the latest open `release-plz-*` PR when the action returns `{}` or otherwise has no `head_branch`.

## Context

The Release PR job succeeded, but `release-plz release-pr` emitted HTTP 422 and returned no PR object because a release PR already existed. The follow-up docs-squash step treated `{}` as a present output and skipped the fallback lookup.

## Test plan

- Not run locally; workflow-only shell change.
- Expected validation is the `ci` required check on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that alters how the release PR branch is detected; main risk is selecting the wrong PR branch if the `gh pr list` query behaves unexpectedly.
> 
> **Overview**
> Improves the `release-plz` workflow’s “Squash generated docs into release PR” step by always attempting to parse `steps.release-plz.outputs.pr.head_branch` first, then falling back to querying the most recently updated open `release-plz-*` PR when that output is empty.
> 
> This prevents the docs-squash step from silently skipping updates when `release-plz` returns an empty PR object (e.g., when a release PR already exists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d91147980f53b215eb04959cd26f2581d729562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->