### PR TITLE
docs: clarify web settings scope

### DIFF
--- a/docs/guides/web-ui.md
+++ b/docs/guides/web-ui.md
@@ -18,7 +18,13 @@ PITCHFORK_WEB_PORT=3120 pitchfork supervisor start --force
 
 ### Persistent via settings
 
-Add to your `pitchfork.toml` or `~/.config/pitchfork/config.toml`:
+Because the web UI is owned by the supervisor process, persistent web UI
+settings should live in global config (`~/.config/pitchfork/config.toml` or
+`/etc/pitchfork/config.toml`). Project-level `[settings.web]` values only apply
+when the supervisor is started from that project directory and do not
+reconfigure an already-running supervisor.
+
+Add to your global config:
 
 ```toml
 [settings.web]
@@ -53,7 +59,7 @@ pitchfork supervisor run --web-port 3120 --web-path ps
 # Web UI available at http://127.0.0.1:3120/ps/
 ```
 
-Or via settings:
+Or via global settings:
 
 ```toml
 [settings.web]

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -9,6 +9,13 @@ This page documents all configurable settings for pitchfork. Settings can be con
 
 Settings are merged in precedence order, with later sources overriding earlier ones.
 
+Settings for supervisor-owned services, such as `[settings.web]` and
+`[settings.proxy]`, are resolved when the supervisor process starts. Put
+persistent values for those services in global config or set them with
+environment variables/CLI flags for that supervisor invocation. Project-level
+values only apply when the supervisor is started from that project directory and
+do not reconfigure an already-running supervisor.
+
 ## Configuration in pitchfork.toml
 
 Add a `[settings]` section to any `pitchfork.toml` file:
@@ -22,11 +29,6 @@ run = "node server.js"
 [settings.general]
 autostop_delay = "5m"
 log_level = "debug"
-
-[settings.web]
-auto_start = true
-bind_address = "0.0.0.0"
-bind_port = 8080
 
 [settings.tui]
 refresh_rate = "1s"


### PR DESCRIPTION
I spent a while troubleshooting why the web ui wasn't working, only to realize this setting doesn't work in project configs. Here I update the docs to clarify this should go in a user config.