### PR TITLE
fix(proxy): downgrade forwarded requests to HTTP/1.1

### DIFF
--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -1204,6 +1204,12 @@ async fn proxy_handler(State(state): State<ProxyState>, mut req: Request) -> Res
         req.headers_mut().remove(&key);
     }
 
+    // Downgrade the forwarded request to HTTP/1.1. TLS connections negotiate
+    // HTTP/2 inbound via ALPN, but the upstream forward client speaks HTTP/1 to
+    // the daemon. Without this, the still-h2-tagged request is rejected by the
+    // client with `UserUnsupportedVersion`, surfacing as a 502 to the browser.
+    *req.version_mut() = axum::http::Version::HTTP_11;
+
     // Extract the client-side OnUpgrade handle *before* consuming req
     let client_upgrade = hyper::upgrade::on(&mut req);
 


### PR DESCRIPTION
Over TLS the proxy advertises `h2` via ALPN (added in v2.10.0), so browsers connect with HTTP/2. `proxy_handler` strips the HTTP/2 pseudo-headers but forwards the request still tagged `HTTP/2` to the upstream forward client, which connects to daemons over cleartext and is not HTTP/2-capable. The client rejects it with `UserUnsupportedVersion`, so every HTTP/1.1 backend (e.g. a Vite dev server) returns 502 through the HTTPS proxy.

Normalize the forwarded request to HTTP/1.1 before sending it upstream.

Repro with `proxy.https = true`:
- `curl https://<slug>.localhost/` → 502
- `curl --http1.1 https://<slug>.localhost/` → 200

*This PR was created with Claude Code.*