### PR TITLE
chore(ci): assert mise run render produces no diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,15 @@ jobs:
       - run: rm -rf .cargo
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: mise run ci
+      - run: mise run render
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff
+            exit 1
+          fi
 
   windows-build:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             echo "::error::'mise run render' produced changes. Run it locally and commit."
             git status
-            git diff
+            git diff HEAD
             exit 1
           fi
 


### PR DESCRIPTION
Runs `mise run render` and asserts it produces no diff. Follows up the autofix.ci workflow removal in #432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds an extra CI validation step, with the main impact being potential new CI failures if generated/rendered artifacts are out of date.
> 
> **Overview**
> The CI workflow now runs `mise run render` after `mise run ci` and **fails the job if it produces any git diff**, printing the status/diff to help diagnose missing committed generated artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d148f3cdebe3392294181deab864553c345624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->