### PR TITLE
feat: add gate for pre/post start and stop

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -67,7 +67,7 @@ export default defineConfig({
           { text: "Port Management & Proxy", link: "/guides/port-management" },
           { text: "File Watching", link: "/guides/file-watching" },
           { text: "Auto Restart on Failure", link: "/guides/auto-restart" },
-          { text: "Lifecycle Hooks", link: "/guides/lifecycle-hooks" },
+          { text: "Lifecycle Hooks & Gates", link: "/guides/lifecycle-hooks" },
           { text: "Cron Scheduling", link: "/guides/scheduling" },
           { text: "Start on Boot", link: "/guides/boot-start" },
           { text: "Log Management", link: "/guides/logs" },

--- a/docs/guides/lifecycle-hooks.md
+++ b/docs/guides/lifecycle-hooks.md
@@ -1,10 +1,8 @@
-# Lifecycle Hooks
+# Lifecycle Hooks & Gates
 
-Run custom shell commands when daemons become ready, fail, are retried, stop, or produce specific output.
+**Hooks** are fire-and-forget shell commands that run in response to daemon lifecycle events. **Gates** are blocking checkpoints that must pass before the lifecycle proceeds. Use hooks for notifications and side effects; use gates for preconditions and validation.
 
 ## Configuration
-
-Add a `[daemons.<name>.hooks]` section to your `pitchfork.toml`:
 
 ```toml
 [daemons.api]
@@ -15,24 +13,38 @@ ready_http = "http://localhost:3000/health"
 [daemons.api.hooks]
 on_ready = "curl -X POST https://alerts.example.com/ready"
 on_fail = "./scripts/cleanup.sh"
-on_retry = "echo 'retrying api server...'"
-on_stop = "./scripts/notify-stopped.sh"
-on_exit = "./scripts/cleanup.sh"
 on_output = { filter = "Server started", run = "./scripts/notify-ready.sh" }
+
+[daemons.api.gates]
+pre_start = "curl -sf http://deps:8080/health"
+post_start = { run = "curl -sf http://localhost:3000/api/version", timeout = "10s" }
+pre_stop = "./scripts/drain-connections.sh"
+post_stop = "./scripts/cleanup-sockets.sh"
 ```
 
-## Hook Types
+## Hooks
 
-### `on_ready`
+Hooks run in the background and never block the daemon. Errors are logged but do not affect the lifecycle.
 
-Fires when the daemon passes its readiness check (delay, output match, HTTP, port, or command).
+### Hook Types
+
+| Hook | When it fires |
+|------|--------------|
+| `on_ready` | Daemon passes its readiness check (delay, output match, HTTP, port, or command) |
+| `on_fail` | Daemon fails and all retries are exhausted |
+| `on_retry` | Before each retry attempt |
+| `on_stop` | Daemon is explicitly stopped by pitchfork |
+| `on_exit` | Any daemon termination (stop, clean exit, or crash) |
+| `on_output` | Daemon writes a line matching an optional pattern |
+
+#### `on_ready`
 
 ```toml
 [daemons.api.hooks]
 on_ready = "curl -s -X POST https://slack.example.com/webhook -d '{\"text\": \"API is up\"}'"
 ```
 
-### `on_fail`
+#### `on_fail`
 
 Fires when the daemon fails and all retries are exhausted. If `retry = 0`, fires immediately on failure.
 
@@ -41,9 +53,7 @@ Fires when the daemon fails and all retries are exhausted. If `retry = 0`, fires
 on_fail = "./scripts/alert-team.sh"
 ```
 
-The `PITCHFORK_EXIT_CODE` environment variable contains the exit code from the failed process.
-
-### `on_retry`
+#### `on_retry`
 
 Fires before each retry attempt.
 
@@ -52,7 +62,7 @@ Fires before each retry attempt.
 on_retry = "echo 'Retrying api (attempt $PITCHFORK_RETRY_COUNT)...'"
 ```
 
-### `on_stop`
+#### `on_stop`
 
 Fires when the daemon is explicitly stopped by pitchfork (via `pitchfork stop`, `auto = ["stop"]` directory exit, or supervisor shutdown).
 
@@ -61,7 +71,7 @@ Fires when the daemon is explicitly stopped by pitchfork (via `pitchfork stop`, 
 on_stop = "./scripts/notify-stopped.sh"
 ```
 
-### `on_exit`
+#### `on_exit`
 
 Fires on **any** daemon termination — intentional stop, clean exit, or crash. Also fires during supervisor shutdown. Use this for cleanup that should always run regardless of why the daemon stopped.
 
@@ -72,16 +82,12 @@ Fires on **any** daemon termination — intentional stop, clean exit, or crash. 
 on_exit = "docker compose down --volumes"
 ```
 
-The `PITCHFORK_EXIT_CODE` and `PITCHFORK_EXIT_REASON` environment variables are available to distinguish the cause.
+#### `on_output`
 
-### `on_output`
-
-Fires when the daemon writes a line to stdout or stderr that matches an optional pattern. Useful for reacting to log messages without relying on a readiness check.
-
-`on_output` accepts a command string (shorthand) or an inline table (full form):
+Fires when the daemon writes a line to stdout or stderr that matches an optional pattern. Accepts a command string (shorthand) or an inline table (full form):
 
 ```toml
-# Shorthand (run only, fires on every line)
+# Shorthand (fires on every line)
 on_output = "./scripts/log-activity.sh"
 
 # Full form with filter/regex/debounce
@@ -97,34 +103,86 @@ on_output = { filter = "Server started", run = "curl https://monitor.example.com
 
 `filter` and `regex` are mutually exclusive. When neither is specified the hook fires on every line of output, subject to debouncing.
 
+The matched line is available as `$PITCHFORK_MATCHED_LINE`.
+
+### Hook Behavior
+
+- Hooks are **fire-and-forget** — they run in the background and never block the daemon
+- Hook commands run in the daemon's working directory
+- Errors in hooks are logged but do not affect the daemon
+- Hooks read fresh configuration from `pitchfork.toml` each time they fire
+
+## Gates
+
+Gates block the lifecycle until the gate command exits with code 0. If a gate fails (non-zero exit or timeout), the lifecycle action is aborted with an error.
+
+### Gate Types
+
+| Gate | When it runs | Blocks until |
+|------|-------------|-------------|
+| `pre_start` | Before the daemon process is spawned | Command exits 0 |
+| `post_start` | After the daemon becomes ready (or 500 ms after spawn if no readiness check) | Command exits 0 |
+| `pre_stop` | Before the daemon is stopped | Command exits 0 |
+| `post_stop` | After the daemon has stopped | Command exits 0 |
+
+### Shorthand vs Full Form
+
+Each gate accepts a command string (shorthand) or an inline table (full form):
+
 ```toml
-[daemons.api.hooks]
-# Fire once when a specific string appears
-on_output = { filter = "Server started", run = "curl https://monitor.example.com/up" }
+# Shorthand (command only, no timeout)
+pre_start = "curl -sf http://deps:8080/health"
 
-# Fire when a line matches a regex
-on_output = { regex = "listening on port [0-9]+", run = "./scripts/register-port.sh" }
-
-# Fire on every line, but no more than once per 5 seconds
-on_output = { run = "./scripts/log-activity.sh", debounce = "5s" }
+# Full form with timeout
+pre_start = { run = "curl -sf http://deps:8080/health", timeout = "30s" }
 ```
 
-The matched line is available in the hook command as `$PITCHFORK_MATCHED_LINE`.
+| Field | Required | Description |
+|-------|----------|-------------|
+| `run` | Yes | Shell command to execute |
+| `timeout` | No | Maximum time to wait (humantime, e.g. `"30s"`, `"5m"`). Defaults to `settings.supervisor.gate_timeout` if not set. |
+
+### Default Gate Timeout
+
+If no per-gate `timeout` is specified, the global default from `settings.supervisor.gate_timeout` is used (default: `"30s"`). This prevents gates from blocking indefinitely.
+
+```toml
+[settings.supervisor]
+gate_timeout = "60s"
+```
+
+### Gate Behavior
+
+- Gates **block** the lifecycle — the start/stop operation waits for the gate to pass
+- If a gate command exits with a non-zero code, the lifecycle action fails with an error
+- If a gate command times out, it is killed and the lifecycle action fails
+- Gate commands run in the daemon's working directory
+- Gates read fresh configuration from `pitchfork.toml` each time they run
+- `post_start` in non-wait-ready mode runs as a fire-and-forget task after a 500 ms delay (errors are logged but do not block)
+
+## Hooks vs Gates
+
+| | Hooks | Gates |
+|--|-------|-------|
+| Blocking | No (fire-and-forget) | Yes (blocks lifecycle) |
+| Failure impact | Logged, daemon unaffected | Lifecycle aborted with error |
+| Timeout | No | Yes (per-gate or global default) |
+| Config section | `[daemons.<name>.hooks]` | `[daemons.<name>.gates]` |
 
 ## Environment Variables
 
-All hooks receive these environment variables:
+All hooks and gates receive these environment variables:
 
-| Variable | Description |
-|----------|-------------|
-| `PITCHFORK_DAEMON_ID` | The daemon's fully-qualified ID (`namespace/name`) |
-| `PITCHFORK_DAEMON_NAMESPACE` | The daemon's namespace |
-| `PITCHFORK_RETRY_COUNT` | Current retry attempt (0 on first run) |
-| `PITCHFORK_EXIT_CODE` | Exit code of the process (`on_fail`, `on_stop`, `on_exit`). On Unix, processes terminated by a signal (e.g. SIGTERM) have no POSIX exit code; in that case this is set to `-1`. |
-| `PITCHFORK_EXIT_REASON` | Why the daemon stopped. Typically `"stop"` (intentional stop by pitchfork) or `"fail"` (non-zero exit); `"exit"` indicates an unexpected clean exit (process quit on its own with code 0). Available in `on_stop` and `on_exit`. |
-| `PITCHFORK_MATCHED_LINE` | The raw output line that triggered the hook (`on_output` only) |
+| Variable | Hooks | Gates | Description |
+|----------|-------|-------|-------------|
+| `PITCHFORK_DAEMON_ID` | All | All | The daemon's fully-qualified ID (`namespace/name`) |
+| `PITCHFORK_DAEMON_NAMESPACE` | All | All | The daemon's namespace |
+| `PITCHFORK_RETRY_COUNT` | All | All | Current retry attempt (0 on first run) |
+| `PITCHFORK_EXIT_CODE` | `on_fail`, `on_stop`, `on_exit` | `post_stop` | Exit code of the process. On Unix, processes terminated by a signal (e.g. SIGTERM) have no POSIX exit code; set to `-1`. |
+| `PITCHFORK_EXIT_REASON` | `on_stop`, `on_exit` | `post_stop` | Why the daemon stopped: `"stop"` (intentional), `"fail"` (non-zero exit), or `"exit"` (clean exit) |
+| `PITCHFORK_MATCHED_LINE` | `on_output` | — | The raw output line that triggered the hook |
 
-Any custom `env` variables from the daemon config are also passed to hooks.
+Any custom `env` variables from the daemon config are also passed to hooks and gates.
 
 ## Stop Signal
 
@@ -153,14 +211,9 @@ stop_signal = { signal = "SIGINT", timeout = "5s" }
 - If the process does not exit within the timeout, `SIGKILL` is sent as a last resort
 - The default signal is `SIGTERM`, and the default timeout comes from `settings.supervisor.stop_timeout`
 
-## Behavior
-
-- Hooks are **fire-and-forget** — they run in the background and never block the daemon
-- Hook commands run in the daemon's working directory
-- Errors in hooks are logged but do not affect the daemon
-- Hooks read fresh configuration from `pitchfork.toml` each time they fire
-
 ## Examples
+
+### Hooks
 
 **Send a Slack notification on failure:**
 
@@ -244,4 +297,47 @@ run = "python worker.py"
 
 [daemons.worker.hooks]
 on_output = { run = "sh -c 'echo \"$(date): active\" >> /var/log/worker-activity.log'", debounce = "10s" }
+```
+
+### Gates
+
+**Wait for a dependency before starting:**
+
+```toml
+[daemons.api]
+run = "npm run server"
+
+[daemons.api.gates]
+pre_start = "curl -sf http://localhost:5432/health"
+```
+
+**Validate the daemon is healthy after startup:**
+
+```toml
+[daemons.api]
+run = "npm run server"
+ready_http = "http://localhost:3000/health"
+
+[daemons.api.gates]
+post_start = { run = "curl -sf http://localhost:3000/api/version", timeout = "10s" }
+```
+
+**Drain connections before stopping:**
+
+```toml
+[daemons.api]
+run = "npm run server"
+
+[daemons.api.gates]
+pre_stop = "./scripts/drain-connections.sh"
+```
+
+**Clean up after a daemon stops:**
+
+```toml
+[daemons.api]
+run = "npm run server"
+
+[daemons.api.gates]
+post_stop = "./scripts/cleanup-sockets.sh"
 ```

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -73,6 +73,26 @@
       "type": "string",
       "pattern": "^[\\w.-]+(/[\\w.-]+)?$"
     },
+    "GateConfig": {
+      "description": "A single gate command configuration.\n\nAccepts two TOML forms:\n```toml\npre_start = \"curl http://deps/health\"  # shorthand (command only)\npre_start = { run = \"curl http://deps/health\", timeout = \"30s\" }  # full\n```",
+      "type": "object",
+      "properties": {
+        "run": {
+          "description": "Command to run",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "Timeout for the gate command (humantime, e.g. `\"30s\"`).\nDefaults to no timeout (wait indefinitely).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ]
+    },
     "MemoryLimit": {
       "description": "Memory limit in human-readable format, e.g. '50MB', '1GiB', '512KB'",
       "type": "string"
@@ -213,6 +233,17 @@
             "type": "string"
           }
         },
+        "gates": {
+          "description": "Lifecycle gates (pre_start, post_start, pre_stop, post_stop)",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PitchforkTomlGates"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "hooks": {
           "description": "Lifecycle hooks (on_ready, on_fail, on_retry)",
           "anyOf": [
@@ -351,6 +382,56 @@
       "required": [
         "run"
       ]
+    },
+    "PitchforkTomlGates": {
+      "description": "Lifecycle gates for a daemon.\n\nGates block the daemon lifecycle until the gate command succeeds.\nUnlike hooks (fire-and-forget), gates must pass before proceeding.",
+      "type": "object",
+      "properties": {
+        "post_start": {
+          "description": "Gate that must pass after the daemon becomes ready",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GateConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "post_stop": {
+          "description": "Gate that must pass after the daemon has stopped",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GateConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pre_start": {
+          "description": "Gate that must pass before the daemon process is spawned",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GateConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pre_stop": {
+          "description": "Gate that must pass before the daemon is stopped",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GateConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
     },
     "PitchforkTomlHooks": {
       "description": "Lifecycle hooks for a daemon",
@@ -762,6 +843,13 @@
         },
         "file_watch_debounce": {
           "description": "File watch debounce duration",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "gate_timeout": {
+          "description": "Default timeout for gate commands",
           "type": [
             "string",
             "null"

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -82,7 +82,7 @@
           "type": "string"
         },
         "timeout": {
-          "description": "Timeout for the gate command (humantime, e.g. `\"30s\"`).\nDefaults to no timeout (wait indefinitely).",
+          "description": "Timeout for the gate command (humantime, e.g. `\"30s\"`).\nDefaults to `settings.supervisor.gate_timeout` (30s by default) when not set.",
           "type": [
             "string",
             "null"

--- a/settings.toml
+++ b/settings.toml
@@ -540,7 +540,8 @@ pre_start = { run = "check-db.sh", timeout = "10s" }
 ```
 
 Set to `"0s"` to disable the global timeout (gates wait indefinitely unless
-they have their own timeout).
+they have their own timeout). Note: per-gate `timeout` takes precedence;
+if neither per-gate nor global timeout is set, gates wait indefinitely.
 """
 
 [supervisor.cpu_violation_threshold]

--- a/settings.toml
+++ b/settings.toml
@@ -523,6 +523,26 @@ If unset and the supervisor is running as root via `sudo`, daemons default to
 the sudo-calling user from `SUDO_UID`/`SUDO_GID` instead of running as root.
 """
 
+[supervisor.gate_timeout]
+type = "Duration"
+env = "PITCHFORK_GATE_TIMEOUT"
+default = "30s"
+description = "Default timeout for gate commands"
+docs = """
+Maximum time to wait for a gate command to complete when no per-gate `timeout`
+is configured. Gates block the daemon lifecycle, so a hung gate can prevent
+startup or shutdown from completing.
+
+Each gate can override this with its own `timeout` field:
+```toml
+[daemons.myapp.gates]
+pre_start = { run = "check-db.sh", timeout = "10s" }
+```
+
+Set to `"0s"` to disable the global timeout (gates wait indefinitely unless
+they have their own timeout).
+"""
+
 [supervisor.cpu_violation_threshold]
 type = "Integer"
 env = "PITCHFORK_CPU_VIOLATION_THRESHOLD"

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -898,7 +898,7 @@ pub struct GateConfig {
     /// Command to run
     pub run: String,
     /// Timeout for the gate command (humantime, e.g. `"30s"`).
-    /// Defaults to no timeout (wait indefinitely).
+    /// Defaults to `settings.supervisor.gate_timeout` (30s by default) when not set.
     pub timeout: Option<String>,
 }
 

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -883,6 +883,112 @@ pub struct PitchforkTomlHooks {
 }
 
 // ---------------------------------------------------------------------------
+// GateConfig (string-or-object pattern)
+// ---------------------------------------------------------------------------
+
+/// A single gate command configuration.
+///
+/// Accepts two TOML forms:
+/// ```toml
+/// pre_start = "curl http://deps/health"  # shorthand (command only)
+/// pre_start = { run = "curl http://deps/health", timeout = "30s" }  # full
+/// ```
+#[derive(Debug, Clone, JsonSchema)]
+pub struct GateConfig {
+    /// Command to run
+    pub run: String,
+    /// Timeout for the gate command (humantime, e.g. `"30s"`).
+    /// Defaults to no timeout (wait indefinitely).
+    pub timeout: Option<String>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+#[doc(hidden)]
+pub struct GateConfigRaw {
+    run: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    timeout: Option<String>,
+}
+
+impl StringOrStruct for GateConfig {
+    type Short = String;
+    type Raw = GateConfigRaw;
+
+    fn from_short(run: String) -> Self {
+        Self { run, timeout: None }
+    }
+
+    fn from_raw(raw: GateConfigRaw) -> std::result::Result<Self, String> {
+        if let Some(ref t) = raw.timeout {
+            humantime::parse_duration(t).map_err(|e| format!("invalid gate timeout '{t}': {e}"))?;
+        }
+        Ok(Self {
+            run: raw.run,
+            timeout: raw.timeout,
+        })
+    }
+
+    fn is_shorthand(&self) -> bool {
+        self.timeout.is_none()
+    }
+
+    fn to_short(&self) -> String {
+        self.run.clone()
+    }
+
+    fn to_raw(&self) -> GateConfigRaw {
+        GateConfigRaw {
+            run: self.run.clone(),
+            timeout: self.timeout.clone(),
+        }
+    }
+}
+
+impl Serialize for GateConfig {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.string_or_struct_serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for GateConfig {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Self::string_or_struct_deserialize(d)
+    }
+}
+
+impl GateConfig {
+    pub fn timeout_duration(&self) -> Option<std::time::Duration> {
+        self.timeout
+            .as_deref()
+            .and_then(|s| humantime::parse_duration(s).ok())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PitchforkTomlGates
+// ---------------------------------------------------------------------------
+
+/// Lifecycle gates for a daemon.
+///
+/// Gates block the daemon lifecycle until the gate command succeeds.
+/// Unlike hooks (fire-and-forget), gates must pass before proceeding.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, JsonSchema)]
+pub struct PitchforkTomlGates {
+    /// Gate that must pass before the daemon process is spawned
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub pre_start: Option<GateConfig>,
+    /// Gate that must pass after the daemon becomes ready
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub post_start: Option<GateConfig>,
+    /// Gate that must pass before the daemon is stopped
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub pre_stop: Option<GateConfig>,
+    /// Gate that must pass after the daemon has stopped
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub post_stop: Option<GateConfig>,
+}
+
+// ---------------------------------------------------------------------------
 // PortBump (BoolOrU32 pattern)
 // ---------------------------------------------------------------------------
 

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -824,53 +824,24 @@ impl IpcClient {
     /// - Ad-hoc daemon handling (no dependencies)
     /// - Parallel execution within dependency levels
     pub async fn stop_daemons(self: &Arc<Self>, ids: &[DaemonId]) -> Result<StopResult> {
-        // Get currently running daemons
-        let running_daemons: HashSet<DaemonId> = self
-            .active_daemons()
-            .await?
-            .iter()
-            .filter(|d| d.status.is_running() || d.status.is_waiting())
-            .map(|d| d.id.clone())
-            .collect();
-
-        // Filter to only running daemons
-        let requested_ids: Vec<DaemonId> = ids
-            .iter()
-            .filter(|id| {
-                if !running_daemons.contains(*id) {
-                    warn!("Daemon {id} is not running");
-                    false
-                } else {
-                    true
-                }
-            })
-            .cloned()
-            .collect();
-
-        if requested_ids.is_empty() {
-            info!("No running daemons to stop");
+        if ids.is_empty() {
+            info!("No daemons to stop");
             return Ok(StopResult { any_failed: false });
         }
 
         let mut any_failed = false;
 
         // Use shared reverse dependency ordering
-        let stop_levels = compute_reverse_stop_order(&requested_ids);
+        let stop_levels = compute_reverse_stop_order(ids);
 
         for level in stop_levels {
-            // Filter to only running daemons in this level
-            let to_stop: Vec<DaemonId> = level
-                .into_iter()
-                .filter(|id| running_daemons.contains(id))
-                .collect();
-
-            if to_stop.is_empty() {
+            if level.is_empty() {
                 continue;
             }
 
             // Stop all daemons in this level concurrently
             let mut tasks = Vec::new();
-            for id in to_stop {
+            for id in level {
                 let task = Self::spawn_stop_task(self.clone(), id);
                 tasks.push(task);
             }

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -11,8 +11,9 @@ use std::path::{Path, PathBuf};
 
 // Re-export config value types so existing `use crate::pitchfork_toml::X` paths keep working.
 pub use crate::config_types::{
-    CpuLimit, CronRetrigger, Dir, MemoryLimit, OnOutputHook, PitchforkTomlAuto, PitchforkTomlCron,
-    PitchforkTomlHooks, PortBump, PortConfig, ReadyHttp, Retry, StopConfig, StopSignal, WatchMode,
+    CpuLimit, CronRetrigger, Dir, GateConfig, MemoryLimit, OnOutputHook, PitchforkTomlAuto,
+    PitchforkTomlCron, PitchforkTomlGates, PitchforkTomlHooks, PortBump, PortConfig, ReadyHttp,
+    Retry, StopConfig, StopSignal, WatchMode,
 };
 
 /// Raw slug entry as read from TOML (uses String for dir path).
@@ -125,6 +126,8 @@ struct PitchforkTomlDaemonRaw {
     pub env: Option<IndexMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub hooks: Option<PitchforkTomlHooks>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub gates: Option<PitchforkTomlGates>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub mise: Option<bool>,
     /// Unix user to run this daemon as.
@@ -939,6 +942,7 @@ impl PitchforkToml {
                 dir: raw_daemon.dir,
                 env: raw_daemon.env,
                 hooks: raw_daemon.hooks,
+                gates: raw_daemon.gates,
                 mise: raw_daemon.mise,
                 user: raw_daemon.user,
                 memory_limit: raw_daemon.memory_limit,
@@ -1089,6 +1093,7 @@ impl PitchforkToml {
                     dir: daemon.dir.clone(),
                     env: daemon.env.clone(),
                     hooks: daemon.hooks.clone(),
+                    gates: daemon.gates.clone(),
                     mise: daemon.mise,
                     user: daemon.user.clone(),
                     memory_limit: daemon.memory_limit,
@@ -1321,6 +1326,8 @@ pub struct PitchforkTomlDaemon {
     pub env: Option<IndexMap<String, String>>,
     /// Lifecycle hooks (on_ready, on_fail, on_retry)
     pub hooks: Option<PitchforkTomlHooks>,
+    /// Lifecycle gates (pre_start, post_start, pre_stop, post_stop)
+    pub gates: Option<PitchforkTomlGates>,
     /// Wrap this daemon's command with `mise x --` for tool/env setup.
     /// Overrides the global `settings.general.mise` when set.
     pub mise: Option<bool>,

--- a/src/supervisor/hooks.rs
+++ b/src/supervisor/hooks.rs
@@ -242,6 +242,37 @@ fn get_gate_config(
 }
 
 // ---------------------------------------------------------------------------
+// run_post_stop_gate — convenience wrapper for the PostStop gate
+// ---------------------------------------------------------------------------
+
+/// Run the `post_stop` gate for a daemon with the given exit information.
+///
+/// `exit_code` and `exit_reason` are exposed to the gate command via
+/// `PITCHFORK_EXIT_CODE` and `PITCHFORK_EXIT_REASON` environment variables.
+pub(crate) async fn run_post_stop_gate(
+    daemon_id: DaemonId,
+    daemon_dir: PathBuf,
+    retry_count: u32,
+    daemon_env: Option<IndexMap<String, String>>,
+    exit_code: i32,
+    exit_reason: &str,
+) -> crate::Result<()> {
+    GateContext::new(
+        GateType::PostStop,
+        daemon_id,
+        daemon_dir,
+        retry_count,
+        daemon_env,
+    )
+    .extra_env(vec![
+        ("PITCHFORK_EXIT_CODE".to_string(), exit_code.to_string()),
+        ("PITCHFORK_EXIT_REASON".to_string(), exit_reason.to_string()),
+    ])
+    .run()
+    .await
+}
+
+// ---------------------------------------------------------------------------
 // fire_hook — fire-and-forget lifecycle hook
 // ---------------------------------------------------------------------------
 

--- a/src/supervisor/hooks.rs
+++ b/src/supervisor/hooks.rs
@@ -1,11 +1,15 @@
-//! Hook execution for daemon lifecycle events
+//! Hook and gate execution for daemon lifecycle events
 //!
 //! Hooks are fire-and-forget shell commands that run in response to daemon
 //! lifecycle events (ready, fail, retry). They are configured in pitchfork.toml
 //! under `[daemons.<name>.hooks]`.
+//!
+//! Gates block the lifecycle until the command exits with code 0. They are
+//! configured under `[daemons.<name>.gates]`.
 
 use crate::daemon_id::DaemonId;
-use crate::pitchfork_toml::PitchforkToml;
+use crate::pitchfork_toml::{GateConfig, PitchforkToml};
+use crate::settings::settings;
 use crate::shell::Shell;
 use crate::supervisor::SUPERVISOR;
 use crate::{env, pitchfork_toml, template};
@@ -13,7 +17,10 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-/// The type of lifecycle hook to fire
+// ---------------------------------------------------------------------------
+// HookType / GateType
+// ---------------------------------------------------------------------------
+
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum HookType {
     OnReady,
@@ -21,6 +28,24 @@ pub(crate) enum HookType {
     OnRetry,
     OnStop,
     OnExit,
+}
+
+pub(crate) enum GateType {
+    PreStart,
+    PostStart,
+    PreStop,
+    PostStop,
+}
+
+impl std::fmt::Display for GateType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GateType::PreStart => write!(f, "pre_start"),
+            GateType::PostStart => write!(f, "post_start"),
+            GateType::PreStop => write!(f, "pre_stop"),
+            GateType::PostStop => write!(f, "post_stop"),
+        }
+    }
 }
 
 impl std::fmt::Display for HookType {
@@ -35,6 +60,156 @@ impl std::fmt::Display for HookType {
     }
 }
 
+// ---------------------------------------------------------------------------
+// GateContext — encapsulates all data needed to run a gate
+// ---------------------------------------------------------------------------
+
+pub(crate) struct GateContext {
+    gate_type: GateType,
+    daemon_id: DaemonId,
+    daemon_dir: PathBuf,
+    retry_count: u32,
+    daemon_env: Option<IndexMap<String, String>>,
+    extra_env: Vec<(String, String)>,
+}
+
+impl GateContext {
+    pub(crate) fn new(
+        gate_type: GateType,
+        daemon_id: DaemonId,
+        daemon_dir: PathBuf,
+        retry_count: u32,
+        daemon_env: Option<IndexMap<String, String>>,
+    ) -> Self {
+        Self {
+            gate_type,
+            daemon_id,
+            daemon_dir,
+            retry_count,
+            daemon_env,
+            extra_env: vec![],
+        }
+    }
+
+    pub(crate) fn extra_env(mut self, env: Vec<(String, String)>) -> Self {
+        self.extra_env = env;
+        self
+    }
+
+    /// Run the gate, blocking until it succeeds or fails.
+    ///
+    /// Unlike hooks (fire-and-forget), gates block the lifecycle until the command
+    /// exits with code 0. Returns `Ok(())` on success, `Err` on failure or timeout.
+    ///
+    /// If no gate is configured for the given type, returns `Ok(())` immediately.
+    /// If the config file cannot be loaded, returns an error (gates must not be
+    /// silently skipped — they are blocking by design).
+    pub(crate) async fn run(self) -> crate::Result<()> {
+        let gate_type = self.gate_type;
+        let daemon_id = self.daemon_id;
+
+        let pt = PitchforkToml::all_merged().map_err(|e| {
+            miette::miette!("failed to load config for {gate_type} gate of daemon {daemon_id}: {e}")
+        })?;
+
+        let gate_config = pt
+            .daemons
+            .get(&daemon_id)
+            .and_then(|d| get_gate_config(&d.gates, &gate_type));
+
+        let Some(config) = gate_config else {
+            return Ok(());
+        };
+
+        let cmd = match render_hook_template(&config.run, &daemon_id, &pt).await {
+            Ok(cmd) => cmd,
+            Err(e) => {
+                return Err(miette::miette!(
+                    "{gate_type} gate template error for daemon {daemon_id}: {e}"
+                ));
+            }
+        };
+
+        info!("running {gate_type} gate for daemon {daemon_id}: {cmd}");
+
+        let mut command = Shell::default_for_platform().command(&cmd);
+        command
+            .current_dir(&self.daemon_dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+
+        if let Some(ref path) = *env::ORIGINAL_PATH {
+            command.env("PATH", path);
+        }
+
+        if let Some(ref env_vars) = self.daemon_env {
+            command.envs(env_vars);
+        }
+
+        command
+            .env("PITCHFORK_DAEMON_ID", daemon_id.qualified())
+            .env("PITCHFORK_DAEMON_NAMESPACE", daemon_id.namespace())
+            .env("PITCHFORK_RETRY_COUNT", self.retry_count.to_string());
+
+        for (key, value) in &self.extra_env {
+            command.env(key, value);
+        }
+
+        let mut child = match command.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(miette::miette!(
+                    "failed to spawn {gate_type} gate for daemon {daemon_id}: {e}"
+                ));
+            }
+        };
+
+        // Effective timeout: per-gate timeout > global default > none
+        let timeout = config
+            .timeout_duration()
+            .or_else(|| Some(settings().supervisor_gate_timeout()));
+
+        if let Some(timeout) = timeout {
+            match tokio::time::timeout(timeout, child.wait()).await {
+                Ok(Ok(status)) if status.success() => {
+                    info!("{gate_type} gate for daemon {daemon_id} passed");
+                    Ok(())
+                }
+                Ok(Ok(status)) => Err(miette::miette!(
+                    "{gate_type} gate for daemon {daemon_id} exited with {status}"
+                )),
+                Ok(Err(e)) => Err(miette::miette!(
+                    "{gate_type} gate for daemon {daemon_id} failed: {e}"
+                )),
+                Err(_) => {
+                    let _ = child.kill().await;
+                    let _ = child.wait().await;
+                    Err(miette::miette!(
+                        "{gate_type} gate for daemon {daemon_id} timed out after {timeout:?}"
+                    ))
+                }
+            }
+        } else {
+            match child.wait().await {
+                Ok(status) if status.success() => {
+                    info!("{gate_type} gate for daemon {daemon_id} passed");
+                    Ok(())
+                }
+                Ok(status) => Err(miette::miette!(
+                    "{gate_type} gate for daemon {daemon_id} exited with {status}"
+                )),
+                Err(e) => Err(miette::miette!(
+                    "{gate_type} gate for daemon {daemon_id} failed: {e}"
+                )),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
 fn get_hook_cmd(
     hooks: &Option<pitchfork_toml::PitchforkTomlHooks>,
     hook_type: &HookType,
@@ -47,6 +222,22 @@ fn get_hook_cmd(
         HookType::OnExit => h.on_exit.clone(),
     })
 }
+
+fn get_gate_config(
+    gates: &Option<pitchfork_toml::PitchforkTomlGates>,
+    gate_type: &GateType,
+) -> Option<GateConfig> {
+    gates.as_ref().and_then(|g| match gate_type {
+        GateType::PreStart => g.pre_start.clone(),
+        GateType::PostStart => g.post_start.clone(),
+        GateType::PreStop => g.pre_stop.clone(),
+        GateType::PostStop => g.post_stop.clone(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// fire_hook — fire-and-forget lifecycle hook
+// ---------------------------------------------------------------------------
 
 /// Fire a hook command as a fire-and-forget tokio task.
 ///
@@ -76,7 +267,6 @@ pub(crate) async fn fire_hook(
 
         let Some(cmd) = hook_cmd else { return };
 
-        // Render Tera templates in hook command with context from state file
         let cmd = match render_hook_template(&cmd, &daemon_id, &pt).await {
             Ok(cmd) => cmd,
             Err(e) => {
@@ -97,12 +287,10 @@ pub(crate) async fn fire_hook(
             command.env("PATH", path);
         }
 
-        // Apply user env vars first
         if let Some(ref env_vars) = daemon_env {
             command.envs(env_vars);
         }
 
-        // Inject pitchfork metadata env vars AFTER user env so they can't be overwritten
         command
             .env("PITCHFORK_DAEMON_ID", daemon_id.qualified())
             .env("PITCHFORK_DAEMON_NAMESPACE", daemon_id.namespace())
@@ -124,13 +312,7 @@ pub(crate) async fn fire_hook(
         }
     });
 
-    // Register the handle so supervisor shutdown can await it.
-    // Use lock().await instead of try_lock() to guarantee registration — fire_hook
-    // is called from async monitoring tasks (not latency-sensitive hot paths), so
-    // awaiting the lock is safe and eliminates the silent-drop window where a
-    // JoinHandle could be lost under lock contention.
     let mut tasks = SUPERVISOR.hook_tasks.lock().await;
-    // Prune already-finished handles to avoid unbounded growth
     tasks.retain(|h| !h.is_finished());
     tasks.push(handle);
 }
@@ -148,7 +330,6 @@ pub(crate) async fn fire_output_hook(
     matched_line: String,
 ) {
     let handle = tokio::spawn(async move {
-        // Render Tera templates in output hook command
         let pt = PitchforkToml::all_merged().unwrap_or_default();
         let cmd = match render_hook_template(&cmd, &daemon_id, &pt).await {
             Ok(cmd) => cmd,
@@ -197,7 +378,11 @@ pub(crate) async fn fire_output_hook(
     tasks.push(handle);
 }
 
-/// Render Tera templates in a hook command using the current state file data.
+// ---------------------------------------------------------------------------
+// Template rendering
+// ---------------------------------------------------------------------------
+
+/// Render Tera templates in a hook/gate command using the current state file data.
 ///
 /// In the supervisor, daemons are already running, so `resolved_port` and
 /// `active_port` are available from the state file.
@@ -206,7 +391,6 @@ async fn render_hook_template(
     daemon_id: &DaemonId,
     pt: &PitchforkToml,
 ) -> Result<String, template::RenderError> {
-    // Collect resolved ports from all running daemons in the state file
     let resolved_daemons: HashMap<DaemonId, Vec<u16>> = {
         let state_file = SUPERVISOR.state_file.lock().await;
         state_file

--- a/src/supervisor/hooks.rs
+++ b/src/supervisor/hooks.rs
@@ -165,9 +165,15 @@ impl GateContext {
         };
 
         // Effective timeout: per-gate timeout > global default > none
-        let timeout = config
-            .timeout_duration()
-            .or_else(|| Some(settings().supervisor_gate_timeout()));
+        // Duration::ZERO means "disable timeout" (wait indefinitely).
+        let global_timeout = settings().supervisor_gate_timeout();
+        let timeout = config.timeout_duration().or_else(|| {
+            if global_timeout.is_zero() {
+                None
+            } else {
+                Some(global_timeout)
+            }
+        });
 
         if let Some(timeout) = timeout {
             match tokio::time::timeout(timeout, child.wait()).await {

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -2,7 +2,7 @@
 //!
 //! Contains the core `run()`, `run_once()`, and `stop()` methods for daemon process management.
 
-use super::hooks::{self, GateContext, GateType, HookType, fire_hook};
+use super::hooks::{self, GateContext, GateType, HookType, fire_hook, run_post_stop_gate};
 use super::{SUPERVISOR, Supervisor};
 use crate::daemon::RunOptions;
 use crate::daemon_id::DaemonId;
@@ -1087,7 +1087,7 @@ impl Supervisor {
                 Ok(Ok(())) => {
                     info!("daemon {id} is ready");
                     // Run post_start gate after daemon is ready
-                    GateContext::new(
+                    if let Err(e) = GateContext::new(
                         GateType::PostStart,
                         id.clone(),
                         opts.dir.0.clone(),
@@ -1095,7 +1095,15 @@ impl Supervisor {
                         opts.env.clone(),
                     )
                     .run()
-                    .await?;
+                    .await
+                    {
+                        warn!("post_start gate failed for daemon {id} (still running): {e}");
+                        return Ok(IpcResponse::DaemonFailed {
+                            error: format!(
+                                "post_start gate failed: {e} (daemon is still running, use 'pitchfork stop {id}' to stop it)"
+                            ),
+                        });
+                    }
                     Ok(IpcResponse::DaemonReady { daemon })
                 }
                 Ok(Err(exit_code)) => {
@@ -1221,18 +1229,14 @@ impl Supervisor {
                     // Run post_stop gate after daemon has stopped
                     let post_stop_dir = daemon.dir.clone().unwrap_or_else(|| env::CWD.clone());
                     let post_stop_env = daemon.env.clone();
-                    GateContext::new(
-                        GateType::PostStop,
+                    run_post_stop_gate(
                         id.clone(),
                         post_stop_dir,
                         daemon.retry_count,
                         post_stop_env,
+                        -1,
+                        "stop",
                     )
-                    .extra_env(vec![
-                        ("PITCHFORK_EXIT_CODE".to_string(), "-1".to_string()),
-                        ("PITCHFORK_EXIT_REASON".to_string(), "stop".to_string()),
-                    ])
-                    .run()
                     .await?;
                 } else {
                     debug!("pid {pid} not running, process may have exited unexpectedly");
@@ -1251,18 +1255,15 @@ impl Supervisor {
                     // Run post_stop gate even when process was already dead
                     let post_stop_dir = daemon.dir.clone().unwrap_or_else(|| env::CWD.clone());
                     let post_stop_env = daemon.env.clone();
-                    GateContext::new(
-                        GateType::PostStop,
+                    let (exit_code, exit_reason) = daemon_exit_info(&daemon);
+                    run_post_stop_gate(
                         id.clone(),
                         post_stop_dir,
                         daemon.retry_count,
                         post_stop_env,
+                        exit_code,
+                        exit_reason,
                     )
-                    .extra_env(vec![
-                        ("PITCHFORK_EXIT_CODE".to_string(), "-1".to_string()),
-                        ("PITCHFORK_EXIT_REASON".to_string(), "stop".to_string()),
-                    ])
-                    .run()
                     .await?;
 
                     return Ok(IpcResponse::DaemonWasNotRunning);
@@ -1273,18 +1274,15 @@ impl Supervisor {
                 // exited. Run post_stop gate for cleanup, then report status.
                 let post_stop_dir = daemon.dir.clone().unwrap_or_else(|| env::CWD.clone());
                 let post_stop_env = daemon.env.clone();
-                GateContext::new(
-                    GateType::PostStop,
+                let (exit_code, exit_reason) = daemon_exit_info(&daemon);
+                run_post_stop_gate(
                     id.clone(),
                     post_stop_dir,
                     daemon.retry_count,
                     post_stop_env,
+                    exit_code,
+                    exit_reason,
                 )
-                .extra_env(vec![
-                    ("PITCHFORK_EXIT_CODE".to_string(), "-1".to_string()),
-                    ("PITCHFORK_EXIT_REASON".to_string(), "stop".to_string()),
-                ])
-                .run()
                 .await?;
 
                 debug!("daemon {id} not running");
@@ -1294,6 +1292,27 @@ impl Supervisor {
             debug!("daemon {id} not found");
             Ok(IpcResponse::DaemonNotFound)
         }
+    }
+}
+
+/// Extract exit code and reason from a daemon's current state.
+///
+/// Used by `post_stop` gate to set `PITCHFORK_EXIT_CODE` and
+/// `PITCHFORK_EXIT_REASON` environment variables. For daemons that exited
+/// on their own (not via explicit stop), this returns the actual exit info
+/// from `DaemonStatus::Errored(code)` rather than the placeholder `-1/"stop"`.
+fn daemon_exit_info(daemon: &crate::daemon::Daemon) -> (i32, &'static str) {
+    match &daemon.status {
+        DaemonStatus::Errored(code) => (*code, "fail"),
+        DaemonStatus::Stopped => {
+            let reason = if daemon.last_exit_success.unwrap_or(true) {
+                "exit"
+            } else {
+                "fail"
+            };
+            (-1, reason)
+        }
+        _ => (-1, "stop"),
     }
 }
 

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -2,7 +2,7 @@
 //!
 //! Contains the core `run()`, `run_once()`, and `stop()` methods for daemon process management.
 
-use super::hooks::{self, HookType, fire_hook};
+use super::hooks::{self, GateContext, GateType, HookType, fire_hook};
 use super::{SUPERVISOR, Supervisor};
 use crate::daemon::RunOptions;
 use crate::daemon_id::DaemonId;
@@ -148,6 +148,17 @@ impl Supervisor {
         let id = &opts.id;
         let original_cmd = opts.cmd.clone(); // Save original command for persistence
         let cmd = opts.cmd;
+
+        // Run pre_start gate (blocks until success or failure)
+        GateContext::new(
+            GateType::PreStart,
+            id.clone(),
+            opts.dir.0.clone(),
+            opts.retry_count,
+            opts.env.clone(),
+        )
+        .run()
+        .await?;
 
         // Create channel for readiness notification if wait_ready is true
         let (ready_tx, ready_rx) = if opts.wait_ready {
@@ -1075,6 +1086,16 @@ impl Supervisor {
             match ready_rx.await {
                 Ok(Ok(())) => {
                     info!("daemon {id} is ready");
+                    // Run post_start gate after daemon is ready
+                    GateContext::new(
+                        GateType::PostStart,
+                        id.clone(),
+                        opts.dir.0.clone(),
+                        opts.retry_count,
+                        opts.env.clone(),
+                    )
+                    .run()
+                    .await?;
                     Ok(IpcResponse::DaemonReady { daemon })
                 }
                 Ok(Err(exit_code)) => {
@@ -1087,6 +1108,28 @@ impl Supervisor {
                 }
             }
         } else {
+            // Non-waiting start: fire post_start gate in background after a brief
+            // delay to allow the process to initialize. The gate runs as a
+            // fire-and-forget task since the caller has already returned.
+            let gate_id = id.clone();
+            let gate_dir = opts.dir.0.clone();
+            let gate_retry_count = opts.retry_count;
+            let gate_env = opts.env.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                if let Err(e) = GateContext::new(
+                    GateType::PostStart,
+                    gate_id.clone(),
+                    gate_dir,
+                    gate_retry_count,
+                    gate_env,
+                )
+                .run()
+                .await
+                {
+                    warn!("post_start gate for daemon {gate_id} failed: {e}");
+                }
+            });
             Ok(IpcResponse::DaemonStart { daemon })
         }
     }
@@ -1103,6 +1146,18 @@ impl Supervisor {
         if let Some(daemon) = self.get_daemon(id).await {
             trace!("daemon to stop: {daemon}");
             if let Some(pid) = daemon.pid {
+                // Run pre_stop gate before stopping the daemon
+                let daemon_dir = daemon.dir.clone().unwrap_or_else(|| env::CWD.clone());
+                let daemon_env = daemon.env.clone();
+                GateContext::new(
+                    GateType::PreStop,
+                    id.clone(),
+                    daemon_dir.clone(),
+                    daemon.retry_count,
+                    daemon_env,
+                )
+                .run()
+                .await?;
                 trace!("killing pid: {pid}");
                 PROCS.refresh_pids(&[pid]);
                 if PROCS.is_running(pid) {
@@ -1162,6 +1217,23 @@ impl Supervisor {
                             .build(),
                     )
                     .await?;
+
+                    // Run post_stop gate after daemon has stopped
+                    let post_stop_dir = daemon.dir.clone().unwrap_or_else(|| env::CWD.clone());
+                    let post_stop_env = daemon.env.clone();
+                    GateContext::new(
+                        GateType::PostStop,
+                        id.clone(),
+                        post_stop_dir,
+                        daemon.retry_count,
+                        post_stop_env,
+                    )
+                    .extra_env(vec![
+                        ("PITCHFORK_EXIT_CODE".to_string(), "-1".to_string()),
+                        ("PITCHFORK_EXIT_REASON".to_string(), "stop".to_string()),
+                    ])
+                    .run()
+                    .await?;
                 } else {
                     debug!("pid {pid} not running, process may have exited unexpectedly");
                     // Process already dead, directly mark as stopped
@@ -1175,10 +1247,46 @@ impl Supervisor {
                             .build(),
                     )
                     .await?;
+
+                    // Run post_stop gate even when process was already dead
+                    let post_stop_dir = daemon.dir.clone().unwrap_or_else(|| env::CWD.clone());
+                    let post_stop_env = daemon.env.clone();
+                    GateContext::new(
+                        GateType::PostStop,
+                        id.clone(),
+                        post_stop_dir,
+                        daemon.retry_count,
+                        post_stop_env,
+                    )
+                    .extra_env(vec![
+                        ("PITCHFORK_EXIT_CODE".to_string(), "-1".to_string()),
+                        ("PITCHFORK_EXIT_REASON".to_string(), "stop".to_string()),
+                    ])
+                    .run()
+                    .await?;
+
                     return Ok(IpcResponse::DaemonWasNotRunning);
                 }
                 Ok(IpcResponse::Ok)
             } else {
+                // Daemon exists in state but has no PID — it may have already
+                // exited. Run post_stop gate for cleanup, then report status.
+                let post_stop_dir = daemon.dir.clone().unwrap_or_else(|| env::CWD.clone());
+                let post_stop_env = daemon.env.clone();
+                GateContext::new(
+                    GateType::PostStop,
+                    id.clone(),
+                    post_stop_dir,
+                    daemon.retry_count,
+                    post_stop_env,
+                )
+                .extra_env(vec![
+                    ("PITCHFORK_EXIT_CODE".to_string(), "-1".to_string()),
+                    ("PITCHFORK_EXIT_REASON".to_string(), "stop".to_string()),
+                ])
+                .run()
+                .await?;
+
                 debug!("daemon {id} not running");
                 Ok(IpcResponse::DaemonNotRunning)
             }

--- a/tests/test_gates.rs
+++ b/tests/test_gates.rs
@@ -1,0 +1,598 @@
+mod common;
+
+use common::TestEnv;
+use std::time::Duration;
+
+/// Test that pre_start gate blocks daemon start until it succeeds
+#[test]
+fn test_gate_pre_start_passes() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let marker = env.marker_path("pre_start_pass");
+
+    let toml_content = format!(
+        r#"
+[daemons.pre_start_pass_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.pre_start_pass_test.gates]
+pre_start = "touch {}"
+"#,
+        marker.display()
+    );
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "pre_start_pass_test"]);
+    assert!(
+        output.status.success(),
+        "Start should succeed when pre_start gate passes: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        marker.exists(),
+        "pre_start gate should have created marker file"
+    );
+
+    env.run_command(&["stop", "pre_start_pass_test"]);
+}
+
+/// Test that pre_start gate failure prevents daemon from starting
+#[test]
+fn test_gate_pre_start_fails_blocks_start() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let toml_content = r#"
+[daemons.pre_start_fail_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.pre_start_fail_test.gates]
+pre_start = "exit 1"
+"#
+    .to_string();
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "pre_start_fail_test"]);
+    assert!(
+        !output.status.success(),
+        "Start should fail when pre_start gate fails"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("pre_start gate") || stderr.contains("exited with"),
+        "Error should mention gate failure: {stderr}"
+    );
+}
+
+/// Test that pre_start gate timeout kills the gate and fails the start
+#[test]
+fn test_gate_pre_start_timeout() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let toml_content = r#"
+[daemons.pre_start_timeout_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.pre_start_timeout_test.gates]
+pre_start = { run = "sleep 300", timeout = "1s" }
+"#
+    .to_string();
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "pre_start_timeout_test"]);
+    assert!(
+        !output.status.success(),
+        "Start should fail when pre_start gate times out"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("timed out"),
+        "Error should mention timeout: {stderr}"
+    );
+}
+
+/// Test that post_start gate runs after daemon becomes ready (wait_ready mode)
+#[test]
+fn test_gate_post_start_wait_ready() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let marker = env.marker_path("post_start_wait");
+
+    let toml_content = format!(
+        r#"
+[daemons.post_start_wait_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.post_start_wait_test.gates]
+post_start = "touch {}"
+"#,
+        marker.display()
+    );
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "post_start_wait_test"]);
+    assert!(
+        output.status.success(),
+        "Start should succeed when post_start gate passes: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        marker.exists(),
+        "post_start gate should have created marker file"
+    );
+
+    env.run_command(&["stop", "post_start_wait_test"]);
+}
+
+/// Test that post_start gate failure returns error in wait_ready mode
+#[test]
+fn test_gate_post_start_fail_wait_ready() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let toml_content = r#"
+[daemons.post_start_fail_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.post_start_fail_test.gates]
+post_start = "exit 1"
+"#
+    .to_string();
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "post_start_fail_test"]);
+    assert!(
+        !output.status.success(),
+        "Start should fail when post_start gate fails in wait_ready mode"
+    );
+}
+
+/// Test that pre_stop gate runs before daemon is stopped
+#[test]
+fn test_gate_pre_stop() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let marker = env.marker_path("pre_stop");
+
+    let toml_content = format!(
+        r#"
+[daemons.pre_stop_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.pre_stop_test.gates]
+pre_stop = "touch {}"
+"#,
+        marker.display()
+    );
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "pre_stop_test"]);
+    assert!(
+        output.status.success(),
+        "Start should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Marker should NOT exist yet (pre_stop runs on stop, not start)
+    assert!(!marker.exists(), "pre_stop gate should not have run yet");
+
+    let output = env.run_command(&["stop", "pre_stop_test"]);
+    assert!(
+        output.status.success(),
+        "Stop should succeed when pre_stop gate passes: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        marker.exists(),
+        "pre_stop gate should have created marker file"
+    );
+}
+
+/// Test that pre_stop gate failure prevents daemon from being stopped
+#[test]
+fn test_gate_pre_stop_fails_blocks_stop() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let toml_content = r#"
+[daemons.pre_stop_fail_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.pre_stop_fail_test.gates]
+pre_stop = "exit 1"
+"#
+    .to_string();
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "pre_stop_fail_test"]);
+    assert!(
+        output.status.success(),
+        "Start should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = env.run_command(&["stop", "pre_stop_fail_test"]);
+    assert!(
+        !output.status.success(),
+        "Stop should fail when pre_stop gate fails"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("pre_stop gate") || stderr.contains("exited with"),
+        "Error should mention gate failure: {stderr}"
+    );
+}
+
+/// Test that post_stop gate runs after daemon has stopped
+#[test]
+fn test_gate_post_stop() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let marker = env.marker_path("post_stop");
+
+    let toml_content = format!(
+        r#"
+[daemons.post_stop_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.post_stop_test.gates]
+post_stop = "touch {}"
+"#,
+        marker.display()
+    );
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "post_stop_test"]);
+    assert!(
+        output.status.success(),
+        "Start should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Marker should NOT exist yet (post_stop runs after stop)
+    assert!(!marker.exists(), "post_stop gate should not have run yet");
+
+    let output = env.run_command(&["stop", "post_stop_test"]);
+    assert!(
+        output.status.success(),
+        "Stop should succeed when post_stop gate passes: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        marker.exists(),
+        "post_stop gate should have created marker file"
+    );
+}
+
+/// Test that post_stop gate receives PITCHFORK_EXIT_CODE and PITCHFORK_EXIT_REASON env vars
+#[test]
+fn test_gate_post_stop_env_vars() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let marker = env.marker_path("post_stop_env");
+
+    let toml_content = format!(
+        r#"
+[daemons.post_stop_env_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.post_stop_env_test.gates]
+post_stop = "sh -c 'echo $PITCHFORK_EXIT_CODE $PITCHFORK_EXIT_REASON > {}'"
+"#,
+        marker.display()
+    );
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "post_stop_env_test"]);
+    assert!(
+        output.status.success(),
+        "Start should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = env.run_command(&["stop", "post_stop_env_test"]);
+    assert!(
+        output.status.success(),
+        "Stop should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Poll for marker content
+    let mut content = String::new();
+    for _ in 0..30 {
+        content = std::fs::read_to_string(&marker).unwrap_or_default();
+        if !content.trim().is_empty() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    assert!(
+        marker.exists(),
+        "post_stop gate should have created marker file"
+    );
+    assert_eq!(
+        content.trim(),
+        "-1 stop",
+        "post_stop gate should receive PITCHFORK_EXIT_CODE=-1 and PITCHFORK_EXIT_REASON=stop"
+    );
+}
+
+/// Test that gate commands receive PITCHFORK_DAEMON_ID and PITCHFORK_RETRY_COUNT env vars
+#[test]
+fn test_gate_env_vars() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let marker = env.marker_path("gate_env");
+
+    let toml_content = format!(
+        r#"
+[daemons.gate_env_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.gate_env_test.gates]
+pre_start = "sh -c 'echo $PITCHFORK_DAEMON_ID $PITCHFORK_RETRY_COUNT > {}'"
+"#,
+        marker.display()
+    );
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "gate_env_test"]);
+    assert!(
+        output.status.success(),
+        "Start should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Poll for marker content
+    let mut content = String::new();
+    for _ in 0..30 {
+        content = std::fs::read_to_string(&marker).unwrap_or_default();
+        if !content.trim().is_empty() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    assert!(
+        marker.exists(),
+        "pre_start gate should have created marker file"
+    );
+    assert_eq!(
+        content.trim(),
+        "project/gate_env_test 0",
+        "Gate should receive PITCHFORK_DAEMON_ID and PITCHFORK_RETRY_COUNT=0"
+    );
+
+    env.run_command(&["stop", "gate_env_test"]);
+}
+
+/// Test that gate shorthand form (string) works
+#[test]
+fn test_gate_shorthand_form() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let marker = env.marker_path("gate_shorthand");
+
+    let toml_content = format!(
+        r#"
+[daemons.gate_shorthand_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.gate_shorthand_test.gates]
+pre_start = "touch {}"
+"#,
+        marker.display()
+    );
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "gate_shorthand_test"]);
+    assert!(
+        output.status.success(),
+        "Start should succeed with shorthand gate form: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        marker.exists(),
+        "Shorthand gate should have created marker file"
+    );
+
+    env.run_command(&["stop", "gate_shorthand_test"]);
+}
+
+/// Test that gate full form (object with timeout) works
+#[test]
+fn test_gate_full_form_with_timeout() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let marker = env.marker_path("gate_full_form");
+
+    let toml_content = format!(
+        r#"
+[daemons.gate_full_form_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.gate_full_form_test.gates]
+pre_start = {{ run = "touch {}", timeout = "30s" }}
+"#,
+        marker.display()
+    );
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "gate_full_form_test"]);
+    assert!(
+        output.status.success(),
+        "Start should succeed with full form gate: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        marker.exists(),
+        "Full form gate should have created marker file"
+    );
+
+    env.run_command(&["stop", "gate_full_form_test"]);
+}
+
+/// Test that no gate configured means the lifecycle proceeds normally
+#[test]
+fn test_no_gate_configured() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let toml_content = r#"
+[daemons.no_gate_test]
+run = "sleep 60"
+ready_delay = 1
+"#
+    .to_string();
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "no_gate_test"]);
+    assert!(
+        output.status.success(),
+        "Start should succeed when no gate is configured: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    env.run_command(&["stop", "no_gate_test"]);
+}
+
+/// Test that post_stop gate runs even when process was already dead
+#[test]
+fn test_gate_post_stop_already_dead() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let marker = env.marker_path("post_stop_dead");
+
+    let toml_content = format!(
+        r#"
+[daemons.post_stop_dead_test]
+run = "sh -c 'sleep 1 && exit 0'"
+ready_delay = 1
+
+[daemons.post_stop_dead_test.gates]
+post_stop = "touch {}"
+"#,
+        marker.display()
+    );
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "post_stop_dead_test"]);
+    // Daemon exits quickly, start may or may not succeed depending on timing
+    eprintln!("start stdout: {}", String::from_utf8_lossy(&output.stdout));
+    eprintln!("start stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    // Wait for daemon to exit
+    std::thread::sleep(Duration::from_secs(2));
+
+    // Stop the already-dead daemon — post_stop gate should still run
+    let output = env.run_command(&["stop", "post_stop_dead_test"]);
+    eprintln!("stop stdout: {}", String::from_utf8_lossy(&output.stdout));
+    eprintln!("stop stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    // Poll for marker file
+    for _ in 0..30 {
+        if marker.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    assert!(
+        marker.exists(),
+        "post_stop gate should run even when process was already dead"
+    );
+}
+
+/// Test that multiple gates work together (pre_start + post_start + pre_stop + post_stop)
+#[test]
+fn test_gate_all_four_lifecycle_points() {
+    let env = TestEnv::new();
+    env.ensure_binary_exists().unwrap();
+
+    let pre_start_marker = env.marker_path("all_pre_start");
+    let post_start_marker = env.marker_path("all_post_start");
+    let pre_stop_marker = env.marker_path("all_pre_stop");
+    let post_stop_marker = env.marker_path("all_post_stop");
+
+    let toml_content = format!(
+        r#"
+[daemons.all_gates_test]
+run = "sleep 60"
+ready_delay = 1
+
+[daemons.all_gates_test.gates]
+pre_start = "touch {}"
+post_start = "touch {}"
+pre_stop = "touch {}"
+post_stop = "touch {}"
+"#,
+        pre_start_marker.display(),
+        post_start_marker.display(),
+        pre_stop_marker.display(),
+        post_stop_marker.display()
+    );
+    env.create_toml(&toml_content);
+
+    let output = env.run_command(&["start", "all_gates_test"]);
+    assert!(
+        output.status.success(),
+        "Start should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(pre_start_marker.exists(), "pre_start gate should have run");
+    assert!(
+        post_start_marker.exists(),
+        "post_start gate should have run"
+    );
+    assert!(
+        !pre_stop_marker.exists(),
+        "pre_stop gate should not have run yet"
+    );
+    assert!(
+        !post_stop_marker.exists(),
+        "post_stop gate should not have run yet"
+    );
+
+    let output = env.run_command(&["stop", "all_gates_test"]);
+    assert!(
+        output.status.success(),
+        "Stop should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(pre_stop_marker.exists(), "pre_stop gate should have run");
+    assert!(post_stop_marker.exists(), "post_stop gate should have run");
+}


### PR DESCRIPTION
addresses #449.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle gates (pre_start, post_start, pre_stop, post_stop) with per-gate timeouts, env vars, blocking behavior, and TOML support; global supervisor.gate_timeout (default 30s, 0s = disabled). Post-start runs synchronously when waiting for readiness, otherwise scheduled as fire‑and‑forget.

* **Documentation**
  * How‑To guide renamed to “Lifecycle Hooks & Gates”, expanded with gate behavior, env var lists, examples, and hooks‑vs‑gates comparison.

* **Schema**
  * Public schema extended with gate config types and supervisor.gate_timeout.

* **Tests**
  * Integration tests covering gate ordering, timeouts, env vars, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->