### PR TITLE
chore(ci): add zizmor workflow for github actions security analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
   MISE_EXPERIMENTAL: true
@@ -19,23 +21,35 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: true
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - run: rm -rf .cargo
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
       - run: mise run ci
 
   windows-build:
     runs-on: windows-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: true
+          persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
       # `cargo check` (debug) catches the compile errors that otherwise only
       # surface in the release pipeline, without paying for an optimized link.
       # Integration tests under tests/ are Unix-only (lsof, pkill, etc.) so
@@ -51,6 +65,7 @@ jobs:
       - windows-build
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions: {}
     # Run on success or upstream failure but skip when the workflow is cancelled
     # — `always()` would override `cancel-in-progress` and waste a runner.
     if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - run: rm -rf .cargo
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          lookup-only: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: mise run ci
 
   windows-build:
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          lookup-only: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # `cargo check` (debug) catches the compile errors that otherwise only
       # surface in the release pipeline, without paying for an optimized link.
       # Integration tests under tests/ are Unix-only (lsof, pkill, etc.) so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           cache: false
       - run: rm -rf .cargo
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # save-if gates cache writes to main so PRs can only restore, not poison.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # zizmor: ignore[cache-poisoning] v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: mise run ci
@@ -47,7 +48,8 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # save-if gates cache writes to main so PRs can only restore, not poison.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # zizmor: ignore[cache-poisoning] v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       # `cargo check` (debug) catches the compile errors that otherwise only

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,11 +11,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -27,11 +23,14 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -43,6 +43,8 @@ jobs:
     needs: release-plz-release
     if: >-
       ${{ always() && (inputs.tag != '' || needs.release-plz-release.outputs.tag != '') }}
+    permissions:
+      contents: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ inputs.tag != '' && inputs.tag || needs.release-plz-release.outputs.tag }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
       - name: Run release-plz
         id: release-plz
-        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
           command: release
         env:
@@ -111,7 +111,7 @@ jobs:
           persist-credentials: false
       - name: Run release-plz
         id: release-plz
-        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
           command: release-pr
         env:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -103,12 +103,13 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      # release-plz-pr needs persisted credentials so the later
+      # `git fetch` / `git push --force-with-lease` can authenticate.
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # zizmor: ignore[artipacked] v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          persist-credentials: false
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -120,7 +120,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - name: Squash generated docs into release PR
         run: |
-          PR_BRANCH=$(echo '${STEPS_RELEASE_PLZ_OUTPUTS_PR}' | jq -r '.head_branch // empty')
+          PR_BRANCH=$(echo "${STEPS_RELEASE_PLZ_OUTPUTS_PR}" | jq -r '.head_branch // empty')
           if [ -z "$PR_BRANCH" ]; then
             PR_BRANCH=$(gh pr list --state open --base main --json headRefName,updatedAt --jq 'sort_by(.updatedAt) | reverse | map(select(.headRefName | startswith("release-plz-")))[0].headRefName // empty' 2>/dev/null || true)
           fi

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,8 +1,6 @@
 name: Release-plz
 
-permissions:
-  pull-requests: write
-  contents: write
+permissions: {}
 
 on:
   push:
@@ -20,6 +18,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.repository_owner == 'endevco' }}
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       tag: ${{ steps.release-plz.outputs.releases && fromJSON(steps.release-plz.outputs.releases)[0].tag || '' }}
     steps:
@@ -45,7 +46,9 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ inputs.tag != '' && inputs.tag || needs.release-plz-release.outputs.tag }}
-    secrets: inherit
+    secrets:
+      CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
+      CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
 
   enhance-release:
     name: Enhance release notes
