### PR TITLE
feat(proxy): sync slug hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "tower-http",
  "urlencoding",
@@ -4162,6 +4163,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ strum = { version = "0.28", features = ["derive"] }
 sysinfo = "0.38"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 toml = { version = "1.0", features = ["preserve_order"] }
 rmcp = { version = "1", features = ["server", "transport-io"] }
 uuid = { version = "1", features = ["v4", "fast-rng"] }

--- a/docs/guides/port-management.md
+++ b/docs/guides/port-management.md
@@ -262,26 +262,30 @@ enable = true
 tld = "test"
 ```
 
-This requires wildcard DNS resolution for `*.test`. On macOS with dnsmasq:
+With the default `proxy.sync_hosts = true`, pitchfork keeps registered slugs
+synced into `/etc/hosts`, so you usually do not need to set up `dnsmasq` or any
+other wildcard DNS service just to use a custom TLD.
+
+For example, if you register these slugs:
 
 ```bash
-# Install dnsmasq
-brew install dnsmasq
-
-# Add wildcard DNS entry
-echo "address=/.test/127.0.0.1" >> /usr/local/etc/dnsmasq.conf
-
-# Configure macOS resolver
-sudo mkdir -p /etc/resolver
-echo "nameserver 127.0.0.1" | sudo tee /etc/resolver/test
-
-# Start dnsmasq
-sudo brew services start dnsmasq
+pitchfork proxy add api
+pitchfork proxy add docs
 ```
 
-::: info
-Later we will add built-in support for custom TLDs without manual DNS configuration.
-:::
+pitchfork will maintain matching `/etc/hosts` entries such as:
+
+```text
+127.0.0.1 api.test
+127.0.0.1 docs.test
+```
+
+This works for registered slugs only. It is not wildcard DNS for arbitrary
+`*.test` names.
+
+If pitchfork cannot write `/etc/hosts`, you still need to provide DNS
+resolution yourself, for example with `dnsmasq` or platform-specific resolver
+configuration.
 
 
 ## Proxy Commands

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -625,6 +625,13 @@
           ],
           "format": "int64"
         },
+        "sync_hosts": {
+          "description": "Automatically sync slug hostnames to /etc/hosts",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "tld": {
           "description": "Top-level domain used for proxy URLs",
           "type": [

--- a/settings.toml
+++ b/settings.toml
@@ -670,3 +670,23 @@ the browser receives an error page indicating the startup timed out.
 - `"30s"` - Default, suitable for most daemons
 - `"60s"` - For daemons with slow initialisation (e.g. large Java apps)
 """
+
+[proxy.sync_hosts]
+type = "Bool"
+env = "PITCHFORK_PROXY_SYNC_HOSTS"
+default = "true"
+description = "Automatically sync slug hostnames to /etc/hosts"
+docs = """
+When enabled (default), pitchfork automatically adds entries to `/etc/hosts`
+for registered slugs (e.g. `127.0.0.1 myapp.localhost`) so that browsers
+can resolve them.
+
+This is needed because Safari does not auto-resolve `.localhost` subdomains,
+and custom TLDs (e.g. `.test`) always require DNS entries.
+
+Entries are managed in a marked block in `/etc/hosts` and cleaned up when
+the proxy shuts down. Writing to `/etc/hosts` may require `sudo`.
+
+Set to `false` to disable automatic hosts file management. You will need to
+configure DNS resolution yourself (e.g. `dnsmasq`, `/etc/resolver/` on macOS).
+"""

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -1083,7 +1083,9 @@ impl PitchforkToml {
                 daemon: daemon.map(str::to_string),
             },
         );
-        pt.write_unlocked()
+        pt.write_unlocked()?;
+        crate::proxy::hosts::sync_hosts_from_settings();
+        Ok(())
     }
 
     /// Remove a slug from the global config's `[slugs]` section.
@@ -1105,6 +1107,7 @@ impl PitchforkToml {
         let removed = pt.slugs.shift_remove(slug).is_some();
         if removed {
             pt.write_unlocked()?;
+            crate::proxy::hosts::sync_hosts_from_settings();
         }
         Ok(removed)
     }
@@ -1192,6 +1195,20 @@ impl PitchforkTomlDaemon {
         use crate::daemon::RunOptions;
 
         let dir = crate::ipc::batch::resolve_daemon_dir(self.dir.as_deref(), self.path.as_deref());
+        let slug = crate::pitchfork_toml::PitchforkToml::read_global_slugs()
+            .into_iter()
+            .find(|(slug, entry)| {
+                let daemon_name = entry.daemon.as_deref().unwrap_or(slug);
+                if daemon_name != id.name() {
+                    return false;
+                }
+
+                match crate::pitchfork_toml::PitchforkToml::namespace_for_dir(&entry.dir).ok() {
+                    Some(namespace) => namespace == id.namespace(),
+                    None => false,
+                }
+            })
+            .map(|(slug, _)| slug);
 
         RunOptions {
             id: id.clone(),
@@ -1219,7 +1236,7 @@ impl PitchforkTomlDaemon {
                 self.path.as_deref(),
             )),
             mise: self.mise,
-            slug: None,
+            slug,
             proxy: None,
             user: self.user.clone(),
             memory_limit: self.memory_limit,

--- a/src/proxy/hosts.rs
+++ b/src/proxy/hosts.rs
@@ -1,0 +1,200 @@
+//! /etc/hosts management for the reverse proxy.
+//!
+//! Automatically syncs registered slug hostnames into `/etc/hosts` so that
+//! browsers can resolve them (needed for Safari, which doesn't auto-resolve
+//! `.localhost` subdomains, and for custom TLDs like `.test`).
+//!
+//! Entries are managed inside a marked block delimited by
+//! `# pitchfork-start` / `# pitchfork-end`.  The block is replaced on each
+//! sync and removed entirely on proxy shutdown.
+
+use crate::settings::settings;
+use std::sync::OnceLock;
+
+/// Marker lines for the pitchfork-managed block in /etc/hosts.
+const MARKER_START: &str = "# pitchfork-start";
+const MARKER_END: &str = "# pitchfork-end";
+static BLANK_LINES_RE: OnceLock<regex::Regex> = OnceLock::new();
+
+/// Path to the hosts file on the current platform.
+fn hosts_path() -> std::path::PathBuf {
+    if cfg!(windows) {
+        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
+        std::path::PathBuf::from(system_root)
+            .join("System32")
+            .join("drivers")
+            .join("etc")
+            .join("hosts")
+    } else {
+        std::path::PathBuf::from("/etc/hosts")
+    }
+}
+
+/// Sync all registered slug hostnames into /etc/hosts.
+///
+/// Reads the current slug table from global config, builds the expected
+/// hosts block, and replaces (or appends) the pitchfork-managed block.
+///
+/// Best-effort: logs a warning on failure (e.g. permission denied) and
+/// does not prevent proxy startup.
+pub fn sync_hosts_file(bind_ip: &str, tld: &str) {
+    let slugs = crate::pitchfork_toml::PitchforkToml::read_global_slugs();
+    let mut entries: Vec<String> = Vec::new();
+    for slug in slugs.keys() {
+        entries.push(format!("{bind_ip} {slug}.{tld}"));
+    }
+    write_hosts_block(&entries);
+}
+
+/// Refresh `/etc/hosts` from the current settings if sync is enabled.
+///
+/// Used when slug registrations change while the proxy is already running.
+pub fn sync_hosts_from_settings() {
+    let s = settings();
+    if s.proxy.enable && s.proxy.sync_hosts {
+        sync_hosts_file(&s.proxy.host, &s.proxy.tld);
+    }
+}
+
+/// Remove the pitchfork-managed block from /etc/hosts.
+///
+/// Called on proxy shutdown to clean up stale entries.
+pub fn clean_hosts_file() {
+    write_hosts_block(&[]);
+}
+
+/// Read /etc/hosts, replace the marked block, write back atomically.
+fn write_hosts_block(entries: &[String]) {
+    let path = hosts_path();
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            if !entries.is_empty() {
+                log::warn!(
+                    "Failed to read {} for hosts sync: {e}. \
+                     Set proxy.sync_hosts = false to suppress this warning.",
+                    path.display()
+                );
+            }
+            return;
+        }
+    };
+
+    let cleaned = remove_block(&content);
+
+    let new_content = if entries.is_empty() {
+        cleaned
+    } else {
+        let block = build_block(entries);
+        format!("{}\n{block}\n", cleaned.trim_end())
+    };
+
+    // Atomic write: write to a temp file in the same directory, then rename.
+    let parent = path.parent().unwrap_or(std::path::Path::new("/etc"));
+    let tmp_path = parent.join(format!(".pitchfork-hosts-tmp-{}", std::process::id()));
+
+    if let Err(e) = std::fs::write(&tmp_path, &new_content) {
+        log::warn!(
+            "Failed to write {} for hosts sync: {e}. \
+             Writing to /etc/hosts may require sudo. \
+             Set proxy.sync_hosts = false to suppress this warning.",
+            tmp_path.display()
+        );
+        let _ = std::fs::remove_file(&tmp_path);
+        return;
+    }
+
+    if let Err(e) = std::fs::rename(&tmp_path, &path) {
+        log::warn!(
+            "Failed to rename {} to {}: {e}. \
+             Writing to /etc/hosts may require sudo. \
+             Set proxy.sync_hosts = false to suppress this warning.",
+            tmp_path.display(),
+            path.display()
+        );
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+}
+
+/// Build the pitchfork-managed block for the given entries.
+fn build_block(entries: &[String]) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+    let lines = entries.join("\n");
+    format!("{MARKER_START}\n{lines}\n{MARKER_END}")
+}
+
+/// Remove the pitchfork-managed block from /etc/hosts content and return
+/// the cleaned content with trailing newlines normalized.
+fn remove_block(content: &str) -> String {
+    let start_idx = match content.find(MARKER_START) {
+        Some(i) => i,
+        None => return content.to_string(),
+    };
+    let end_idx = match content[start_idx..].find(MARKER_END) {
+        Some(i) => start_idx + i + MARKER_END.len(),
+        None => return content.to_string(),
+    };
+    let before = &content[..start_idx];
+    let after = &content[end_idx..];
+    let result = format!("{before}{after}");
+    // Normalize excessive blank lines caused by removing the block
+    let re = BLANK_LINES_RE.get_or_init(|| regex::Regex::new(r"\n{3,}").unwrap());
+    re.replace_all(&result, "\n\n").trim_end().to_string() + "\n"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_block() {
+        let entries = vec![
+            "127.0.0.1 myapp.localhost".to_string(),
+            "127.0.0.1 api.myapp.localhost".to_string(),
+        ];
+        let block = build_block(&entries);
+        assert!(block.starts_with("# pitchfork-start\n"));
+        assert!(block.ends_with("\n# pitchfork-end"));
+        assert!(block.contains("127.0.0.1 myapp.localhost"));
+        assert!(block.contains("127.0.0.1 api.myapp.localhost"));
+    }
+
+    #[test]
+    fn test_build_block_empty() {
+        assert!(build_block(&[]).is_empty());
+    }
+
+    #[test]
+    fn test_remove_block() {
+        let content =
+            "127.0.0.1 localhost\n# pitchfork-start\n127.0.0.1 myapp.localhost\n# pitchfork-end\n";
+        let cleaned = remove_block(content);
+        assert!(!cleaned.contains("pitchfork-start"));
+        assert!(!cleaned.contains("myapp.localhost"));
+        assert!(cleaned.contains("127.0.0.1 localhost"));
+    }
+
+    #[test]
+    fn test_remove_block_no_markers() {
+        let content = "127.0.0.1 localhost\n";
+        let cleaned = remove_block(content);
+        assert_eq!(cleaned, content);
+    }
+
+    #[test]
+    fn test_remove_block_normalizes_blank_lines() {
+        let content = "127.0.0.1 localhost\n\n\n# pitchfork-start\n127.0.0.1 myapp.localhost\n# pitchfork-end\n\n\n";
+        let cleaned = remove_block(content);
+        assert!(!cleaned.contains("\n\n\n"));
+    }
+
+    #[test]
+    fn test_remove_block_ignores_end_marker_before_start_marker() {
+        let content = "127.0.0.1 localhost\n# pitchfork-end\n# pitchfork-start\n127.0.0.1 myapp.localhost\n# pitchfork-end\n";
+        let cleaned = remove_block(content);
+        assert_eq!(cleaned, "127.0.0.1 localhost\n# pitchfork-end\n");
+    }
+}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -10,4 +10,5 @@
 //! myapp.localhost:7777          →  localhost:8080  (via slug)
 //! ```
 
