### PR TITLE
fix(web): close web log SSE streams on navigation

### DIFF
--- a/src/web/assets/logs.js
+++ b/src/web/assets/logs.js
@@ -28,4 +28,15 @@
       closeLogSources();
     }
   });
+
+  window.addEventListener("pageshow", function (evt) {
+    if (evt.persisted) {
+      logSources.forEach(function (source) {
+        if (source.readyState !== EventSource.OPEN) {
+          source.close();
+          logSources.delete(source);
+        }
+      });
+    }
+  });
 })();

--- a/src/web/assets/logs.js
+++ b/src/web/assets/logs.js
@@ -2,7 +2,7 @@
   const logSources = new Set();
 
   window.pitchforkLogEventSource = function (url) {
-    const source = new EventSource(url, { withCredentials: true });
+    const source = new EventSource(url);
     logSources.add(source);
     source.addEventListener("error", function () {
       if (source.readyState === EventSource.CLOSED) {
@@ -23,16 +23,9 @@
     logSources.clear();
   }
 
-  window.addEventListener("pagehide", closeLogSources);
-  window.addEventListener("beforeunload", closeLogSources);
-  document.addEventListener(
-    "click",
-    function (evt) {
-      const link = evt.target.closest && evt.target.closest("a[href]");
-      if (link && link.target !== "_blank") {
-        closeLogSources();
-      }
-    },
-    true,
-  );
+  window.addEventListener("pagehide", function (evt) {
+    if (!evt.persisted) {
+      closeLogSources();
+    }
+  });
 })();

--- a/src/web/assets/logs.js
+++ b/src/web/assets/logs.js
@@ -1,0 +1,38 @@
+(function () {
+  const logSources = new Set();
+
+  window.pitchforkLogEventSource = function (url) {
+    const source = new EventSource(url, { withCredentials: true });
+    logSources.add(source);
+    source.addEventListener("error", function () {
+      if (source.readyState === EventSource.CLOSED) {
+        logSources.delete(source);
+      }
+    });
+    return source;
+  };
+
+  if (window.htmx) {
+    htmx.createEventSource = window.pitchforkLogEventSource;
+  }
+
+  function closeLogSources() {
+    logSources.forEach(function (source) {
+      source.close();
+    });
+    logSources.clear();
+  }
+
+  window.addEventListener("pagehide", closeLogSources);
+  window.addEventListener("beforeunload", closeLogSources);
+  document.addEventListener(
+    "click",
+    function (evt) {
+      const link = evt.target.closest && evt.target.closest("a[href]");
+      if (link && link.target !== "_blank") {
+        closeLogSources();
+      }
+    },
+    true,
+  );
+})();

--- a/src/web/routes/logs.rs
+++ b/src/web/routes/logs.rs
@@ -32,42 +32,7 @@ fn base_html(title: &str, content: &str) -> String {
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     <script src="https://unpkg.com/htmx-ext-sse@2.2.2/sse.js"></script>
     <script src="https://unpkg.com/lucide@0.474.0"></script>
-    <script>
-        (function() {{
-            const logSources = new Set();
-
-            window.pitchforkLogEventSource = function(url) {{
-                const source = new EventSource(url, {{ withCredentials: true }});
-                logSources.add(source);
-                source.addEventListener('error', function() {{
-                    if (source.readyState === EventSource.CLOSED) {{
-                        logSources.delete(source);
-                    }}
-                }});
-                return source;
-            }};
-
-            if (window.htmx) {{
-                htmx.createEventSource = window.pitchforkLogEventSource;
-            }}
-
-            function closeLogSources() {{
-                logSources.forEach(function(source) {{
-                    source.close();
-                }});
-                logSources.clear();
-            }}
-
-            window.addEventListener('pagehide', closeLogSources);
-            window.addEventListener('beforeunload', closeLogSources);
-            document.addEventListener('click', function(evt) {{
-                const link = evt.target.closest && evt.target.closest('a[href]');
-                if (link && link.target !== '_blank') {{
-                    closeLogSources();
-                }}
-            }}, true);
-        }})();
-    </script>
+    <script src="{bp}/static/logs.js"></script>
     <link rel="stylesheet" href="{bp}/static/style.css">
 </head>
 <body>

--- a/src/web/routes/logs.rs
+++ b/src/web/routes/logs.rs
@@ -32,6 +32,42 @@ fn base_html(title: &str, content: &str) -> String {
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     <script src="https://unpkg.com/htmx-ext-sse@2.2.2/sse.js"></script>
     <script src="https://unpkg.com/lucide@0.474.0"></script>
+    <script>
+        (function() {{
+            const logSources = new Set();
+
+            window.pitchforkLogEventSource = function(url) {{
+                const source = new EventSource(url, {{ withCredentials: true }});
+                logSources.add(source);
+                source.addEventListener('error', function() {{
+                    if (source.readyState === EventSource.CLOSED) {{
+                        logSources.delete(source);
+                    }}
+                }});
+                return source;
+            }};
+
+            if (window.htmx) {{
+                htmx.createEventSource = window.pitchforkLogEventSource;
+            }}
+
+            function closeLogSources() {{
+                logSources.forEach(function(source) {{
+                    source.close();
+                }});
+                logSources.clear();
+            }}
+
+            window.addEventListener('pagehide', closeLogSources);
+            window.addEventListener('beforeunload', closeLogSources);
+            document.addEventListener('click', function(evt) {{
+                const link = evt.target.closest && evt.target.closest('a[href]');
+                if (link && link.target !== '_blank') {{
+                    closeLogSources();
+                }}
+            }}, true);
+        }})();
+    </script>
     <link rel="stylesheet" href="{bp}/static/style.css">
 </head>
 <body>
@@ -224,7 +260,7 @@ pub async fn index() -> Html<String> {
                     let url_id = url_encode(id);
                     format!(
                         r#"
-                var clearSource_{idx} = new EventSource('{bp}/logs/{url_id}/stream');
+                var clearSource_{idx} = window.pitchforkLogEventSource('{bp}/logs/{url_id}/stream');
                 clearSource_{idx}.addEventListener('clear', function(e) {{
                     document.getElementById('log-output-' + '{js_id}').textContent = '';
                 }});
@@ -294,7 +330,7 @@ pub async fn show(Path(id): Path<String>) -> Html<String> {
             // Auto-scroll to bottom on load
             document.getElementById('log-output').scrollTop = document.getElementById('log-output').scrollHeight;
             // Listen for clear event using native EventSource (htmx-ext-sse only handles 'message' events)
-            var clearSource = new EventSource('{bp}/logs/{url_id}/stream');
+            var clearSource = window.pitchforkLogEventSource('{bp}/logs/{url_id}/stream');
             clearSource.addEventListener('clear', function(e) {{
                 document.getElementById('log-output').textContent = '';
             }});


### PR DESCRIPTION
## Summary

Bug: the web UI gets stuck when navigating away from the Logs page while logs are streaming.

Here we fix it by tracking logs page EventSource instances and closing tracked streams on pagehide.

## Verification

Manual browser test with a daemon continuously writing logs:

1. Open /logs
2. Confirm logs stream
3. Navigate to Dashboard (previously, this navigation would block)
4. Confirm navigation completes immediately
5. Navigate back to Logs
6. Confirm streaming resumes