### PR TITLE
chore(docs): remove shrill.en.dev analytics script

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -166,15 +166,6 @@ export default defineConfig({
         content: "https://pitchfork.en.dev/img/android-chrome-512x512.png",
       },
     ],
-    [
-      "script",
-      {
-        defer: "",
-        "data-domain": "pitchfork.en.dev",
-        "data-api": "https://shrill.en.dev/f5f1/event",
-        src: "https://shrill.en.dev/shrill/script.js",
-      },
-    ],
   ],
 
   // Ignore localhost URLs in CLI examples


### PR DESCRIPTION
Removes the proxied shrill.en.dev analytics snippet from the VitePress docs config — the endpoint is going away.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docs-only change that removes a third-party analytics script; no product logic or data handling is affected.
> 
> **Overview**
> Removes the `shrill.en.dev` analytics `<script>` tag from `docs/.vitepress/config.mts` so the docs site no longer loads the proxied tracking snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7f46d7d1ba23438f2d50c20d0f82ca7a6132657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->