+pub mod hosts;
 pub mod server;

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -186,6 +186,7 @@ struct ProxyState {
 /// This function is intended to be spawned as a background task.
 pub async fn serve(
     bind_tx: tokio::sync::oneshot::Sender<std::result::Result<(), String>>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> crate::Result<()> {
     let s = settings();
     let Some(effective_port) = u16::try_from(s.proxy.port).ok().filter(|&p| p > 0) else {
@@ -233,9 +234,9 @@ pub async fn serve(
     let addr = SocketAddr::from((bind_ip, effective_port));
 
     if s.proxy.https {
-        serve_https_with_http_fallback(app, addr, s, effective_port, bind_tx).await
+        serve_https_with_http_fallback(app, addr, s, effective_port, bind_tx, cancel).await
     } else {
-        serve_http(app, addr, effective_port, bind_tx).await
+        serve_http(app, addr, effective_port, bind_tx, cancel).await
     }
 }
 
@@ -245,9 +246,13 @@ async fn serve_http(
     addr: SocketAddr,
     effective_port: u16,
     bind_tx: tokio::sync::oneshot::Sender<std::result::Result<(), String>>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> crate::Result<()> {
     let listener = match TcpListener::bind(addr).await {
         Ok(l) => {
+            if settings().proxy.sync_hosts {
+                crate::proxy::hosts::sync_hosts_from_settings();
+            }
             let _ = bind_tx.send(Ok(()));
             l
         }
@@ -265,10 +270,12 @@ async fn serve_http(
              The supervisor must be started with sudo to bind to this port."
         );
     }
+    let shutdown_signal = cancel.clone().cancelled_owned();
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
     )
+    .with_graceful_shutdown(shutdown_signal)
     .await
     .map_err(|e| miette::miette!("Proxy server error: {e}"))?;
     Ok(())
@@ -277,9 +284,8 @@ async fn serve_http(
 /// Serve HTTPS with automatic HTTP detection on the same port.
 ///
 /// Peeks at the first byte of each incoming TCP connection:
-/// - `0x16` (TLS ClientHello) → hand off to the TLS acceptor
-/// - anything else → treat as plain HTTP (useful for health checks and
-///   clients that haven't been configured to use HTTPS)
+/// - `0x16` (TLS ClientHello) → hand off to the TLS acceptor (HTTP/2 + HTTP/1.1 via ALPN)
+/// - anything else → 302 redirect to HTTPS
 #[cfg(feature = "proxy-tls")]
 async fn serve_https_with_http_fallback(
     app: Router,
@@ -287,6 +293,7 @@ async fn serve_https_with_http_fallback(
     s: &crate::settings::Settings,
     effective_port: u16,
     bind_tx: tokio::sync::oneshot::Sender<std::result::Result<(), String>>,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> crate::Result<()> {
     use rustls::ServerConfig;
     use tokio_rustls::TlsAcceptor;
@@ -309,14 +316,20 @@ async fn serve_https_with_http_fallback(
     // Build the SNI resolver (loads CA, caches per-domain certs)
     let resolver = SniCertResolver::new(&ca_cert_path, &ca_key_path)?;
 
-    let tls_config = ServerConfig::builder()
+    let mut tls_config = ServerConfig::builder()
         .with_no_client_auth()
         .with_cert_resolver(Arc::new(resolver));
+    // Advertise HTTP/2 and HTTP/1.1 via ALPN so browsers negotiate HTTP/2
+    // for multiplexed requests (eliminates the 6-connection-per-host limit).
+    tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 
     let acceptor = TlsAcceptor::from(Arc::new(tls_config));
 
     let listener = match TcpListener::bind(addr).await {
         Ok(l) => {
+            if settings().proxy.sync_hosts {
+                crate::proxy::hosts::sync_hosts_from_settings();
+            }
             let _ = bind_tx.send(Ok(()));
             l
         }
@@ -335,55 +348,86 @@ async fn serve_https_with_http_fallback(
         );
     }
 
+    // Build a lightweight redirect app for plain-HTTP requests.
+    let redirect_app = Router::new().fallback(redirect_to_https_handler);
+
     // Accept connections and sniff the first byte to decide TLS vs plain HTTP.
+    let mut conn_tasks: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
     loop {
-        let (stream, _peer_addr) = match listener.accept().await {
-            Ok(conn) => conn,
-            Err(e) => {
-                // Transient errors (e.g. EAGAIN, EMFILE) should not bring down
-                // the entire proxy server.  Log and retry after a brief pause.
-                log::warn!("Accept error (will retry): {e}");
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                continue;
-            }
-        };
+        // Reap finished connection tasks during normal operation so the JoinSet
+        // does not retain one entry per historical connection.
+        while conn_tasks.try_join_next().is_some() {}
 
-        let acceptor = acceptor.clone();
-        let app = app.clone();
+        tokio::select! {
+            accept_result = listener.accept() => {
+                let (stream, _peer_addr) = match accept_result {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        log::warn!("Accept error (will retry): {e}");
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        continue;
+                    }
+                };
 
-        tokio::spawn(async move {
-            // Peek at the first byte without consuming it.
-            // TLS ClientHello always starts with 0x16 (content type "handshake").
-            let mut peek_buf = [0u8; 1];
-            match stream.peek(&mut peek_buf).await {
-                Ok(0) | Err(_) => return, // connection closed before sending anything
-                _ => {}
-            }
+                let acceptor = acceptor.clone();
+                let app = app.clone();
+                let redirect_app = redirect_app.clone();
 
-            if peek_buf[0] == 0x16 {
-                // TLS handshake
-                match acceptor.accept(stream).await {
-                    Ok(tls_stream) => {
-                        let io = hyper_util::rt::TokioIo::new(tls_stream);
-                        let svc = hyper_util::service::TowerToHyperService::new(app);
+                conn_tasks.spawn(async move {
+                    // Peek at the first byte without consuming it.
+                    // TLS ClientHello always starts with 0x16 (content type "handshake").
+                    let mut peek_buf = [0u8; 1];
+                    match stream.peek(&mut peek_buf).await {
+                        Ok(0) | Err(_) => return,
+                        _ => {}
+                    }
+
+                    if peek_buf[0] == 0x16 {
+                        // TLS handshake → HTTP/2 or HTTP/1.1 (negotiated via ALPN)
+                        match acceptor.accept(stream).await {
+                            Ok(tls_stream) => {
+                                let io = hyper_util::rt::TokioIo::new(tls_stream);
+                                let svc = hyper_util::service::TowerToHyperService::new(app);
+                                if let Err(e) = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+                                    .serve_connection_with_upgrades(io, svc)
+                                    .await
+                                {
+                                    // HTTP/2 RST_STREAM errors from cancelled browser requests
+                                    // (navigation, HMR) are normal — log at debug to avoid noise.
+                                    log::debug!("Connection error: {e}");
+                                }
+                            }
+                            Err(e) => {
+                                log::debug!("TLS handshake error: {e}");
+                            }
+                        }
+                    } else {
+                        // Plain HTTP on the TLS port → 302 redirect to HTTPS
+                        let io = hyper_util::rt::TokioIo::new(stream);
+                        let svc = hyper_util::service::TowerToHyperService::new(redirect_app);
                         let _ = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
                             .serve_connection_with_upgrades(io, svc)
                             .await;
                     }
-                    Err(e) => {
-                        log::debug!("TLS handshake error: {e}");
-                    }
-                }
-            } else {
-                // Plain HTTP on the TLS port
-                let io = hyper_util::rt::TokioIo::new(stream);
-                let svc = hyper_util::service::TowerToHyperService::new(app);
-                let _ = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
-                    .serve_connection_with_upgrades(io, svc)
-                    .await;
+                });
+
+                while conn_tasks.try_join_next().is_some() {}
             }
-        });
+            _ = cancel.cancelled() => {
+                log::info!("Proxy server shutting down (cancel signal received)");
+                break;
+            }
+        }
     }
+
+    // Drain in-flight connections with a timeout.
+    let drain_timeout = std::time::Duration::from_secs(10);
+    let _ = tokio::time::timeout(drain_timeout, async {
+        while conn_tasks.join_next().await.is_some() {}
+    })
+    .await;
+
+    Ok(())
 }
 
 /// Fallback when proxy-tls feature is not enabled.
@@ -394,6 +438,7 @@ async fn serve_https_with_http_fallback(
     _s: &crate::settings::Settings,
     _effective_port: u16,
     bind_tx: tokio::sync::oneshot::Sender<std::result::Result<(), String>>,
+    _cancel: tokio_util::sync::CancellationToken,
 ) -> crate::Result<()> {
     let msg = "HTTPS proxy support requires the `proxy-tls` feature.\n\
          Rebuild pitchfork with: cargo build --features proxy-tls"
@@ -1556,6 +1601,71 @@ fn starting_html_response(slug: &str, raw_host: &str) -> Response {
         .header("retry-after", "2")
         .body(Body::from(html))
         .unwrap_or_else(|_| (StatusCode::SERVICE_UNAVAILABLE, "Starting…").into_response())
+}
+
+/// Handler that redirects plain-HTTP requests to HTTPS.
+///
+/// Used when the proxy is configured for HTTPS but receives a plain-HTTP
+/// request on the same port (after the first-byte peek determines it is
+/// not a TLS ClientHello).  Returns a 302 redirect to the HTTPS equivalent.
+///
+/// WebSocket upgrade attempts over plain HTTP are rejected with 400
+/// because WS-over-plain-HTTP to a TLS port is inherently broken.
+async fn redirect_to_https_handler(req: Request) -> Response {
+    // Reject WebSocket upgrades over plain HTTP
+    if req.headers().contains_key("upgrade") {
+        log::warn!("Dropping plain-HTTP WebSocket upgrade attempt — use wss:// instead of ws://");
+        return (
+            StatusCode::BAD_REQUEST,
+            "WebSocket over plain HTTP is not supported on the HTTPS port. Use wss:// instead.",
+        )
+            .into_response();
+    }
+
+    let raw_host = get_request_host(&req);
+    let Some(raw_host) = raw_host else {
+        return (StatusCode::BAD_REQUEST, "Missing Host header").into_response();
+    };
+
+    // Strip any incoming port from Host and use the configured HTTPS port.
+    let hostname = if raw_host.starts_with('[') {
+        // IPv6: "[::1]:port" or "[::1]"
+        raw_host
+            .split_once("]:")
+            .map(|(host, _)| host)
+            .unwrap_or(&raw_host)
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+    } else {
+        // IPv4/hostname: "host:port" or "host"
+        let mut parts = raw_host.rsplitn(2, ':');
+        let last = parts.next().unwrap_or(&raw_host);
+        parts.next().unwrap_or(last)
+    };
+
+    let path = req
+        .uri()
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+
+    let https_port = match u16::try_from(settings().proxy.port).ok().filter(|&p| p > 0) {
+        Some(443) | None => String::new(),
+        Some(port) => format!(":{port}"),
+    };
+
+    let host_for_url = if raw_host.starts_with('[') {
+        format!("[{hostname}]")
+    } else {
+        hostname.to_string()
+    };
+
+    let location = format!("https://{host_for_url}{https_port}{path}");
+    (
+        StatusCode::FOUND,
+        [(axum::http::header::LOCATION, location)],
+    )
+        .into_response()
 }
 
 /// Build a plain-text error response.

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -368,6 +368,9 @@ impl Supervisor {
             }
         }
 
+        // Inject proxy-related environment variables
+        inject_proxy_env(&mut cmd, &opts.slug);
+
         #[cfg(unix)]
         {
             let run_identity = run_identity.clone();
@@ -1712,4 +1715,80 @@ mod tests {
         let identity = resolve_run_identity(Some("root"), 0, 0, Some("501"), Some("20")).unwrap();
         assert_eq!(identity, RunIdentity::Inherit);
     }
+}
+
+/// Inject proxy-related environment variables into a daemon's command.
+///
+/// Adds:
+/// - `HOST` — the address the daemon should bind to (`127.0.0.1`)
+/// - `PITCHFORK_URL` — the public proxy URL for this daemon (if it has a slug)
+/// - `NODE_EXTRA_CA_CERTS` — path to the pitchfork CA cert (if HTTPS enabled)
+/// - `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` — `.<tld>` for Vite host allowlisting
+fn inject_proxy_env(cmd: &mut tokio::process::Command, slug: &Option<String>) {
+    let s = crate::settings::settings();
+
+    if should_force_loopback_host(slug) {
+        // Only force loopback binding for daemons that are actually routed via a slug.
+        cmd.env("HOST", "127.0.0.1");
+    }
+
+    // PITCHFORK_URL: the daemon's public proxy URL (only if it has a slug and proxy is enabled)
+    if let Some(url) = build_pitchfork_url(slug, s) {
+        cmd.env("PITCHFORK_URL", &url);
+    }
+
+    // NODE_EXTRA_CA_CERTS: let Node.js backends trust the pitchfork CA
+    if s.proxy.enable && s.proxy.https {
+        let ca_path = if s.proxy.tls_cert.is_empty() {
+            crate::env::PITCHFORK_STATE_DIR.join("proxy").join("ca.pem")
+        } else {
+            std::path::PathBuf::from(&s.proxy.tls_cert)
+        };
+        if ca_path.exists() {
+            cmd.env("NODE_EXTRA_CA_CERTS", ca_path.to_string_lossy().to_string());
+        }
+    }
+
+    // __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: Vite host allowlisting
+    if s.proxy.enable {
+        cmd.env(
+            "__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS",
+            format!(".{}", s.proxy.tld),
+        );
+    }
+}
+
+fn should_force_loopback_host(slug: &Option<String>) -> bool {
+    let Some(slug) = slug.as_deref() else {
+        return false;
+    };
+
+    let s = crate::settings::settings();
+    if !s.proxy.enable {
+        return false;
+    }
+
+    let slugs = crate::pitchfork_toml::PitchforkToml::read_global_slugs();
+    slugs.contains_key(slug)
+}
+
+/// Compute the public proxy URL for a daemon.
+///
+/// Returns `None` if the daemon has no slug or the proxy is not enabled.
+fn build_pitchfork_url(slug: &Option<String>, s: &crate::settings::Settings) -> Option<String> {
+    let slug = slug.as_ref()?;
+    if !s.proxy.enable {
+        return None;
+    }
+    let scheme = if s.proxy.https { "https" } else { "http" };
+    let port = u16::try_from(s.proxy.port).ok().filter(|&p| p > 0)?;
+    let port_suffix = if (scheme == "https" && port == 443) || (scheme == "http" && port == 80) {
+        String::new()
+    } else {
+        format!(":{port}")
+    };
+    Some(format!(
+        "{scheme}://{slug}.{tld}{port_suffix}",
+        tld = s.proxy.tld
+    ))
 }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -78,6 +78,11 @@ pub struct Supervisor {
     /// Signalled by each monitoring task after it finishes registering hooks
     /// (or decides it has nothing to register). `close()` waits on this.
     pub(crate) monitor_done: Notify,
+    /// Cancellation token for the proxy server — cancelled on shutdown to
+    /// stop accepting new connections and drain in-flight ones.
+    pub(crate) proxy_cancel: Mutex<Option<tokio_util::sync::CancellationToken>>,
+    /// Join handle for the proxy task so shutdown can wait for cleanup.
+    pub(crate) proxy_task: Mutex<Option<JoinHandle<()>>>,
 }
 
 pub(crate) fn interval_duration() -> Duration {
@@ -133,6 +138,8 @@ impl Supervisor {
             hook_tasks: Mutex::new(Vec::new()),
             active_monitors: AtomicU32::new(0),
             monitor_done: Notify::new(),
+            proxy_cancel: Mutex::new(None),
+            proxy_task: Mutex::new(None),
         })
     }
 
@@ -248,11 +255,15 @@ impl Supervisor {
             // channel.  This avoids the TOCTOU race of a pre-flight bind check
             // while still surfacing binding failures immediately.
             let (bind_tx, bind_rx) = tokio::sync::oneshot::channel();
-            tokio::spawn(async {
-                if let Err(e) = crate::proxy::server::serve(bind_tx).await {
+            let proxy_cancel = tokio_util::sync::CancellationToken::new();
+            let proxy_cancel_clone = proxy_cancel.clone();
+            *self.proxy_cancel.lock().await = Some(proxy_cancel);
+            let proxy_task = tokio::spawn(async move {
+                if let Err(e) = crate::proxy::server::serve(bind_tx, proxy_cancel_clone).await {
                     error!("Proxy server error: {e}");
                 }
             });
+            *self.proxy_task.lock().await = Some(proxy_task);
             match bind_rx.await {
                 Ok(Ok(())) => {
                     // Proxy bound successfully — nothing to do.
@@ -509,6 +520,23 @@ impl Supervisor {
     }
 
     pub(crate) async fn close(&self) {
+        // Signal the proxy server to stop accepting new connections
+        // and drain in-flight ones, *before* stopping daemons so the
+        // proxy has time to finish forwarding active requests.
+        if let Some(cancel) = self.proxy_cancel.lock().await.take() {
+            cancel.cancel();
+        }
+
+        if let Some(proxy_task) = self.proxy_task.lock().await.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(12), proxy_task).await;
+        }
+
+        // Clean up /etc/hosts entries managed by pitchfork
+        let s = settings();
+        if s.proxy.enable && s.proxy.sync_hosts {
+            crate::proxy::hosts::clean_hosts_file();
+        }
+
         let pitchfork_id = DaemonId::pitchfork();
         let active = self.active_daemons().await;
         let active_ids: Vec<DaemonId> = active


### PR DESCRIPTION
This is a big enhancement to proxy feature:

- add `proxy.sync_hosts` setting (default: `true`)
	- automatically sync registered slug hostnames into `/etc/hosts`
	- refresh hosts entries when slugs are added or removed
	- clean up pitchfork-managed hosts entries on proxy shutdown
	- propagate slug information into daemon `RunOptions`
- inject proxy-related environment variables into routed daemons:
    - `HOST`
    - `PITCHFORK_URL`
    - `NODE_EXTRA_CA_CERTS`
    - `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS`
- add graceful proxy shutdown with `CancellationToken`
- drain in-flight proxy connections during supervisor shutdown
- advertise HTTP/2 via ALPN in HTTPS mode
- redirect plain HTTP requests on the HTTPS port to `https://`
- reject plain-HTTP WebSocket upgrade attempts on the HTTPS port
- update port management docs to reflect built-in hosts syncing