@@ -53,12 +56,15 @@ jobs:
     if: >-
       ${{ always() && needs.upload-assets.result == 'success' && (inputs.tag != '' || needs.release-plz-release.outputs.tag != '') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       TAG: ${{ inputs.tag != '' && inputs.tag || needs.release-plz-release.outputs.tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - run: communique generate "$TAG" --github-release
         env:
@@ -90,6 +96,9 @@ jobs:
     name: Release PR
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.repository_owner == 'endevco' }}
+    permissions:
+      contents: write
+      pull-requests: write
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
@@ -99,6 +108,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          persist-credentials: false
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
@@ -110,7 +120,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - name: Squash generated docs into release PR
         run: |
-          PR_BRANCH=$(echo '${{ steps.release-plz.outputs.pr }}' | jq -r '.head_branch // empty')
+          PR_BRANCH=$(echo '${STEPS_RELEASE_PLZ_OUTPUTS_PR}' | jq -r '.head_branch // empty')
           if [ -z "$PR_BRANCH" ]; then
             PR_BRANCH=$(gh pr list --state open --base main --json headRefName,updatedAt --jq 'sort_by(.updatedAt) | reverse | map(select(.headRefName | startswith("release-plz-")))[0].headRefName // empty' 2>/dev/null || true)
           fi
@@ -133,3 +143,4 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          STEPS_RELEASE_PLZ_OUTPUTS_PR: ${{ steps.release-plz.outputs.pr }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
       tag:
         required: true
         type: string
+    secrets:
+      CERTIFICATES_P12:
+        required: true
+      CERTIFICATES_P12_PASS:
+        required: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,6 +39,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: refs/tags/${{ inputs.tag }}
+          persist-credentials: false
       - name: Import codesign certs
         if: startsWith(matrix.os, 'macos')
         uses: apple-actions/import-codesign-certs@fe74d46e82474f87e1ba79832ad28a4013d0e33a # v6
@@ -93,7 +99,8 @@ jobs:
     steps:
       - name: Publish release
         run: |
-          echo "Publishing release ${{ inputs.tag }}..."
-          gh release edit "${{ inputs.tag }}" --repo "${{ github.repository }}" --draft=false
+          echo "Publishing release ${INPUTS_TAG}..."
+          gh release edit "${INPUTS_TAG}" --repo "${{ github.repository }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUTS_TAG: ${{ inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
       - name: Install cross
         if: matrix.os == 'ubuntu-latest'
-        uses: taiki-e/install-action@787505cde8a44ea468a00478fe52baf23b15bccd # v2
+        uses: taiki-e/install-action@787505cde8a44ea468a00478fe52baf23b15bccd # v2.75.21
         with:
           tool: cross
       - name: Setup Rust target
@@ -56,7 +56,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
       - name: Install cross-compilation tools
         if: matrix.os != 'ubuntu-latest'
-        uses: taiki-e/setup-cross-toolchain-action@d62f33b587e73b0004731caebc7d2d46b18a7567 # v1
+        uses: taiki-e/setup-cross-toolchain-action@d62f33b587e73b0004731caebc7d2d46b18a7567 # v1.39.2
         with:
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,3 +17,5 @@ jobs:
         with:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,19 @@
+name: zizmor
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths: ['.github/workflows/**']
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,13 +3,14 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths: ['.github/workflows/**']
+    paths: [".github/workflows/**"]
 
 permissions: {}
 
 jobs:
   zizmor:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Adds [zizmor](https://github.com/zizmorcore/zizmor) to audit GitHub Actions workflows for security issues. Runs on push to main and on PRs that change `.github/workflows/**`. Fails CI on any finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it modifies CI/release GitHub Actions permissions, credential persistence, and secret passing, which could break publishing or deployment if misconfigured.
> 
> **Overview**
> Introduces a new `zizmor` workflow that runs on `main` pushes and workflow-file PRs to lint GitHub Actions for security issues and fail on findings.
> 
> Hardens existing workflows by setting top-level `permissions: {}`, scoping per-job permissions, disabling `actions/checkout` credential persistence where not needed, and gating `rust-cache` writes to `main` to reduce cache-poisoning risk.
> 
> Adjusts release automation by explicitly passing required signing secrets through `workflow_call`, updating some action version pins/comments, and making a couple of shell steps use explicit env vars (e.g., `INPUTS_TAG`, `STEPS_RELEASE_PLZ_OUTPUTS_PR`) for safer interpolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d3000e469ca801fc4bc151369192e7b1f72a860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->