### PR TITLE
chore: set dev profile debug to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,3 +118,6 @@ indexmap = "2"
 
 [dev-dependencies]
 tempfile = "3"
+
+[profile.dev]
+debug = 1


### PR DESCRIPTION
## Summary

Reduces `target/` disk usage by setting `[profile.dev] debug = 1`, while keeping backtrace file:line info intact.

The default `debug = 2` writes full DWARF — including variable/type info that's only needed when stepping through code in a debugger (lldb/gdb). With `debug = 1`, panics, `RUST_BACKTRACE=1`, and error chains still resolve to file:line; only debugger variable inspection is reduced.

In practice this typically shrinks `target/` by a meaningful percentage, which adds up across worktrees.

## Test plan

- [ ] `cargo build` still succeeds
- [ ] CI is green

---
*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build configuration tweak that only affects local dev compilation artifacts and debug symbol detail; no runtime logic changes.
> 
> **Overview**
> Updates `Cargo.toml` to set `[profile.dev] debug = 1`, reducing debug info emitted in dev builds (smaller `target/` output) while keeping basic file/line backtraces available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9e17c39ef59247ee17ba6d387adb17bea5306fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->