### PR TITLE
[codex] add sponsor feed to docs

### DIFF
--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -1,0 +1,122 @@
+<template>
+  <section
+    v-if="sponsors.length"
+    aria-labelledby="endev-sponsors-title"
+    class="EndevSponsors"
+  >
+    <div class="EndevSponsorsInner">
+      <p id="endev-sponsors-title" class="EndevSponsorsTitle">
+        Company sponsors
+      </p>
+      <div class="EndevSponsorsLogos">
+        <a
+          v-for="sponsor in sponsors"
+          :key="sponsor.name"
+          :aria-label="sponsor.name"
+          class="EndevSponsorsLogo"
+          :href="sponsor.url"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <img :alt="sponsor.name" :src="sponsor.logo" />
+        </a>
+      </div>
+      <a class="EndevSponsorsCta" href="https://en.dev/#contact">
+        Sponsor the work
+      </a>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { onMounted, ref } from "vue";
+
+const sponsors = ref([]);
+
+onMounted(async () => {
+  try {
+    const res = await fetch("https://en.dev/sponsors.json", {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return;
+
+    const payload = await res.json();
+    sponsors.value = (Array.isArray(payload.sponsors) ? payload.sponsors : [])
+      .filter((sponsor) =>
+        sponsor?.kind !== "infrastructure" &&
+        sponsor?.name &&
+        sponsor?.url &&
+        sponsor?.logo
+      );
+  } catch {
+    sponsors.value = [];
+  }
+});
+</script>
+
+<style scoped>
+.EndevSponsors {
+  border-top: 1px solid var(--vp-c-divider);
+  padding: 22px 24px;
+}
+
+.EndevSponsorsInner {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  justify-content: center;
+  margin: 0 auto;
+  max-width: 960px;
+}
+
+.EndevSponsorsTitle {
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.EndevSponsorsLogos {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.EndevSponsorsLogo {
+  align-items: center;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  display: inline-flex;
+  height: 40px;
+  justify-content: center;
+  padding: 8px 12px;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.EndevSponsorsLogo:hover {
+  background: var(--vp-c-bg-soft);
+  border-color: var(--vp-c-brand-1);
+}
+
+.EndevSponsorsLogo img {
+  display: block;
+  max-height: 22px;
+  max-width: 120px;
+}
+
+.EndevSponsorsCta {
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.EndevSponsorsCta:hover {
+  color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import type { Theme } from "vitepress";
 import { h, onMounted, onUnmounted } from "vue";
 import { initBanner } from "./banner";
 import EndevFooter from "./EndevFooter.vue";
+import EndevSponsors from "./EndevSponsors.vue";
 import { data as starsData } from "../stars.data";
 import "./custom.css";
 
@@ -10,7 +11,7 @@ export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
-      "layout-bottom": () => h(EndevFooter),
+      "layout-bottom": () => [h(EndevSponsors), h(EndevFooter)],
     });
   },
   enhanceApp() {


### PR DESCRIPTION
## Summary

Adds an en.dev company sponsor block to the docs footer.

## Changes

- Adds `EndevSponsors.vue`, which fetches `https://en.dev/sponsors.json` client-side.
- Renders the feed's default `sponsors` list, which is paid company sponsors only.
- Places the sponsor block above the existing en.dev footer.

## Validation

- `npm install --no-package-lock --ignore-scripts` in `docs/`
- `npm run docs:build` in `docs/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only UI and an external read-only sponsor JSON fetch; no auth, data, or app logic changes.
> 
> **Overview**
> Adds a **company sponsors** strip to the VitePress docs layout, loaded from en.dev’s public sponsor feed and shown above the existing en.dev footer.
> 
> A new `EndevSponsors` component fetches `https://en.dev/sponsors.json` on the client, keeps only non-infrastructure entries with name/url/logo, and renders linked logos plus a “Sponsor the work” CTA. The theme’s `layout-bottom` slot now renders sponsors first, then `EndevFooter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ac3eccae72e8d26c2ac4e8461a379f3353af99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->