### PR TITLE
feat(config): support ready_http status codes

### DIFF
--- a/docs/guides/ready-checks.md
+++ b/docs/guides/ready-checks.md
@@ -50,7 +50,8 @@ ready_output = "Serving HTTP on"
 
 ## HTTP Check
 
-Wait until an HTTP endpoint returns a 2xx status code.
+Wait until an HTTP endpoint returns a 2xx status code, or a configured exact
+status code.
 
 **CLI:**
 ```bash
@@ -67,12 +68,18 @@ ready_http = "http://localhost:8000/health"
 [daemons.webserver]
 run = "node server.js"
 ready_http = "http://localhost:3000/ready"
+
+[daemons.private_api]
+run = "node server.js"
+ready_http = { url = "http://localhost:3000/health", status = [200, 401] }
 ```
 
 **Best for:** Web services with health check endpoints.
 
 ::: tip
-The HTTP check polls every 500ms with a 5 second timeout per request.
+The HTTP check polls every 500ms with a 5 second timeout per request. The string
+form accepts any 2xx response; the object form accepts the exact `status` codes
+you list.
 :::
 
 ## Port Check
@@ -135,7 +142,7 @@ The command check polls every 500ms. Use this when you need more complex readine
 |------------|-----------|
 | Delay | Daemon runs for N seconds without crashing |
 | Output | Pattern matches stdout/stderr |
-| HTTP | Endpoint returns 2xx status |
+| HTTP | Endpoint returns 2xx status, or a configured exact status |
 | Port | TCP connection to port succeeds |
 | Command | Shell command returns exit code 0 |
 

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -273,10 +273,14 @@
           "minimum": 0
         },
         "ready_http": {
-          "description": "HTTP URL to poll for readiness (expects 2xx response)",
-          "type": [
-            "string",
-            "null"
+          "description": "HTTP URL to poll for readiness. Accepts any 2xx response by default, or configured statuses.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReadyHttp"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "ready_output": {
@@ -439,6 +443,36 @@
               }
             }
           }
+        }
+      ]
+    },
+    "ReadyHttp": {
+      "description": "HTTP readiness check: a URL string accepting any 2xx response, or { url, status } object with exact accepted status codes",
+      "oneOf": [
+        {
+          "description": "HTTP URL to poll for readiness; any 2xx response is ready",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "description": "Exact HTTP status codes that indicate readiness. Omit to accept any 2xx response.",
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "maximum": 599,
+                "minimum": 100
+              }
+            },
+            "url": {
+              "description": "HTTP URL to poll for readiness",
+              "type": "string"
+            }
+          },
+          "required": [
+            "url"
+          ]
         }
       ]
     },

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -218,12 +218,18 @@ ready_output = "ready to accept connections"
 
 ### `ready_http`
 
-HTTP endpoint URL to poll for readiness (2xx = ready).
+HTTP endpoint URL to poll for readiness. By default, any 2xx response is ready.
+Use the object form when specific non-2xx statuses also mean the service is up
+(for example an authenticated endpoint returning 401).
 
 ```toml
 [daemons.api]
 run = "npm run server"
 ready_http = "http://localhost:3000/health"
+
+[daemons.private_api]
+run = "npm run server"
+ready_http = { url = "http://localhost:3000/health", status = [200, 401] }
 ```
 
 ### `ready_port`

--- a/src/cli/config/add.rs
+++ b/src/cli/config/add.rs
@@ -3,7 +3,7 @@ use crate::daemon_id::DaemonId;
 use crate::env;
 use crate::pitchfork_toml::{
     CronRetrigger, PitchforkToml, PitchforkTomlAuto, PitchforkTomlCron, PitchforkTomlDaemon,
-    PitchforkTomlHooks, PortBump, PortConfig, Retry, namespace_from_path,
+    PitchforkTomlHooks, PortBump, PortConfig, ReadyHttp, Retry, namespace_from_path,
 };
 use crate::settings::settings;
 use indexmap::IndexMap;
