### PR TITLE
chore: release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0](https://github.com/endevco/pitchfork/compare/v2.7.0...v2.8.0) - 2026-04-28
+
+### Added
+
+- *(boot-start)* support system level register ([#397](https://github.com/endevco/pitchfork/pull/397))
+
+### Fixed
+
+- *(tui)* remove blocking loading ([#394](https://github.com/endevco/pitchfork/pull/394))
+
 ## [2.7.0](https://github.com/jdx/pitchfork/compare/v2.6.0...v2.7.0) - 2026-04-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,7 +2758,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.7.0"
+version = "2.8.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.en.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2141,7 +2141,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.7.0",
+  "version": "2.8.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.7.0
+**Version**: 2.8.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.7.0"
+version "2.8.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.7.0 -> 2.8.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.8.0](https://github.com/endevco/pitchfork/compare/v2.7.0...v2.8.0) - 2026-04-28

### Added

- *(boot-start)* support system level register ([#397](https://github.com/endevco/pitchfork/pull/397))

### Fixed

- *(tui)* remove blocking loading ([#394](https://github.com/endevco/pitchfork/pull/394))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).