### PR TITLE
docs: prefix star count with ★ glyph and populate it on deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Build with VitePress
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           cd docs
           aube install

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -238,6 +238,12 @@ th {
   line-height: 1;
 }
 
+.VPSocialLinks .star-count .star-glyph {
+  font-family: -apple-system, "Segoe UI Symbol", sans-serif;
+  line-height: 1;
+  margin-right: 0.2em;
+}
+
 .VPSocialLinks a[href*="github.com/jdx/pitchfork"]:hover .star-count {
   color: var(--vp-c-brand-1);
 }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -29,7 +29,7 @@ export default {
           if (!githubLink.querySelector(".star-count")) {
             const starBadge = document.createElement("span");
             starBadge.className = "star-count";
-            starBadge.textContent = starsData.stars;
+            starBadge.textContent = `★ ${starsData.stars}`;
             starBadge.title = "GitHub Stars";
             githubLink.appendChild(starBadge);
           }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -29,8 +29,12 @@ export default {
           if (!githubLink.querySelector(".star-count")) {
             const starBadge = document.createElement("span");
             starBadge.className = "star-count";
-            starBadge.textContent = `★ ${starsData.stars}`;
             starBadge.title = "GitHub Stars";
+            const glyph = document.createElement("span");
+            glyph.className = "star-glyph";
+            glyph.textContent = "★";
+            glyph.setAttribute("aria-hidden", "true");
+            starBadge.append(glyph, starsData.stars);
             githubLink.appendChild(starBadge);
           }
         });


### PR DESCRIPTION
## Summary

Two small changes to the docs:

- **Prefix the GitHub star count with ★** (U+2605) in the top-nav social link, so it reads "★ N" instead of just "N".
- **Pass `GITHUB_TOKEN` to the VitePress build step.** Without it, the build-time data loader in `docs/.vitepress/stars.data.ts` falls back to 0 and returns an empty string, so the badge currently renders blank on the live site (curl-verified). With the token set, the loader can hit the GitHub API and populate the count.

## Test plan

- [ ] Merge → docs deploy runs → reload https://pitchfork.jdx.dev/ → top-nav GitHub icon shows "★ N"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change: adjusts GitHub Pages build environment and a small DOM/CSS tweak in the VitePress theme. Main risk is cosmetic rendering or star-count fetch behavior during deploy.
> 
> **Overview**
> Docs deploy now passes `GITHUB_TOKEN` into the VitePress build step so the build-time GitHub API fetch in `stars.data.ts` can populate the star badge on the published site.
> 
> The top-nav GitHub star badge rendering is updated to prefix the count with a `★` glyph (with added CSS for glyph font/spacing) instead of showing the number alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f535f12f9fb47517b6d48138e19c5c335740c2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->