@@ -246,7 +246,7 @@ impl Add {
                 retry,
                 ready_delay: self.ready_delay,
                 ready_output: self.ready_output.clone(),
-                ready_http: self.ready_http.clone(),
+                ready_http: self.ready_http.clone().map(ReadyHttp::new),
                 ready_port: self.ready_port,
                 ready_cmd: self.ready_cmd.clone(),
                 port: {

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -182,6 +182,142 @@ impl JsonSchema for CpuLimit {
 }
 
 // ---------------------------------------------------------------------------
+// ReadyHttp
+// ---------------------------------------------------------------------------
+
+/// HTTP readiness check configuration.
+///
+/// Accepts two TOML forms:
+/// ```toml
+/// ready_http = "http://localhost:3000/health"  # shorthand, any 2xx response
+/// ready_http = { url = "http://localhost:3000/health", status = [200, 401] }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ReadyHttp {
+    pub url: String,
+    /// Exact status codes that indicate readiness. Empty means any 2xx response.
+    pub status: Vec<u16>,
+}
+
+impl ReadyHttp {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            status: vec![],
+        }
+    }
+
+    pub fn accepts_status(&self, status: u16) -> bool {
+        if self.status.is_empty() {
+            (200..=299).contains(&status)
+        } else {
+            self.status.contains(&status)
+        }
+    }
+}
+
+impl std::fmt::Display for ReadyHttp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.status.is_empty() {
+            f.write_str(&self.url)
+        } else {
+            let status = self
+                .status
+                .iter()
+                .map(u16::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            write!(f, "{} (status: {status})", self.url)
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+#[doc(hidden)]
+pub struct ReadyHttpRaw {
+    url: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    status: Vec<u16>,
+}
+
+impl StringOrStruct for ReadyHttp {
+    type Short = String;
+    type Raw = ReadyHttpRaw;
+
+    fn from_short(url: String) -> Self {
+        Self::new(url)
+    }
+
+    fn from_raw(raw: ReadyHttpRaw) -> std::result::Result<Self, String> {
+        for status in &raw.status {
+            if !(100..=599).contains(status) {
+                return Err(format!(
+                    "ready_http status must be between 100 and 599: {status}"
+                ));
+            }
+        }
+        Ok(Self {
+            url: raw.url,
+            status: raw.status,
+        })
+    }
+
+    fn is_shorthand(&self) -> bool {
+        self.status.is_empty()
+    }
+
+    fn to_short(&self) -> String {
+        self.url.clone()
+    }
+
+    fn to_raw(&self) -> ReadyHttpRaw {
+        ReadyHttpRaw {
+            url: self.url.clone(),
+            status: self.status.clone(),
+        }
+    }
+}
+
+impl Serialize for ReadyHttp {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.string_or_struct_serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for ReadyHttp {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Self::string_or_struct_deserialize(d)
+    }
+}
+
+impl JsonSchema for ReadyHttp {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("ReadyHttp")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "HTTP readiness check: a URL string accepting any 2xx response, or { url, status } object with exact accepted status codes",
+            "oneOf": [
+                { "type": "string", "description": "HTTP URL to poll for readiness; any 2xx response is ready" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "url": { "type": "string", "description": "HTTP URL to poll for readiness" },
+                        "status": {
+                            "type": "array",
+                            "description": "Exact HTTP status codes that indicate readiness. Omit to accept any 2xx response.",
+                            "items": { "type": "integer", "minimum": 100, "maximum": 599 }
+                        }
+                    },
+                    "required": ["url"]
+                }
+            ]
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // StopSignal
 // ---------------------------------------------------------------------------
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,7 +1,7 @@
 use crate::daemon_id::DaemonId;
 use crate::daemon_status::DaemonStatus;
 use crate::pitchfork_toml::{
-    CpuLimit, CronRetrigger, Dir, MemoryLimit, PortConfig, Retry, StopConfig, WatchMode,
+    CpuLimit, CronRetrigger, Dir, MemoryLimit, PortConfig, ReadyHttp, Retry, StopConfig, WatchMode,
 };
 use indexmap::IndexMap;
 use std::fmt::Display;
@@ -86,7 +86,7 @@ pub struct Daemon {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_output: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub ready_http: Option<String>,
+    pub ready_http: Option<ReadyHttp>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -159,7 +159,7 @@ pub struct RunOptions {
     pub retry_count: u32,
     pub ready_delay: Option<u64>,
     pub ready_output: Option<String>,
-    pub ready_http: Option<String>,
+    pub ready_http: Option<ReadyHttp>,
     pub ready_port: Option<u16>,
     pub ready_cmd: Option<String>,
     pub port: Option<PortConfig>,

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -12,7 +12,6 @@ use crate::pitchfork_toml::{
 };
 
 use chrono::{DateTime, Local};
-use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -101,11 +100,7 @@ pub fn build_run_options(
     run_opts.wait_ready = true;
     run_opts.ready_delay = opts.delay.or(run_opts.ready_delay).or(Some(3));
     run_opts.ready_output = opts.output.clone().or(run_opts.ready_output);
-    run_opts.ready_http = opts
-        .http
-        .clone()
-        .map(ReadyHttp::new)
-        .or(run_opts.ready_http);
+    run_opts.ready_http = merge_ready_http_override(run_opts.ready_http, opts.http.clone());
     run_opts.ready_port = opts.port.or(run_opts.ready_port);
     run_opts.ready_cmd = opts.cmd.clone().or(run_opts.ready_cmd);
     if let Some(ref expected) = opts.expected_port {
@@ -115,6 +110,20 @@ pub fn build_run_options(
         run_opts.port.get_or_insert_with(Default::default).bump = bump;
     }
     Ok(run_opts)
+}
+
+fn merge_ready_http_override(
+    configured: Option<ReadyHttp>,
+    override_url: Option<String>,
+) -> Option<ReadyHttp> {
+    match (configured, override_url) {
+        (Some(mut ready_http), Some(url)) => {
+            ready_http.url = url;
+            Some(ready_http)
+        }
+        (None, Some(url)) => Some(ReadyHttp::new(url)),
+        (ready_http, None) => ready_http,
+    }
 }
 
 impl IpcClient {
@@ -410,14 +419,12 @@ impl IpcClient {
                 }
 
                 if let Some(adhoc_daemon) = adhoc_daemons.get(&id) {
-                    if let Some(ref cmd) = adhoc_daemon.cmd {
+                    if adhoc_daemon.cmd.is_some() {
                         let is_explicit = explicitly_requested.contains(&id);
                         let task = Self::spawn_adhoc_start_task(
                             self.clone(),
                             id,
-                            cmd.clone(),
-                            adhoc_daemon.dir.clone().unwrap_or_default(),
-                            adhoc_daemon.env.clone(),
+                            adhoc_daemon,
                             is_explicit,
                             &opts,
                         );
@@ -529,16 +536,21 @@ impl IpcClient {
     fn spawn_adhoc_start_task(
         ipc: Arc<Self>,
         id: DaemonId,
-        cmd: Vec<String>,
-        dir: PathBuf,
-        env: Option<IndexMap<String, String>>,
+        adhoc_daemon: &crate::daemon::Daemon,
         is_explicitly_requested: bool,
         opts: &StartOptions,
     ) -> tokio::task::JoinHandle<SpawnTaskResult> {
+        let cmd = adhoc_daemon
+            .cmd
+            .clone()
+            .expect("ad-hoc daemon start task requires a saved command");
+        let dir = adhoc_daemon.dir.clone().unwrap_or_default();
+        let env = adhoc_daemon.env.clone();
+        let ready_http = adhoc_daemon.ready_http.clone();
         let force = opts.force && is_explicitly_requested;
         let delay = opts.delay;
         let output = opts.output.clone();
-        let http = opts.http.clone().map(ReadyHttp::new);
+        let http = merge_ready_http_override(ready_http, opts.http.clone());
         let port = opts.port;
         let ready_cmd = opts.cmd.clone();
         let expected_port = opts.expected_port.clone();
@@ -717,7 +729,7 @@ impl IpcClient {
             retry: opts.retry.unwrap_or_default(),
             ready_delay: opts.delay.or(Some(3)),
             ready_output: opts.output,
-            ready_http: opts.http.map(ReadyHttp::new),
+            ready_http: merge_ready_http_override(None, opts.http),
             ready_port: opts.port,
             ready_cmd: opts.cmd.clone(),
             port: crate::config_types::PortConfig::from_parts(
@@ -772,6 +784,46 @@ mod tests {
     use crate::env;
 
     use super::*;
+
+    #[test]
+    fn http_override_preserves_configured_status_codes() {
+        let configured = Some(ReadyHttp {
+            url: "http://localhost:3000/original".to_string(),
+            status: vec![401],
+        });
+
+        let ready_http =
+            merge_ready_http_override(configured, Some("http://localhost:3000/health".to_string()))
+                .unwrap();
+
+        assert_eq!(ready_http.url, "http://localhost:3000/health");
+        assert_eq!(ready_http.status, vec![401]);
+        assert!(ready_http.accepts_status(401));
+        assert!(!ready_http.accepts_status(200));
+    }
+
+    #[test]
+    fn build_run_options_preserves_ready_http_status_for_cli_http_override() {
+        let id = DaemonId::try_new("project", "api").unwrap();
+        let daemon_config = PitchforkTomlDaemon {
+            run: "echo ready".to_string(),
+            ready_http: Some(ReadyHttp {
+                url: "http://localhost:3000/original".to_string(),
+                status: vec![401],
+            }),
+            ..PitchforkTomlDaemon::default()
+        };
+        let opts = StartOptions {
+            http: Some("http://localhost:3000/health".to_string()),
+            ..StartOptions::default()
+        };
+
+        let run_opts = build_run_options(&id, &daemon_config, &opts).unwrap();
+        let ready_http = run_opts.ready_http.unwrap();
+
+        assert_eq!(ready_http.url, "http://localhost:3000/health");
+        assert_eq!(ready_http.status, vec![401]);
+    }
 
     #[test]
     fn test_resolve_daemon_dir_none() {

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -8,7 +8,7 @@ use crate::daemon_id::DaemonId;
 use crate::deps::{compute_reverse_stop_order, resolve_dependencies};
 use crate::ipc::client::IpcClient;
 use crate::pitchfork_toml::{
-    PitchforkToml, PitchforkTomlDaemon, is_dot_config_pitchfork, is_global_config,
+    PitchforkToml, PitchforkTomlDaemon, ReadyHttp, is_dot_config_pitchfork, is_global_config,
 };
 
 use chrono::{DateTime, Local};
@@ -101,7 +101,11 @@ pub fn build_run_options(
     run_opts.wait_ready = true;
     run_opts.ready_delay = opts.delay.or(run_opts.ready_delay).or(Some(3));
     run_opts.ready_output = opts.output.clone().or(run_opts.ready_output);
-    run_opts.ready_http = opts.http.clone().or(run_opts.ready_http);
+    run_opts.ready_http = opts
+        .http
+        .clone()
+        .map(ReadyHttp::new)
+        .or(run_opts.ready_http);
     run_opts.ready_port = opts.port.or(run_opts.ready_port);
     run_opts.ready_cmd = opts.cmd.clone().or(run_opts.ready_cmd);
     if let Some(ref expected) = opts.expected_port {
@@ -534,7 +538,7 @@ impl IpcClient {
         let force = opts.force && is_explicitly_requested;
         let delay = opts.delay;
         let output = opts.output.clone();
-        let http = opts.http.clone();
+        let http = opts.http.clone().map(ReadyHttp::new);
         let port = opts.port;
         let ready_cmd = opts.cmd.clone();
         let expected_port = opts.expected_port.clone();
@@ -713,7 +717,7 @@ impl IpcClient {
             retry: opts.retry.unwrap_or_default(),
             ready_delay: opts.delay.or(Some(3)),
             ready_output: opts.output,
-            ready_http: opts.http,
+            ready_http: opts.http.map(ReadyHttp::new),
             ready_port: opts.port,
             ready_cmd: opts.cmd.clone(),
             port: crate::config_types::PortConfig::from_parts(

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 // Re-export config value types so existing `use crate::pitchfork_toml::X` paths keep working.
 pub use crate::config_types::{
     CpuLimit, CronRetrigger, Dir, MemoryLimit, OnOutputHook, PitchforkTomlAuto, PitchforkTomlCron,
-    PitchforkTomlHooks, PortBump, PortConfig, Retry, StopConfig, StopSignal, WatchMode,
+    PitchforkTomlHooks, PortBump, PortConfig, ReadyHttp, Retry, StopConfig, StopSignal, WatchMode,
 };
 
 /// Raw slug entry as read from TOML (uses String for dir path).
@@ -75,7 +75,7 @@ struct PitchforkTomlDaemonRaw {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_output: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub ready_http: Option<String>,
+    pub ready_http: Option<ReadyHttp>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -1153,8 +1153,8 @@ pub struct PitchforkTomlDaemon {
     pub ready_delay: Option<u64>,
     /// Regex pattern to match in ANSI-stripped stdout/stderr to determine readiness
     pub ready_output: Option<String>,
-    /// HTTP URL to poll for readiness (expects 2xx response)
-    pub ready_http: Option<String>,
+    /// HTTP URL to poll for readiness. Accepts any 2xx response by default, or configured statuses.
+    pub ready_http: Option<ReadyHttp>,
     /// TCP port to check for readiness (connection success = ready)
     #[schemars(range(min = 1, max = 65535))]
     pub ready_port: Option<u16>,

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -797,9 +797,9 @@ impl Supervisor {
                             std::future::pending::<()>().await;
                         }
                     }, if !ready_notified && ready_http.is_some() => {
-                        if let (Some(url), Some(client)) = (&ready_http, &http_client) {
-                            match client.get(url).send().await {
-                                Ok(response) if response.status().is_success() => {
+                        if let (Some(http), Some(client)) = (&ready_http, &http_client) {
+                            match client.get(&http.url).send().await {
+                                Ok(response) if http.accepts_status(response.status().as_u16()) => {
                                     info!("daemon {id} ready: HTTP check passed (status {})", response.status());
                                     ready_notified = true;
                                     let _ = log_appender.flush().await;

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -12,6 +12,7 @@ use crate::pitchfork_toml::CronRetrigger;
 use crate::pitchfork_toml::MemoryLimit;
 use crate::pitchfork_toml::PitchforkToml;
 use crate::pitchfork_toml::PortConfig;
+use crate::pitchfork_toml::ReadyHttp;
 use crate::pitchfork_toml::Retry;
 use crate::pitchfork_toml::StopConfig;
 use crate::pitchfork_toml::WatchMode;
@@ -39,7 +40,7 @@ pub(crate) struct UpsertDaemonOpts {
     pub retry_count: Option<u32>,
     pub ready_delay: Option<u64>,
     pub ready_output: Option<String>,
-    pub ready_http: Option<String>,
+    pub ready_http: Option<ReadyHttp>,
     pub ready_port: Option<u16>,
     pub ready_cmd: Option<String>,
     /// Port configuration

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4,8 +4,8 @@ use crate::daemon_id::DaemonId;
 use crate::daemon_list::DaemonListEntry;
 use crate::ipc::client::IpcClient;
 use crate::pitchfork_toml::{
-    CronRetrigger, PitchforkToml, PitchforkTomlAuto, PitchforkTomlCron, PitchforkTomlDaemon, Retry,
-    namespace_from_path,
+    CronRetrigger, PitchforkToml, PitchforkTomlAuto, PitchforkTomlCron, PitchforkTomlDaemon,
+    ReadyHttp, Retry, namespace_from_path,
 };
 use crate::procs::{PROCS, ProcessStats};
 use crate::settings::settings;
@@ -330,6 +330,8 @@ pub struct EditorState {
     pub scroll_offset: usize,
     /// Preserved config field for ready_cmd (no form UI yet)
     preserved_ready_cmd: Option<String>,
+    /// Preserved ready_http statuses (no form UI yet)
+    preserved_ready_http_status: Option<Vec<u16>>,
 }
 
 impl EditorState {
@@ -346,6 +348,7 @@ impl EditorState {
             unsaved_changes: false,
             scroll_offset: 0,
             preserved_ready_cmd: None,
+            preserved_ready_http_status: None,
         }
     }
 
@@ -364,6 +367,10 @@ impl EditorState {
             unsaved_changes: false,
             scroll_offset: 0,
             preserved_ready_cmd: config.ready_cmd.clone(),
+            preserved_ready_http_status: config
+                .ready_http
+                .as_ref()
+                .and_then(|h| (!h.status.is_empty()).then(|| h.status.clone())),
         }
     }
 
@@ -467,7 +474,9 @@ impl EditorState {
                     field.value = FormFieldValue::OptionalText(config.ready_output.clone())
                 }
                 "ready_http" => {
-                    field.value = FormFieldValue::OptionalText(config.ready_http.clone())
+                    field.value = FormFieldValue::OptionalText(
+                        config.ready_http.as_ref().map(|h| h.url.clone()),
+                    )
                 }
                 "ready_port" => field.value = FormFieldValue::OptionalPort(config.ready_port),
                 "boot_start" => field.value = FormFieldValue::OptionalBoolean(config.boot_start),
@@ -535,7 +544,12 @@ impl EditorState {
                 ("ready_output", FormFieldValue::OptionalText(s)) => {
                     config.ready_output = s.clone()
                 }
-                ("ready_http", FormFieldValue::OptionalText(s)) => config.ready_http = s.clone(),
+                ("ready_http", FormFieldValue::OptionalText(s)) => {
+                    config.ready_http = s.clone().map(|url| ReadyHttp {
+                        url,
+                        status: self.preserved_ready_http_status.clone().unwrap_or_default(),
+                    })
+                }
                 ("ready_port", FormFieldValue::OptionalPort(p)) => config.ready_port = *p,
                 ("boot_start", FormFieldValue::OptionalBoolean(b)) => config.boot_start = *b,
                 ("depends", FormFieldValue::StringList(v)) => {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1657,7 +1657,7 @@ fn draw_details_overlay(f: &mut Frame, app: &App) {
         if let Some(http) = &cfg.ready_http {
             lines.push(Line::from(vec![
                 Span::styled("Ready HTTP: ", Style::default().fg(GRAY)),
-                Span::styled(http.clone(), Style::default().fg(Color::White)),
+                Span::styled(http.to_string(), Style::default().fg(Color::White)),
             ]));
         }
 

--- a/src/web/routes/daemons.rs
+++ b/src/web/routes/daemons.rs
@@ -361,7 +361,12 @@ pub async fn show(Path(id): Path<String>) -> Html<String> {
                     .map(|d| format!("{d}s"))
                     .unwrap_or_else(|| "-".into()),
                 html_escape(cfg.ready_output.as_deref().unwrap_or("-")),
-                html_escape(cfg.ready_http.as_deref().unwrap_or("-")),
+                html_escape(
+                    &cfg.ready_http
+                        .as_ref()
+                        .map(|h| h.to_string())
+                        .unwrap_or_else(|| "-".into()),
+                ),
             )
         } else {
             String::new()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -38,6 +38,7 @@ impl TestEnv {
         // Create state and logs directories
         let state_dir = home_dir.join(".local").join("state").join("pitchfork");
         fs::create_dir_all(&state_dir).unwrap();
+        fs::create_dir_all(home_dir.join(".config")).unwrap();
 
         Self {
             temp_dir,
@@ -87,6 +88,8 @@ impl TestEnv {
         cmd.args(args)
             .current_dir(self.project_dir())
             .env("HOME", &self.home_dir)
+            .env("XDG_CONFIG_HOME", self.home_dir.join(".config"))
+            .env("XDG_STATE_HOME", self.home_dir.join(".local").join("state"))
             .env("PITCHFORK_LOG", "debug")
             // Set fast watcher refresh/poll intervals for tests
             .env("PITCHFORK_WATCH_INTERVAL", "100ms")
@@ -108,6 +111,8 @@ impl TestEnv {
             .args(args)
             .current_dir(self.project_dir())
             .env("HOME", &self.home_dir)
+            .env("XDG_CONFIG_HOME", self.home_dir.join(".config"))
+            .env("XDG_STATE_HOME", self.home_dir.join(".local").join("state"))
             .env("PITCHFORK_LOG", "debug")
             // Set fast watcher refresh/poll intervals for tests
             .env("PITCHFORK_WATCH_INTERVAL", "100ms")
@@ -221,6 +226,8 @@ impl TestEnv {
         cmd.args(args)
             .current_dir(dir)
             .env("HOME", &self.home_dir)
+            .env("XDG_CONFIG_HOME", self.home_dir.join(".config"))
+            .env("XDG_STATE_HOME", self.home_dir.join(".local").join("state"))
             .env("PITCHFORK_LOG", "debug")
             // Set fast watcher refresh/poll intervals for tests
             .env("PITCHFORK_WATCH_INTERVAL", "100ms")
@@ -391,6 +398,8 @@ impl TestEnv {
             match Command::new(&self.pitchfork_bin)
                 .args(["supervisor", "stop"])
                 .env("HOME", &self.home_dir)
+                .env("XDG_CONFIG_HOME", self.home_dir.join(".config"))
+                .env("XDG_STATE_HOME", self.home_dir.join(".local").join("state"))
                 .stdout(Stdio::null())
                 .stderr(Stdio::piped())
                 .output()

--- a/tests/scripts/http_server.ts
+++ b/tests/scripts/http_server.ts
@@ -1,9 +1,10 @@
 // Simple HTTP server that delays start by specified seconds
-// Usage: bun run http_server.ts <delay_seconds> <port>
+// Usage: bun run http_server.ts <delay_seconds> <port> [health_status]
 
 const args = process.argv.slice(2);
 const delaySeconds = parseInt(args[0] || "1", 10);
 const port = parseInt(args[1] || "18080", 10);
+const healthStatus = parseInt(args[2] || "200", 10);
 
 console.log(`Waiting ${delaySeconds}s before starting server...`);
 
@@ -15,7 +16,7 @@ setTimeout(async () => {
     fetch(req) {
       const url = new URL(req.url);
       if (url.pathname === "/health") {
-        return new Response("OK", { status: 200 });
+        return new Response("OK", { status: healthStatus });
       }
       return new Response("Not Found", { status: 404 });
     },

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -823,6 +823,46 @@ ready_http = "http://localhost:18081/health"
 }
 
 #[test]
+fn test_ready_http_check_with_status() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    #[cfg(unix)]
+    env.kill_port(18084);
+
+    let script = get_script_path("http_server.ts");
+    let toml_content = format!(
+        r#"
+[daemons.http_status_test]
+run = "bun run {} 1 18084 401"
+ready_http = {{ url = "http://localhost:18084/health", status = [401] }}
+"#,
+        script.display()
+    );
+    env.create_toml(&toml_content);
+
+    let start_time = std::time::Instant::now();
+    let output = env.run_command(&["start", "http_status_test"]);
+    let elapsed = start_time.elapsed();
+
+    println!("Start took: {elapsed:?}");
+    println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+    println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "Start command should succeed");
+    assert!(
+        elapsed >= Duration::from_secs(1),
+        "Should wait for HTTP server to be ready"
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "Should not take too long to detect ready state"
+    );
+
+    env.run_command(&["stop", "http_status_test"]);
+}
+
+#[test]
 fn test_ready_port_check() {
     let env = TestEnv::new();
     env.ensure_binary_exists().unwrap();

--- a/tests/test_pitchfork_toml.rs
+++ b/tests/test_pitchfork_toml.rs
@@ -182,13 +182,62 @@ ready_cmd = "test -f /tmp/ready"
     assert_eq!(daemon.ready_delay, Some(5000));
     assert_eq!(daemon.ready_output, Some("Server is ready".to_string()));
     assert_eq!(
-        daemon.ready_http,
-        Some("http://localhost:8080/health".to_string())
+        daemon.ready_http.as_ref().unwrap().url,
+        "http://localhost:8080/health"
     );
+    assert!(daemon.ready_http.as_ref().unwrap().status.is_empty());
     assert_eq!(daemon.ready_port, Some(8080));
     assert_eq!(daemon.ready_cmd, Some("test -f /tmp/ready".to_string()));
 
     Ok(())
+}
+
+/// Test daemon with structured HTTP ready check
+#[test]
+fn test_daemon_with_ready_http_status() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.ready_daemon]
+run = "echo 'server starting'"
+ready_http = { url = "http://localhost:8080/health", status = [200, 401] }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "ready_daemon").unwrap();
+    let ready_http = daemon.ready_http.as_ref().unwrap();
+
+    assert_eq!(ready_http.url, "http://localhost:8080/health");
+    assert_eq!(ready_http.status, vec![200, 401]);
+    assert!(ready_http.accepts_status(401));
+    assert!(!ready_http.accepts_status(403));
+
+    Ok(())
+}
+
+/// Test daemon with invalid HTTP status ready check
+#[test]
+fn test_daemon_with_invalid_ready_http_status() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.ready_daemon]
+run = "echo 'server starting'"
+ready_http = { url = "http://localhost:8080/health", status = [99] }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
+    let err = format!("{err:?}");
+    assert!(
+        err.contains("ready_http status must be between 100 and 599"),
+        "unexpected error: {err}"
+    );
 }
 
 /// Test multiple daemons in one file


### PR DESCRIPTION
## Summary
- add a structured ready_http form that preserves the existing URL string shorthand
- allow exact accepted HTTP status codes, e.g. `ready_http = { url = "http://localhost:3000/health", status = [200, 401] }`
- update docs, generated JSON schema, and readiness tests
- isolate e2e test XDG config/state paths so tests do not connect to a live local supervisor

## Validation
- `mise x rust@stable -- cargo check`
- `mise x rust@stable -- cargo test --test test_pitchfork_toml`
- `mise x rust@stable bun@latest -- cargo test --test test_e2e ready_http -- --nocapture`

*This PR was generated with AI assistance.*