### PR TITLE
feat(cron): add `immediate` config to control the behaviour on start

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -612,6 +612,18 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "cron-immediate",
+                "usage": "--cron-immediate",
+                "help": "Trigger cron immediately on first check (default: false)",
+                "help_first_line": "Trigger cron immediately on first check (default: false)",
+                "short": [],
+                "long": [
+                  "cron-immediate"
+                ],
+                "hide": false,
+                "global": false
               }
             ],
             "mounts": [],

--- a/docs/cli/config/add.md
+++ b/docs/cli/config/add.md
@@ -129,3 +129,7 @@ Cron schedule expression (6 fields: second minute hour day month weekday)
 ### `--cron-retrigger <CRON_RETRIGGER>`
 
 Cron retrigger behavior: finish, always, success, fail
+
+### `--cron-immediate`
+
+Trigger cron immediately on first check (default: false)

--- a/docs/guides/scheduling.md
+++ b/docs/guides/scheduling.md
@@ -40,6 +40,16 @@ Uses standard 6-field cron format:
 - `0 0 0 * * 0` - Weekly on Sunday at midnight
 - `0 30 9 * * 1-5` - Weekdays at 9:30 AM
 
+## First Trigger on Start
+
+By default, a cron daemon does **not** execute immediately when you run `pitchfork start`. It waits for the next scheduled time. If you want a scheduled time within the last 10 seconds before startup to also trigger the daemon, set `immediate = true`:
+
+```toml
+[daemons.backup]
+run = "./backup.sh"
+cron = { schedule = "0 0 2 * * *", immediate = true }
+```
+
 ## Retrigger Modes
 
 Control what happens when the schedule triggers while the previous run is still active:

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -120,7 +120,7 @@
       ]
     },
     "PitchforkTomlCron": {
-      "description": "Cron scheduling: a cron expression string, or { schedule, retrigger } object",
+      "description": "Cron scheduling: a cron expression string, or { schedule, retrigger, immediate } object",
       "oneOf": [
         {
           "description": "Cron expression (e.g. '0 * * * *')",
@@ -129,6 +129,10 @@
         {
           "type": "object",
           "properties": {
+            "immediate": {
+              "description": "Trigger immediately on first check (default: false)",
+              "type": "boolean"
+            },
             "retrigger": {
               "$ref": "#/$defs/CronRetrigger"
             },

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -465,6 +465,7 @@ cron = { schedule = "0 0 2 * * *", retrigger = "always" }
 **Fields:**
 - `schedule` - Cron expression (6 fields: second, minute, hour, day, month, weekday)
 - `retrigger` - Behavior when schedule fires: `"finish"` (default), `"always"`, `"success"`, `"fail"`
+- `immediate` - Also fire if a scheduled time occurred within the 10 seconds before the daemon started. Default: `false`
 
 ### `mise`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -97,6 +97,7 @@ cmd config help="manage/edit pitchfork.toml files" {
         flag --cron-retrigger help="Cron retrigger behavior: finish, always, success, fail" {
             arg <CRON_RETRIGGER>
         }
+        flag --cron-immediate help="Trigger cron immediately on first check (default: false)"
         arg <ID> help="ID of the daemon to add (e.g., \"api\" or \"namespace/api\")"
         arg "[ARGS]…" help="Arguments to pass to the daemon (alternative to --run)" required=#false double_dash=automatic var=#true
     }

--- a/src/cli/config/add.rs
+++ b/src/cli/config/add.rs
@@ -120,6 +120,9 @@ pub struct Add {
     /// Cron retrigger behavior: finish, always, success, fail
     #[clap(long)]
     cron_retrigger: Option<String>,
+    /// Trigger cron immediately on first check (default: false)
+    #[clap(long)]
+    cron_immediate: bool,
 }
 
 impl Add {
@@ -217,6 +220,7 @@ impl Add {
             Some(PitchforkTomlCron {
                 schedule: schedule.clone(),
                 retrigger,
+                immediate: self.cron_immediate,
             })
         } else {
             None

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -628,6 +628,9 @@ pub struct PitchforkTomlCron {
     pub schedule: String,
     /// Behavior when cron triggers while previous run is still active
     pub retrigger: CronRetrigger,
+    /// Whether to trigger immediately on first check when no prior trigger is recorded.
+    /// When false (default), the first trigger is deferred until the next scheduled time.
+    pub immediate: bool,
 }
 
 impl JsonSchema for PitchforkTomlCron {
@@ -637,14 +640,15 @@ impl JsonSchema for PitchforkTomlCron {
 
     fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
         schemars::json_schema!({
-            "description": "Cron scheduling: a cron expression string, or { schedule, retrigger } object",
+            "description": "Cron scheduling: a cron expression string, or { schedule, retrigger, immediate } object",
             "oneOf": [
                 { "type": "string", "description": "Cron expression (e.g. '0 * * * *')" },
                 {
                     "type": "object",
                     "properties": {
                         "schedule": { "type": "string", "description": "Cron expression" },
-                        "retrigger": generator.subschema_for::<CronRetrigger>()
+                        "retrigger": generator.subschema_for::<CronRetrigger>(),
+                        "immediate": { "type": "boolean", "description": "Trigger immediately on first check (default: false)" }
                     },
                     "required": ["schedule"]
                 }
@@ -659,6 +663,8 @@ pub struct PitchforkTomlCronRaw {
     schedule: String,
     #[serde(default)]
     retrigger: CronRetrigger,
+    #[serde(default)]
+    immediate: bool,
 }
 
 impl StringOrStruct for PitchforkTomlCron {
@@ -669,6 +675,7 @@ impl StringOrStruct for PitchforkTomlCron {
         Self {
             schedule,
             retrigger: CronRetrigger::default(),
+            immediate: false,
         }
     }
 
@@ -676,11 +683,12 @@ impl StringOrStruct for PitchforkTomlCron {
         Ok(Self {
             schedule: raw.schedule,
             retrigger: raw.retrigger,
+            immediate: raw.immediate,
         })
     }
 
     fn is_shorthand(&self) -> bool {
-        self.retrigger == CronRetrigger::default()
+        self.retrigger == CronRetrigger::default() && !self.immediate
     }
 
     fn to_short(&self) -> String {
@@ -691,6 +699,7 @@ impl StringOrStruct for PitchforkTomlCron {
         PitchforkTomlCronRaw {
             schedule: self.schedule.clone(),
             retrigger: self.retrigger,
+            immediate: self.immediate,
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -74,6 +74,8 @@ pub struct Daemon {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cron_retrigger: Option<CronRetrigger>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cron_immediate: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub last_cron_triggered: Option<chrono::DateTime<chrono::Local>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub last_exit_success: Option<bool>,
@@ -155,6 +157,7 @@ pub struct RunOptions {
     pub autostop: bool,
     pub cron_schedule: Option<String>,
     pub cron_retrigger: Option<CronRetrigger>,
+    pub cron_immediate: Option<bool>,
     pub retry: Retry,
     pub retry_count: u32,
     pub ready_delay: Option<u64>,
@@ -237,6 +240,7 @@ impl Daemon {
             autostop: self.autostop,
             cron_schedule: self.cron_schedule.clone(),
             cron_retrigger: self.cron_retrigger,
+            cron_immediate: self.cron_immediate,
             retry: self.retry,
             retry_count: self.retry_count,
             ready_delay: self.ready_delay,

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -1378,6 +1378,7 @@ impl PitchforkTomlDaemon {
             autostop: self.auto.contains(&PitchforkTomlAuto::Stop),
             cron_schedule: self.cron.as_ref().map(|c| c.schedule.clone()),
             cron_retrigger: self.cron.as_ref().map(|c| c.retrigger),
+            cron_immediate: self.cron.as_ref().map(|c| c.immediate),
             retry: self.retry,
             retry_count: 0,
             ready_delay: self.ready_delay,

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -425,6 +425,7 @@ impl Supervisor {
                         o.autostop = opts.autostop;
                         o.cron_schedule = opts.cron_schedule.clone();
                         o.cron_retrigger = opts.cron_retrigger;
+                        o.cron_immediate = opts.cron_immediate;
                         o.retry = Some(opts.retry);
                         o.retry_count = Some(opts.retry_count);
                         o.ready_delay = opts.ready_delay;

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -35,6 +35,7 @@ pub(crate) struct UpsertDaemonOpts {
     pub autostop: bool,
     pub cron_schedule: Option<String>,
     pub cron_retrigger: Option<CronRetrigger>,
+    pub cron_immediate: Option<bool>,
     pub last_exit_success: Option<bool>,
     pub retry: Option<Retry>,
     pub retry_count: Option<u32>,
@@ -138,6 +139,9 @@ impl Supervisor {
             cron_retrigger: opts
                 .cron_retrigger
                 .or(existing.and_then(|d| d.cron_retrigger)),
+            cron_immediate: opts
+                .cron_immediate
+                .or(existing.and_then(|d| d.cron_immediate)),
             last_cron_triggered: existing.and_then(|d| d.last_cron_triggered),
             last_exit_success: opts
                 .last_exit_success

--- a/src/supervisor/watchers.rs
+++ b/src/supervisor/watchers.rs
@@ -363,10 +363,30 @@ impl Supervisor {
                 };
 
                 // Check if we should trigger: look for a scheduled time that has passed
-                // since our last trigger (or last 10 seconds if never triggered)
-                let check_since = daemon
-                    .last_cron_triggered
-                    .unwrap_or_else(|| now - chrono::Duration::seconds(10));
+                // since our last trigger.
+                let check_since = match daemon.last_cron_triggered {
+                    Some(t) => t,
+                    None => {
+                        if daemon.cron_immediate.unwrap_or(false) {
+                            // immediate=true: restore the old look-back behavior.
+                            // A scheduled time within the last 10 seconds before startup
+                            // will trigger immediately.
+                            now - chrono::Duration::seconds(10)
+                        } else {
+                            // immediate=false (default): anchor last_cron_triggered to now
+                            // so the next scheduled time is picked up, without firing now.
+                            let mut state_file = self.state_file.lock().await;
+                            if state_file.set_last_cron_triggered(&id, now) {
+                                if let Err(e) = state_file.write() {
+                                    error!(
+                                        "failed to persist last_cron_triggered for daemon {id}: {e}"
+                                    );
+                                }
+                            }
+                            continue;
+                        }
+                    }
+                };
 
                 // Find if there's a scheduled time between check_since and now
                 let should_trigger = schedule

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -448,6 +448,11 @@ impl EditorState {
                 "Cron Retrigger",
                 "Behavior when cron triggers while previous run is active.",
             ),
+            FormField::optional_bool(
+                "cron_immediate",
+                "Cron Immediate",
+                "Trigger immediately on first check (default: false).",
+            ),
         ]
     }
 
@@ -504,6 +509,10 @@ impl EditorState {
                             .unwrap_or(CronRetrigger::Finish),
                     );
                 }
+                "cron_immediate" => {
+                    field.value =
+                        FormFieldValue::OptionalBoolean(config.cron.as_ref().map(|c| c.immediate));
+                }
                 _ => {}
             }
         }
@@ -520,6 +529,7 @@ impl EditorState {
 
         let mut cron_schedule: Option<String> = None;
         let mut cron_retrigger = CronRetrigger::Finish;
+        let mut cron_immediate = false;
 
         for field in &self.fields {
             match (field.name, &field.value) {
@@ -558,6 +568,9 @@ impl EditorState {
                 ("watch", FormFieldValue::StringList(v)) => config.watch = v.clone(),
                 ("cron_schedule", FormFieldValue::OptionalText(s)) => cron_schedule = s.clone(),
                 ("cron_retrigger", FormFieldValue::Retrigger(r)) => cron_retrigger = *r,
+                ("cron_immediate", FormFieldValue::OptionalBoolean(b)) => {
+                    cron_immediate = b.unwrap_or(false);
+                }
                 _ => {}
             }
         }
@@ -566,6 +579,7 @@ impl EditorState {
             config.cron = Some(PitchforkTomlCron {
                 schedule,
                 retrigger: cron_retrigger,
+                immediate: cron_immediate,
             });
         }
 

--- a/tests/test_pitchfork_toml.rs
+++ b/tests/test_pitchfork_toml.rs
@@ -154,6 +154,36 @@ retrigger = "always"
     let cron = daemon.cron.as_ref().unwrap();
     assert_eq!(cron.schedule, "0 0 * * *");
     assert_eq!(cron.retrigger, pitchfork_toml::CronRetrigger::Always);
+    assert!(!cron.immediate);
+
+    Ok(())
+}
+
+/// Test daemon with cron.immediate = true
+#[test]
+fn test_daemon_with_cron_immediate() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.cron_daemon]
+run = "echo 'cron job'"
+
+[daemons.cron_daemon.cron]
+schedule = "0 0 * * *"
+immediate = true
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "cron_daemon").unwrap();
+
+    assert!(daemon.cron.is_some());
+    let cron = daemon.cron.as_ref().unwrap();
+    assert_eq!(cron.schedule, "0 0 * * *");
+    assert_eq!(cron.retrigger, pitchfork_toml::CronRetrigger::Finish);
+    assert!(cron.immediate);
 
     Ok(())
 }


### PR DESCRIPTION
fixes #460 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--cron-immediate` flag and `cron.immediate` configuration option to trigger scheduled cron jobs immediately on daemon startup if scheduled within the last 10 seconds (defaults to `false`)

* **Documentation**
  * Updated CLI command specs, configuration reference, scheduling guide, and JSON schema documentation

* **Tests**
  * Added unit tests for the new cron immediate configuration option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->