### PR TITLE
chore(ci): add final aggregator job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,40 @@ jobs:
       # Integration tests under tests/ are Unix-only (lsof, pkill, etc.) so
       # we limit the check to lib + bins.
       - run: cargo check --lib --bins --all-features
+
+  # Aggregator that required-status-checks can target. If any upstream job
+  # failed, was cancelled, or was skipped, this step exits non-zero so the PR is
+  # blocked. Lets the branch-protection rule depend on one name instead of N.
+  final:
+    needs:
+      - ci
+      - windows-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: always()
+    steps:
+      - name: Gate on upstream job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          failed = False
+          for name, data in sorted(needs.items()):
+              result = data.get("result", "unknown")
+              if result == "success":
+                  print(f"::notice::{name}: {result}")
+              else:
+                  print(f"::error::{name}: {result}")
+                  failed = True
+
+          if failed:
+              print("One or more upstream jobs did not complete successfully.")
+              sys.exit(1)
+
+          print("All CI jobs completed successfully.")
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
       - windows-build
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    if: always()
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
     steps:
       - name: Gate on upstream job results
         env:


### PR DESCRIPTION
## Summary
- Adds a `final` job to `.github/workflows/ci.yml` that depends on `ci` and `windows-build`, runs with `if: always()`, and exits non-zero if any upstream job didn't succeed.
- Mirrors the pattern in [aube's ci.yml](https://github.com/jdx/aube/blob/main/.github/workflows/ci.yml) so branch protection can target a single status check (`final`) instead of being re-pinned every time a job is added or renamed.
- Drop-in: branch protection still passes once both `ci` and `windows-build` are green; once configured to require `final`, future jobs added to `needs:` are automatically gated.

## Test plan
- [ ] CI green on this PR — both `ci` and `windows-build` pass, then `final` passes
- [ ] Confirm `final` reports `::error::` and fails when an upstream job fails (verifiable on a future PR that breaks one of the jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adds a new gating job; main risk is misconfiguration causing PRs to be blocked if job results are interpreted unexpectedly.
> 
> **Overview**
> Adds a new `final` GitHub Actions job that depends on `ci` and `windows-build` and is intended to be the single required status check for branch protection.
> 
> `final` runs a short Python gate that inspects `needs.*.result`, emits `::notice::`/`::error::` per upstream job, and fails the workflow if any dependency did not complete successfully (while skipping execution when the workflow is cancelled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f68d5ea4844d96045871742d8b0cdc1293628ff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->