### PR TITLE
chore: release v2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.0](https://github.com/endevco/pitchfork/compare/v2.12.1...v2.13.0) - 2026-06-07
+
+### Added
+
+- *(cli)* rename `pf config` to `pf daemons` and add `pf settings` subcommand ([#471](https://github.com/endevco/pitchfork/pull/471))
+- *(logs)* add log rotate ([#470](https://github.com/endevco/pitchfork/pull/470))
+- *(list)* always display fully-qualified daemon names ([#467](https://github.com/endevco/pitchfork/pull/467))
+- *(cron)* add `immediate` config to control the behaviour on start ([#461](https://github.com/endevco/pitchfork/pull/461))
+- add sponsors command ([#458](https://github.com/endevco/pitchfork/pull/458))
+
+### Other
+
+- *(web-ui)* refactor with Vue SPA + separate API endpoints ([#457](https://github.com/endevco/pitchfork/pull/457))
+
 ## [2.12.1](https://github.com/endevco/pitchfork/compare/v2.12.0...v2.12.1) - 2026-05-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,7 +2792,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.12.1"
+version = "2.13.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.12.1"
+version = "2.13.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.en.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2527,7 +2527,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.12.1",
+  "version": "2.13.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.12.1
+**Version**: 2.13.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.12.1"
+version "2.13.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.12.1 -> 2.13.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.13.0](https://github.com/endevco/pitchfork/compare/v2.12.1...v2.13.0) - 2026-06-07

### Added

- *(cli)* rename `pf config` to `pf daemons` and add `pf settings` subcommand ([#471](https://github.com/endevco/pitchfork/pull/471))
- *(logs)* add log rotate ([#470](https://github.com/endevco/pitchfork/pull/470))
- *(list)* always display fully-qualified daemon names ([#467](https://github.com/endevco/pitchfork/pull/467))
- *(cron)* add `immediate` config to control the behaviour on start ([#461](https://github.com/endevco/pitchfork/pull/461))
- add sponsors command ([#458](https://github.com/endevco/pitchfork/pull/458))

### Other

- *(web-ui)* refactor with Vue SPA + separate API endpoints ([#457](https://github.com/endevco/pitchfork/pull/457))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).