### PR TITLE
chore: release v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.0](https://github.com/endevco/pitchfork/compare/v2.9.1...v2.10.0) - 2026-05-05
+
+### Added
+
+- refine startup / tailing logs display ([#420](https://github.com/endevco/pitchfork/pull/420))
+- *(proxy)* sync slug hosts ([#418](https://github.com/endevco/pitchfork/pull/418))
+- inject daemon running info to tera template ([#419](https://github.com/endevco/pitchfork/pull/419))
+
+### Fixed
+
+- *(boot-start)* use LaunchDaemon on MacOS ([#423](https://github.com/endevco/pitchfork/pull/423))
+
+### Other
+
+- *(build)* use serious profile to eliminate binary size ([#424](https://github.com/endevco/pitchfork/pull/424))
+- set dev profile debug to 1 ([#415](https://github.com/endevco/pitchfork/pull/415))
+
 ## [2.9.1](https://github.com/endevco/pitchfork/compare/v2.9.0...v2.9.1) - 2026-05-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,7 +2766,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.9.1"
+version = "2.10.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.en.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2162,7 +2162,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.9.1",
+  "version": "2.10.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.9.1
+**Version**: 2.10.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.9.1"
+version "2.10.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.9.1 -> 2.10.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.10.0](https://github.com/endevco/pitchfork/compare/v2.9.1...v2.10.0) - 2026-05-05

### Added

- refine startup / tailing logs display ([#420](https://github.com/endevco/pitchfork/pull/420))
- *(proxy)* sync slug hosts ([#418](https://github.com/endevco/pitchfork/pull/418))
- inject daemon running info to tera template ([#419](https://github.com/endevco/pitchfork/pull/419))

### Fixed

- *(boot-start)* use LaunchDaemon on MacOS ([#423](https://github.com/endevco/pitchfork/pull/423))

### Other

- *(build)* use serious profile to eliminate binary size ([#424](https://github.com/endevco/pitchfork/pull/424))
- set dev profile debug to 1 ([#415](https://github.com/endevco/pitchfork/pull/415))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).