### PR TITLE
feat(list): always display fully-qualified daemon names

### DIFF
--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,5 +1,4 @@
 use crate::Result;
-use crate::daemon_id::DaemonId;
 use crate::daemon_list::get_all_daemons;
 use crate::daemon_status::DaemonStatus;
 use crate::ipc::client::IpcClient;
@@ -60,11 +59,8 @@ impl List {
         let entries = get_all_daemons(&client).await?;
         let global_slugs = PitchforkToml::read_global_slugs();
 
-        // Collect all IDs for display name resolution (clone to avoid borrow issues)
-        let all_ids: Vec<DaemonId> = entries.iter().map(|e| e.id.clone()).collect();
-
         for entry in entries {
-            let display_name = entry.id.styled_display_name(Some(all_ids.iter()));
+            let display_name = entry.id.styled_qualified();
 
             let status_text = if entry.is_available {
                 "available".to_string()

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -395,10 +395,46 @@ impl PitchforkToml {
             .collect();
 
         if matches.is_empty() {
-            // No config matches. Validate short ID format and return no matches.
+            // No config matches. Search state file for any daemon with matching short name.
+            let state_matches = Self::find_in_state_file(user_id);
+            match state_matches.as_slice() {
+                [] => {}
+                [id] => return Ok(vec![id.clone()]),
+                _ => {
+                    let mut candidates: Vec<String> =
+                        state_matches.iter().map(|id| id.qualified()).collect();
+                    candidates.sort();
+                    return Err(miette::miette!(
+                        "daemon '{}' is ambiguous; matches: {}. Use a qualified daemon ID (namespace/name)",
+                        user_id,
+                        candidates.join(", ")
+                    ));
+                }
+            }
+            // No config or state matches. Validate short ID format and return no matches.
             let _ = DaemonId::try_new("global", user_id)?;
         }
         Ok(matches)
+    }
+
+    /// Finds all daemons in the persisted state file whose short name matches `short_name`.
+    ///
+    /// Logs a warning if the state file exists but cannot be read or parsed.
+    ///
+    /// Returns the matching `DaemonId`s. The caller must handle zero / one / many cases.
+    fn find_in_state_file(short_name: &str) -> Vec<DaemonId> {
+        match StateFile::read(&*env::PITCHFORK_STATE_FILE) {
+            Ok(state) => state
+                .daemons
+                .keys()
+                .filter(|id| id.name() == short_name)
+                .cloned()
+                .collect(),
+            Err(e) => {
+                warn!("cannot read state file: {e}");
+                Vec::new()
+            }
+        }
     }
 
     /// Resolves a user-provided daemon ID to a qualified DaemonId, preferring the current directory's namespace.
@@ -505,15 +541,6 @@ impl PitchforkToml {
         // to global when it is explicitly configured.
         let global_id = DaemonId::try_new("global", user_id)?;
         if self.daemons.contains_key(&global_id) {
-            return Ok(global_id);
-        }
-
-        // Also allow existing ad-hoc daemons (persisted in state file) to be
-        // referenced by short ID. This keeps commands like status/restart/stop
-        // working for daemons started via `pitchfork run`.
-        if let Ok(state) = StateFile::read(&*env::PITCHFORK_STATE_FILE)
-            && state.daemons.contains_key(&global_id)
-        {
             return Ok(global_id);
         }
 

--- a/tests/test_e2e_namespace.rs
+++ b/tests/test_e2e_namespace.rs
@@ -267,9 +267,9 @@ run = "sleep 60"
     let _ = env.run_command_in_dir(&["stop", "web"], &project_y);
 }
 
-/// Test that list command hides namespace when there's no conflict
+/// Test that list command always shows fully-qualified daemon names.
 #[test]
-fn test_list_hides_namespace_without_conflict() {
+fn test_list_always_shows_qualified_names() {
     let env = TestEnv::new();
     env.ensure_binary_exists().unwrap();
 
@@ -299,19 +299,14 @@ run = "sleep 60"
     let list_str = String::from_utf8_lossy(&list_output.stdout);
     println!("list output (no conflict): {list_str}");
 
-    // Should show short names (no namespace) since there's no conflict
+    // Should always show fully-qualified names
     assert!(
-        list_str.contains("unique-api"),
-        "List should contain unique-api"
+        list_str.contains("solo-project/unique-api"),
+        "List should contain fully-qualified solo-project/unique-api"
     );
     assert!(
-        list_str.contains("unique-worker"),
-        "List should contain unique-worker"
-    );
-    // Should NOT contain the namespace prefix (no conflict)
-    assert!(
-        !list_str.contains("solo-project/"),
-        "List should NOT show namespace when there's no conflict, got: {list_str}"
+        list_str.contains("solo-project/unique-worker"),
+        "List should contain fully-qualified solo-project/unique-worker"
     );
 
     // Cleanup


### PR DESCRIPTION
fixes #465.

Modify pitchfork ls to always show namespace/name format instead of omitting the namespace when there's no local conflict.

Also add state_file fallback in resolve_daemon_id() for resolving short daemon IDs globally when no local config matches. When ambiguous, error now lists all matching fully-qualified IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon ID resolution now consults persisted state when matching short daemon names and provides guidance when multiple matches exist.

* **Bug Fixes**
  * Daemon list output consistently displays fully-qualified names in namespace/name format.

* **Tests**
  * Added an end-to-end test to ensure list output always shows fully-qualified daemon names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->