### PR TITLE
ci(release-plz): add workflow_dispatch manual-finish path

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,12 +8,18 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to finish releasing (e.g. v2.7.0). Skips release-plz, runs upload-assets + enhance-release."
+        required: true
+        type: string
 
 jobs:
   release-plz-release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'endevco' }}
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'endevco' }}
     outputs:
       tag: ${{ steps.release-plz.outputs.releases && fromJSON(steps.release-plz.outputs.releases)[0].tag || '' }}
     steps:
@@ -34,30 +40,33 @@ jobs:
   upload-assets:
     name: Upload assets
     needs: release-plz-release
-    if: ${{ needs.release-plz-release.outputs.tag != '' }}
+    if: >-
+      ${{ always() && (inputs.tag != '' || needs.release-plz-release.outputs.tag != '') }}
     uses: ./.github/workflows/release.yml
     with:
-      tag: ${{ needs.release-plz-release.outputs.tag }}
+      tag: ${{ inputs.tag != '' && inputs.tag || needs.release-plz-release.outputs.tag }}
     secrets: inherit
 
   enhance-release:
     name: Enhance release notes
     needs: [release-plz-release, upload-assets]
-    if: ${{ needs.release-plz-release.outputs.tag != '' }}
+    if: >-
+      ${{ always() && needs.upload-assets.result == 'success' && (inputs.tag != '' || needs.release-plz-release.outputs.tag != '') }}
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ inputs.tag != '' && inputs.tag || needs.release-plz-release.outputs.tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-      - run: communique generate "${{ needs.release-plz-release.outputs.tag }}" --github-release
+      - run: communique generate "$TAG" --github-release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       - name: Append en.dev sponsor blurb
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          TAG: ${{ needs.release-plz-release.outputs.tag }}
         run: |
           {
             gh release view "$TAG" --json body --jq .body
@@ -75,7 +84,7 @@ jobs:
   release-plz-pr:
     name: Release PR
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'endevco' }}
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'endevco' }}
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false


### PR DESCRIPTION
Adds a workflow_dispatch trigger to release-plz.yml that takes an existing tag and runs the asset-upload + release-note-enhance jobs against it, skipping the release-plz step itself.

Used immediately to finish v2.7.0: crates.io [pitchfork-cli@2.7.0](https://crates.io/crates/pitchfork-cli/2.7.0) was published in attempt 1 of run [24962145246](https://github.com/endevco/pitchfork/actions/runs/24962145246) but the subsequent tag push 403'd on the rotated PAT, leaving the GitHub release + binaries missing. After this lands, `gh workflow run release-plz.yml -R endevco/pitchfork -f tag=v2.7.0` will build/upload assets and enhance the release notes for the existing v2.7.0 tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the release automation control flow and `if` conditions; misconfiguration could unintentionally skip/trigger release steps or run asset uploads against the wrong tag.
> 
> **Overview**
> Adds a `workflow_dispatch` entrypoint to `release-plz.yml` that accepts an existing `tag`, enabling a *manual “finish release”* path that skips `release-plz` and instead runs the existing asset upload and release-note enhancement steps for that tag.
> 
> Tightens job gating so `release-plz` jobs only run on `push` events, and updates `upload-assets`/`enhance-release` to run when either the dispatched `inputs.tag` or the generated tag output is present (using a shared `TAG` env var for release note generation and editing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b134e867b10201a512b7888038af12c60a7abef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->