### PR TITLE
chore: release v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0](https://github.com/endevco/pitchfork/compare/v2.11.0...v2.12.0) - 2026-05-27
+
+### Added
+
+- *(proxy)* support worktree ([#448](https://github.com/endevco/pitchfork/pull/448))
+- *(cli)* stream output on CLI command start ([#444](https://github.com/endevco/pitchfork/pull/444))
+
+### Fixed
+
+- *(web)* close web log SSE streams on navigation ([#447](https://github.com/endevco/pitchfork/pull/447))
+
+### Other
+
+- avoid state file frequently write to disk ([#446](https://github.com/endevco/pitchfork/pull/446))
+
 ## [2.11.0](https://github.com/endevco/pitchfork/compare/v2.10.0...v2.11.0) - 2026-05-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,7 +2760,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.11.0"
+version = "2.12.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.11.0"
+version = "2.12.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.en.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2257,7 +2257,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.11.0",
+  "version": "2.12.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.11.0
+**Version**: 2.12.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.11.0"
+version "2.12.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.11.0 -> 2.12.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.12.0](https://github.com/endevco/pitchfork/compare/v2.11.0...v2.12.0) - 2026-05-27

### Added

- *(proxy)* support worktree ([#448](https://github.com/endevco/pitchfork/pull/448))
- *(cli)* stream output on CLI command start ([#444](https://github.com/endevco/pitchfork/pull/444))

### Fixed

- *(web)* close web log SSE streams on navigation ([#447](https://github.com/endevco/pitchfork/pull/447))

### Other

- avoid state file frequently write to disk ([#446](https://github.com/endevco/pitchfork/pull/446))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).