### PR TITLE
chore(ci): prevent duplicate sponsor section in release notes

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -68,8 +68,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
         run: |
+          body=$(gh release view "$TAG" --json body --jq .body)
+          if grep -qiE '^##.*Sponsor pitchfork' <<<"$body"; then
+            echo "Sponsor section already present in $TAG release notes; skipping append."
+            exit 0
+          fi
           {
-            gh release view "$TAG" --json body --jq .body
+            printf '%s\n' "$body"
             cat <<'EOF'
 
           ## 💚 Sponsor pitchfork

--- a/communique.toml
+++ b/communique.toml
@@ -1,4 +1,6 @@
 context = "pitchfork is a daemon supervisor CLI for developers. It manages background processes with features like auto-start/stop, cron scheduling, retry logic, and HTTP ready checks."
 
+system_extra = "Do not include a 'Sponsor pitchfork' section, sponsorship blurb, or any en.dev/funding callout in the generated notes. A sponsor section is appended by a separate CI step; emitting one here causes a duplicate."
+
 [defaults]
 emoji = false


### PR DESCRIPTION
## Summary

[v2.9.1](https://github.com/endevco/pitchfork/releases/tag/v2.9.1) shipped with two "Sponsor pitchfork" sections — one without an emoji (LLM-generated) and one with `## 💚 Sponsor pitchfork` (CI-appended). Root cause: `communique` (which uses `match_style` by default) picked up the sponsor pattern from prior releases and emitted its own copy, then the workflow's `Append en.dev sponsor blurb` step appended a second one unconditionally.

The release body has already been fixed manually.

## What this PR changes

Two-layer defense so it doesn't recur:

- **`communique.toml`**: add `system_extra` instructing the LLM not to emit a sponsor/funding section, since CI appends one.
- **`.github/workflows/release-plz.yml`**: make the append step idempotent — if the release body already contains a `## … Sponsor pitchfork` heading (case-insensitive), skip the append and exit cleanly.

Either layer alone would have prevented the v2.9.1 issue; together they cover both "LLM ignored the instruction" and "instruction missing from a future config."

## Test plan

- [ ] Next release runs cleanly with exactly one sponsor section.
- [ ] If `communique` ever generates a sponsor section anyway, CI logs `Sponsor section already present in <tag> release notes; skipping append.` instead of duplicating.

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/config-only change that only affects release note generation/append behavior. Main risk is skipping the sponsor blurb if the heading-detection regex matches unintended content.
> 
> **Overview**
> Prevents duplicate “Sponsor pitchfork” content in GitHub release notes by adding a **two-layer guard**.
> 
> Updates `communique.toml` to explicitly instruct the generator not to include any sponsor/en.dev funding section, and updates the `release-plz.yml` “Append en.dev sponsor blurb” step to **skip appending** when a `## ... Sponsor pitchfork` heading already exists in the release body (case-insensitive).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1df511421ff6c7e1a580ea12784de6278ececdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->