### PR TITLE
test(depends): fix flake in test_dependency_start_order

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -149,6 +149,23 @@ impl TestEnv {
         fs::read_to_string(self.log_path(daemon_id)).unwrap_or_default()
     }
 
+    /// Poll the log file for a daemon until it contains `needle` or `timeout` elapses.
+    /// Returns the final log contents (which may not contain `needle` if it timed out —
+    /// callers should still assert on the result so failures point at the missing content).
+    pub fn wait_for_logs(&self, daemon_id: &str, needle: &str, timeout: Duration) -> String {
+        let start = std::time::Instant::now();
+        loop {
+            let logs = self.read_logs(daemon_id);
+            if logs.contains(needle) {
+                return logs;
+            }
+            if start.elapsed() >= timeout {
+                return logs;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
     /// Get log file path for a daemon
     pub fn log_path(&self, daemon_id: &str) -> PathBuf {
         // If the ID doesn't contain a namespace, assume it's from the project directory

--- a/tests/test_e2e_depends.rs
+++ b/tests/test_e2e_depends.rs
@@ -103,10 +103,11 @@ ready_delay = 1
     );
     assert!(list_stdout.contains("api"), "api daemon should be running");
 
-    // Verify logs exist for all (confirms they were started)
-    let db_logs = env.read_logs("database");
-    let backend_logs = env.read_logs("backend");
-    let api_logs = env.read_logs("api");
+    // Verify logs exist for all (confirms they were started). Poll because the
+    // child shell's echo can take a beat to flush after the start command returns.
+    let db_logs = env.wait_for_logs("database", "database started", Duration::from_secs(5));
+    let backend_logs = env.wait_for_logs("backend", "backend started", Duration::from_secs(5));
+    let api_logs = env.wait_for_logs("api", "api started", Duration::from_secs(5));
 
     assert!(
         db_logs.contains("database started"),


### PR DESCRIPTION
## Summary
- `test_dependency_start_order` flaked on CI ([failing run](https://github.com/endevco/pitchfork/actions/runs/25282332342/job/74121418155)) because it asserted on `api` log contents immediately after `pitchfork start api` returned, racing the child shell's `echo` flush.
- Added a `wait_for_logs(daemon_id, needle, timeout)` polling helper to `tests/common/mod.rs` and used it for the three log assertions in the affected test.
- Same commit had a parallel CI run pass — confirms it's a flake, not a regression in the windows-build branch.

## Test plan
- [x] `cargo nextest run -E 'binary(test_e2e_depends)'` — all 10 tests pass locally
- [x] `cargo fmt --check` and `cargo clippy --tests --all-features -- -D warnings` clean
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds a small polling helper to reduce timing-related flakiness; no production code paths are affected.
> 
> **Overview**
> Stabilizes the `test_dependency_start_order` E2E test by avoiding a race where log assertions could run before the child process’ `echo` output is flushed.
> 
> Adds a `TestEnv::wait_for_logs(daemon_id, needle, timeout)` helper in `tests/common/mod.rs` and updates `tests/test_e2e_depends.rs` to poll for expected log lines (up to 5s) instead of reading logs once immediately after `start`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f91f3a67c567df184e1cad6895723b14bb530ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->