### PR TITLE
chore: release v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.0](https://github.com/endevco/pitchfork/compare/v2.10.0...v2.11.0) - 2026-05-17
+
+### Added
+
+- *(config)* support ready_http status codes ([#437](https://github.com/endevco/pitchfork/pull/437))
+- *(config)* impl daemon group ([#442](https://github.com/endevco/pitchfork/pull/442))
+- *(proxy)* auto trust if possible ([#431](https://github.com/endevco/pitchfork/pull/431))
+- *(proxy)* support LAN mode with mDNS ([#430](https://github.com/endevco/pitchfork/pull/430))
+- *(proxy)* support wildcard subdomain ([#426](https://github.com/endevco/pitchfork/pull/426))
+
+### Other
+
+- avoid refresh full pid tree when Procs::new() ([#441](https://github.com/endevco/pitchfork/pull/441))
+- *(build)* suit for non-Windows/MacOS/Linux build ([#429](https://github.com/endevco/pitchfork/pull/429))
+
 ## [2.10.0](https://github.com/endevco/pitchfork/compare/v2.9.1...v2.10.0) - 2026-05-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2802,7 +2802,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.10.0"
+version = "2.11.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.en.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2257,7 +2257,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.10.0",
+  "version": "2.11.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.10.0
+**Version**: 2.11.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.10.0"
+version "2.11.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.10.0 -> 2.11.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.11.0](https://github.com/endevco/pitchfork/compare/v2.10.0...v2.11.0) - 2026-05-17

### Added

- *(config)* support ready_http status codes ([#437](https://github.com/endevco/pitchfork/pull/437))
- *(config)* impl daemon group ([#442](https://github.com/endevco/pitchfork/pull/442))
- *(proxy)* auto trust if possible ([#431](https://github.com/endevco/pitchfork/pull/431))
- *(proxy)* support LAN mode with mDNS ([#430](https://github.com/endevco/pitchfork/pull/430))
- *(proxy)* support wildcard subdomain ([#426](https://github.com/endevco/pitchfork/pull/426))

### Other

- avoid refresh full pid tree when Procs::new() ([#441](https://github.com/endevco/pitchfork/pull/441))
- *(build)* suit for non-Windows/MacOS/Linux build ([#429](https://github.com/endevco/pitchfork/pull/429))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).