### PR TITLE
ci: remove rust toolchain action from workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,8 +22,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
@@ -87,8 +85,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5


### PR DESCRIPTION
## Summary

- Remove the `dtolnay/rust-toolchain` setup step from both Release-plz jobs.
- Leave release-plz/action and the rest of the workflow unchanged.

## Test plan

- Searched `.github/workflows` for `dtolnay/rust-toolchain`, `actions-rs/toolchain`, and `rust-toolchain`; no workflow references remain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes the `dtolnay/rust-toolchain` install step from GitHub Actions jobs, without changing release logic or credentials; the main risk is a workflow failure if `release-plz/action` no longer provides Rust tooling implicitly.
> 
> **Overview**
> Simplifies the `release-plz` GitHub Actions workflow by removing the `dtolnay/rust-toolchain` setup step from both the `release` and `release-pr` jobs.
> 
> All other release-plz invocation, tokens, and follow-up steps (asset upload, release-note enhancement, and doc squashing) remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e3a418f822b4bcddd39c37472f380e09b8c878. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->