### PR TITLE
fix(build): restore Windows compile and add windows CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,17 @@ jobs:
       - run: rm -rf .cargo
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: mise run ci
+
+  windows-build:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: true
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # `cargo check` (debug) catches the compile errors that otherwise only
+      # surface in the release pipeline, without paying for an optimized link.
+      # Integration tests under tests/ are Unix-only (lsof, pkill, etc.) so
+      # we limit the check to lib + bins.
+      - run: cargo check --lib --bins --all-features

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -197,13 +197,32 @@ impl JsonSchema for CpuLimit {
 #[serde(try_from = "String")]
 pub struct StopSignal(i32);
 
+// Signal numbers. On Unix we pull them from `libc` so they match the platform
+// (SIGUSR1/2 differ between Linux and BSD/macOS). On Windows the values are
+// only used for parsing and Display — `procs::kill` ignores `stop_signal` and
+// uses TerminateProcess via sysinfo — so POSIX-typical Linux values are fine.
+#[cfg(unix)]
+use libc::{SIGHUP, SIGINT, SIGQUIT, SIGTERM, SIGUSR1, SIGUSR2};
+#[cfg(windows)]
+const SIGHUP: i32 = 1;
+#[cfg(windows)]
+const SIGINT: i32 = 2;
+#[cfg(windows)]
+const SIGQUIT: i32 = 3;
+#[cfg(windows)]
+const SIGTERM: i32 = 15;
+#[cfg(windows)]
+const SIGUSR1: i32 = 10;
+#[cfg(windows)]
+const SIGUSR2: i32 = 12;
+
 const SIGNAL_TABLE: &[(&str, i32)] = &[
-    ("HUP", libc::SIGHUP),
-    ("INT", libc::SIGINT),
-    ("QUIT", libc::SIGQUIT),
-    ("TERM", libc::SIGTERM),
-    ("USR1", libc::SIGUSR1),
-    ("USR2", libc::SIGUSR2),
+    ("HUP", SIGHUP),
+    ("INT", SIGINT),
+    ("QUIT", SIGQUIT),
+    ("TERM", SIGTERM),
+    ("USR1", SIGUSR1),
+    ("USR2", SIGUSR2),
 ];
 
 impl StopSignal {
@@ -218,7 +237,7 @@ impl StopSignal {
 
 impl Default for StopSignal {
     fn default() -> Self {
-        Self(libc::SIGTERM)
+        Self(SIGTERM)
     }
 }
 

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -244,7 +244,7 @@ pub fn compute_reverse_stop_order_with_config(
 mod tests {
     use super::*;
     use crate::daemon_id::DaemonId;
-    use crate::pitchfork_toml::{PitchforkTomlDaemon, Retry};
+    use crate::pitchfork_toml::PitchforkTomlDaemon;
     use indexmap::IndexMap;
 
     // Helper to build a test daemon with only `depends` set, all other fields default/None.

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod watch_files;
 mod web;
 
 pub use miette::Result;
+#[cfg(unix)]
 use tokio::signal;
 #[cfg(unix)]
 use tokio::signal::unix::SignalKind;

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+#[cfg(unix)]
 use crate::settings::settings;
 use miette::IntoDiagnostic;
 use once_cell::sync::Lazy;
@@ -212,11 +213,12 @@ impl Procs {
 
         #[cfg(windows)]
         {
+            let _ = (stop_signal, stop_timeout);
             if let Some(process) = self.lock_system().process(sysinfo_pid) {
                 process.kill();
                 process.wait();
             }
-            return Ok(true);
+            Ok(true)
         }
 
         #[cfg(unix)]

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -464,9 +464,9 @@ pub fn generate_ca(cert_path: &std::path::Path, key_path: &std::path::Path) -> c
     // Using OpenOptions + mode() so the file is never world-readable,
     // even briefly before a chmod call.
     {
-        use std::io::Write;
         #[cfg(unix)]
         {
+            use std::io::Write;
             use std::os::unix::fs::OpenOptionsExt;
             std::fs::OpenOptions::new()
                 .write(true)
@@ -809,9 +809,9 @@ impl SniCertResolver {
         let disk_path = self.host_certs_dir.join(format!("{safe_name}.pem"));
         let combined_pem = format!("{}{}", leaf_cert.pem(), key_pem);
         {
-            use std::io::Write;
             #[cfg(unix)]
             {
+                use std::io::Write;
                 use std::os::unix::fs::OpenOptionsExt;
                 if let Err(e) = std::fs::OpenOptions::new()
                     .write(true)

--- a/src/state_file.rs
+++ b/src/state_file.rs
@@ -249,7 +249,6 @@ fn normalized_lock_path(path: &Path) -> PathBuf {
 mod tests {
     use super::*;
     use crate::daemon_status::DaemonStatus;
-    use crate::pitchfork_toml::Retry;
 
     #[test]
     fn test_state_file_toml_roundtrip_stopped() {

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -12,6 +12,7 @@ mod autostop;
 mod hooks;
 mod ipc_handlers;
 mod lifecycle;
+#[cfg(unix)]
 mod pty;
 mod retry;
 mod state;
@@ -29,7 +30,9 @@ use crate::{Result, env};
 use duct::cmd;
 use miette::IntoDiagnostic;
 use once_cell::sync::Lazy;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+#[cfg(unix)]
+use std::collections::HashSet;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;

--- a/src/supervisor/pty.rs
+++ b/src/supervisor/pty.rs
@@ -23,7 +23,6 @@ pub struct PtyPair {
 /// practice — the extra fd is simply unused — but if strict
 /// close-on-exec semantics are needed, set `FD_CLOEXEC` manually via
 /// `fcntl(fd, F_SETFD, FD_CLOEXEC)`.
-#[cfg(unix)]
 pub fn openpty() -> std::io::Result<PtyPair> {
     let mut master_fd: libc::c_int = -1;
     let mut slave_fd: libc::c_int = -1;

--- a/src/web/routes/logs.rs
+++ b/src/web/routes/logs.rs
@@ -389,6 +389,7 @@ pub async fn stream_sse(
         let mut file_handle: Option<std::fs::File> = None;
 
         // Internal result type for file operations within spawn_blocking
+        #[allow(dead_code)] // FileRotated is constructed only on Unix
         enum FileOpResult {
             Data(Vec<u8>),
             Truncated,
@@ -417,8 +418,10 @@ pub async fn stream_sse(
                 let fh = file_handle.take();
                 let mut ls = last_size;
                 let prev_ino = last_path_ino;
+                #[cfg_attr(not(unix), allow(unused_variables))]
                 let poll_count = poll_count;
                 tokio::task::spawn_blocking(move || {
+                    #[cfg_attr(not(unix), allow(unused_variables))]
                     let opened_fresh = fh.is_none();
                     let mut file = match fh {
                         Some(f) => f,


### PR DESCRIPTION
## Summary

The v2.9.0 release pipeline failed on both Windows targets (run [25281536062](https://github.com/endevco/pitchfork/actions/runs/25281536062)) due to two recently-merged PRs that didn't cfg-gate Unix-only code:

- **#408** added `src/supervisor/pty.rs` (uses `std::os::fd`) and a bare `mod pty;` in `supervisor/mod.rs` — `std::os::fd` doesn't exist on Windows.
- **#406** introduced `libc::SIG*` references in `src/config_types.rs`, but `libc` is gated to `[target.'cfg(unix)']` in `Cargo.toml`.

This PR:
- Gates `mod pty;` behind `cfg(unix)`.
- Replaces `libc::SIG*` lookups in `StopSignal` with platform-portable constants — `libc` on Unix (where signal numbers vary across BSD/Linux), hardcoded POSIX-typical values on Windows. The Windows constants are only used for parsing/Display; `procs::kill` ignores `stop_signal` on Windows and uses `TerminateProcess` via `sysinfo`.
- Cleans up the incidental Windows-only warnings in the same touched files (unused imports, unused vars, dead-code variant, needless return).
- Adds a `windows-build` CI job running `cargo check --lib --bins --all-features` on `windows-latest`. Integration tests under `tests/` use `lsof`/`pkill` and are Unix-only, so we limit the check to lib + bins. This catches the regression in PR CI rather than the release pipeline.

A follow-up patch release will be needed since v2.9.0 shipped with no Windows binaries.

## Test plan

- [x] `cargo check --all-targets --all-features` (Linux) clean
- [x] `cargo check --target x86_64-pc-windows-gnu --all-features` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (Linux) clean
- [x] `cargo clippy --lib --bins --target x86_64-pc-windows-gnu -- -D warnings` clean
- [ ] New `windows-build` CI job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily platform `cfg` gating and CI configuration to catch Windows-only compile issues; runtime behavior is unchanged except for stop-signal parsing/display constants on Windows.
> 
> **Overview**
> Restores Windows compatibility by `cfg`-gating Unix-only modules/imports (e.g. `supervisor::pty`, Unix signal handling) and fixing Windows-only warnings/unused code paths.
> 
> Makes `StopSignal` platform-portable by using `libc` signal numbers on Unix and POSIX-typical constants on Windows, and adjusts Windows process-kill code to ignore unused stop-signal parameters.
> 
> Adds a new GitHub Actions `windows-build` job that runs `cargo check --lib --bins --all-features` on `windows-latest` to catch Windows compile regressions in PR CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3c38303df8542956fe725e9d9ee150e6cc49abc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->