### PR TITLE
chore: add plausible analytics

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -170,7 +170,7 @@ export default defineConfig({
       "script",
       {
         defer: "",
-        "data-domain": "pa--1IDrOZtv0naZ-aGb1KMK",
+        "data-domain": "pitchfork.en.dev",
         "data-api": "https://shrill.en.dev/f5f1/event",
         src: "https://shrill.en.dev/shrill/script.js",
       },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -166,6 +166,15 @@ export default defineConfig({
         content: "https://pitchfork.en.dev/img/android-chrome-512x512.png",
       },
     ],
+    [
+      "script",
+      {
+        defer: "",
+        "data-domain": "pa--1IDrOZtv0naZ-aGb1KMK",
+        "data-api": "https://shrill.en.dev/f5f1/event",
+        src: "https://shrill.en.dev/shrill/script.js",
+      },
+    ],
   ],
 
   // Ignore localhost URLs in CLI examples


### PR DESCRIPTION
## Summary

- Adds Plausible Analytics to the docs site via the shrill.en.dev Cloudflare worker proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that injects a third-party analytics script; main impact is on client-side loading and privacy/compliance expectations.
> 
> **Overview**
> Adds Plausible Analytics tracking to the docs site by injecting a deferred `<script>` tag into VitePress `head`, configured to report to `shrill.en.dev` (Cloudflare worker proxy) via `data-domain` and `data-api`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d452089879d978dcfa31f997b1e0e81e164ec61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->