### PR TITLE
chore: move pitchfork back to jdx

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,7 +17,7 @@ jobs:
   release-plz-release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.repository_owner == 'endevco' }}
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'jdx' }}
     permissions:
       contents: write
       pull-requests: write
@@ -72,7 +72,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      - name: Append en.dev sponsor blurb
+      - name: Append sponsor blurb
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
         run: |
@@ -87,9 +87,9 @@ jobs:
 
           ## 💚 Sponsor pitchfork
 
-          pitchfork is built by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev) — an independent studio shipping developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, pitchfork, and more. Development is sustained by sponsorships.
+          pitchfork is built by [@jdx](https://github.com/jdx), who ships developer tools like [mise](https://mise.jdx.dev/), hk, pitchfork, and more. Development is sustained by sponsorships.
 
-          If pitchfork has a place in your dev workflow, please consider [sponsoring at en.dev](https://en.dev). Individual and company sponsorships are what keep the project healthy and moving forward.
+          If pitchfork has a place in your dev workflow, please consider [sponsoring on GitHub](https://github.com/sponsors/jdx). Individual and company sponsorships are what keep the project healthy and moving forward.
           EOF
           } > /tmp/release-notes.md
           gh release edit "$TAG" --notes-file /tmp/release-notes.md
@@ -97,7 +97,7 @@ jobs:
   release-plz-pr:
     name: Release PR
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.repository_owner == 'endevco' }}
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'jdx' }}
     permissions:
       contents: write
       pull-requests: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,97 +7,97 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.13.0](https://github.com/endevco/pitchfork/compare/v2.12.1...v2.13.0) - 2026-06-07
+## [2.13.0](https://github.com/jdx/pitchfork/compare/v2.12.1...v2.13.0) - 2026-06-07
 
 ### Added
 
-- *(cli)* rename `pf config` to `pf daemons` and add `pf settings` subcommand ([#471](https://github.com/endevco/pitchfork/pull/471))
-- *(logs)* add log rotate ([#470](https://github.com/endevco/pitchfork/pull/470))
-- *(list)* always display fully-qualified daemon names ([#467](https://github.com/endevco/pitchfork/pull/467))
-- *(cron)* add `immediate` config to control the behaviour on start ([#461](https://github.com/endevco/pitchfork/pull/461))
-- add sponsors command ([#458](https://github.com/endevco/pitchfork/pull/458))
+- *(cli)* rename `pf config` to `pf daemons` and add `pf settings` subcommand ([#471](https://github.com/jdx/pitchfork/pull/471))
+- *(logs)* add log rotate ([#470](https://github.com/jdx/pitchfork/pull/470))
+- *(list)* always display fully-qualified daemon names ([#467](https://github.com/jdx/pitchfork/pull/467))
+- *(cron)* add `immediate` config to control the behaviour on start ([#461](https://github.com/jdx/pitchfork/pull/461))
+- add sponsors command ([#458](https://github.com/jdx/pitchfork/pull/458))
 
 ### Other
 
-- *(web-ui)* refactor with Vue SPA + separate API endpoints ([#457](https://github.com/endevco/pitchfork/pull/457))
+- *(web-ui)* refactor with Vue SPA + separate API endpoints ([#457](https://github.com/jdx/pitchfork/pull/457))
 
-## [2.12.1](https://github.com/endevco/pitchfork/compare/v2.12.0...v2.12.1) - 2026-05-28
+## [2.12.1](https://github.com/jdx/pitchfork/compare/v2.12.0...v2.12.1) - 2026-05-28
 
 ### Fixed
 
-- *(procs)* show process-tree daemon metrics ([#435](https://github.com/endevco/pitchfork/pull/435))
-- get running command directly in cron/watch instead of getting from DaemonId ([#453](https://github.com/endevco/pitchfork/pull/453))
+- *(procs)* show process-tree daemon metrics ([#435](https://github.com/jdx/pitchfork/pull/435))
+- get running command directly in cron/watch instead of getting from DaemonId ([#453](https://github.com/jdx/pitchfork/pull/453))
 
-## [2.12.0](https://github.com/endevco/pitchfork/compare/v2.11.0...v2.12.0) - 2026-05-27
+## [2.12.0](https://github.com/jdx/pitchfork/compare/v2.11.0...v2.12.0) - 2026-05-27
 
 ### Added
 
-- *(proxy)* support worktree ([#448](https://github.com/endevco/pitchfork/pull/448))
-- *(cli)* stream output on CLI command start ([#444](https://github.com/endevco/pitchfork/pull/444))
+- *(proxy)* support worktree ([#448](https://github.com/jdx/pitchfork/pull/448))
+- *(cli)* stream output on CLI command start ([#444](https://github.com/jdx/pitchfork/pull/444))
 
 ### Fixed
 
-- *(web)* close web log SSE streams on navigation ([#447](https://github.com/endevco/pitchfork/pull/447))
+- *(web)* close web log SSE streams on navigation ([#447](https://github.com/jdx/pitchfork/pull/447))
 
 ### Other
 
-- avoid state file frequently write to disk ([#446](https://github.com/endevco/pitchfork/pull/446))
+- avoid state file frequently write to disk ([#446](https://github.com/jdx/pitchfork/pull/446))
 
-## [2.11.0](https://github.com/endevco/pitchfork/compare/v2.10.0...v2.11.0) - 2026-05-17
+## [2.11.0](https://github.com/jdx/pitchfork/compare/v2.10.0...v2.11.0) - 2026-05-17
 
 ### Added
 
-- *(config)* support ready_http status codes ([#437](https://github.com/endevco/pitchfork/pull/437))
-- *(config)* impl daemon group ([#442](https://github.com/endevco/pitchfork/pull/442))
-- *(proxy)* auto trust if possible ([#431](https://github.com/endevco/pitchfork/pull/431))
-- *(proxy)* support LAN mode with mDNS ([#430](https://github.com/endevco/pitchfork/pull/430))
-- *(proxy)* support wildcard subdomain ([#426](https://github.com/endevco/pitchfork/pull/426))
+- *(config)* support ready_http status codes ([#437](https://github.com/jdx/pitchfork/pull/437))
+- *(config)* impl daemon group ([#442](https://github.com/jdx/pitchfork/pull/442))
+- *(proxy)* auto trust if possible ([#431](https://github.com/jdx/pitchfork/pull/431))
+- *(proxy)* support LAN mode with mDNS ([#430](https://github.com/jdx/pitchfork/pull/430))
+- *(proxy)* support wildcard subdomain ([#426](https://github.com/jdx/pitchfork/pull/426))
 
 ### Other
 
-- avoid refresh full pid tree when Procs::new() ([#441](https://github.com/endevco/pitchfork/pull/441))
-- *(build)* suit for non-Windows/MacOS/Linux build ([#429](https://github.com/endevco/pitchfork/pull/429))
+- avoid refresh full pid tree when Procs::new() ([#441](https://github.com/jdx/pitchfork/pull/441))
+- *(build)* suit for non-Windows/MacOS/Linux build ([#429](https://github.com/jdx/pitchfork/pull/429))
 
-## [2.10.0](https://github.com/endevco/pitchfork/compare/v2.9.1...v2.10.0) - 2026-05-05
+## [2.10.0](https://github.com/jdx/pitchfork/compare/v2.9.1...v2.10.0) - 2026-05-05
 
 ### Added
 
-- refine startup / tailing logs display ([#420](https://github.com/endevco/pitchfork/pull/420))
-- *(proxy)* sync slug hosts ([#418](https://github.com/endevco/pitchfork/pull/418))
-- inject daemon running info to tera template ([#419](https://github.com/endevco/pitchfork/pull/419))
+- refine startup / tailing logs display ([#420](https://github.com/jdx/pitchfork/pull/420))
+- *(proxy)* sync slug hosts ([#418](https://github.com/jdx/pitchfork/pull/418))
+- inject daemon running info to tera template ([#419](https://github.com/jdx/pitchfork/pull/419))
 
 ### Fixed
 
-- *(boot-start)* use LaunchDaemon on MacOS ([#423](https://github.com/endevco/pitchfork/pull/423))
+- *(boot-start)* use LaunchDaemon on MacOS ([#423](https://github.com/jdx/pitchfork/pull/423))
 
 ### Other
 
-- *(build)* use serious profile to eliminate binary size ([#424](https://github.com/endevco/pitchfork/pull/424))
-- set dev profile debug to 1 ([#415](https://github.com/endevco/pitchfork/pull/415))
+- *(build)* use serious profile to eliminate binary size ([#424](https://github.com/jdx/pitchfork/pull/424))
+- set dev profile debug to 1 ([#415](https://github.com/jdx/pitchfork/pull/415))
 
-## [2.9.1](https://github.com/endevco/pitchfork/compare/v2.9.0...v2.9.1) - 2026-05-03
-
-### Fixed
-
-- *(build)* restore Windows compile and add windows CI job ([#410](https://github.com/endevco/pitchfork/pull/410))
-
-## [2.9.0](https://github.com/endevco/pitchfork/compare/v2.8.0...v2.9.0) - 2026-05-03
-
-### Added
-
-- keep ANSI by default and impl PTY mode ([#408](https://github.com/endevco/pitchfork/pull/408))
-- customize stop signal and refactor config types ([#406](https://github.com/endevco/pitchfork/pull/406))
-- add hook `on_output` ([#399](https://github.com/endevco/pitchfork/pull/399))
-
-## [2.8.0](https://github.com/endevco/pitchfork/compare/v2.7.0...v2.8.0) - 2026-04-28
-
-### Added
-
-- *(boot-start)* support system level register ([#397](https://github.com/endevco/pitchfork/pull/397))
+## [2.9.1](https://github.com/jdx/pitchfork/compare/v2.9.0...v2.9.1) - 2026-05-03
 
 ### Fixed
 
-- *(tui)* remove blocking loading ([#394](https://github.com/endevco/pitchfork/pull/394))
+- *(build)* restore Windows compile and add windows CI job ([#410](https://github.com/jdx/pitchfork/pull/410))
+
+## [2.9.0](https://github.com/jdx/pitchfork/compare/v2.8.0...v2.9.0) - 2026-05-03
+
+### Added
+
+- keep ANSI by default and impl PTY mode ([#408](https://github.com/jdx/pitchfork/pull/408))
+- customize stop signal and refactor config types ([#406](https://github.com/jdx/pitchfork/pull/406))
+- add hook `on_output` ([#399](https://github.com/jdx/pitchfork/pull/399))
+
+## [2.8.0](https://github.com/jdx/pitchfork/compare/v2.7.0...v2.8.0) - 2026-04-28
+
+### Added
+
+- *(boot-start)* support system level register ([#397](https://github.com/jdx/pitchfork/pull/397))
+
+### Fixed
+
+- *(tui)* remove blocking loading ([#394](https://github.com/jdx/pitchfork/pull/394))
 
 ## [2.7.0](https://github.com/jdx/pitchfork/compare/v2.6.0...v2.7.0) - 2026-04-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ license = "MIT"
 version = "2.13.0"
 edition = "2024"
 rust-version = "1.87"
-homepage = "https://pitchfork.en.dev"
+homepage = "https://pitchfork.jdx.dev"
 repository = "https://github.com/jdx/pitchfork"
-documentation = "https://pitchfork.en.dev"
+documentation = "https://pitchfork.jdx.dev"
 build = "build.rs"
 include = [
     "src/**/*.rs",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 <h1 align="center">
-  <a href="https://pitchfork.en.dev">
+  <a href="https://pitchfork.jdx.dev">
     <img src="docs/public/img/logo.png" alt="pitchfork" width="256" height="256" />
     <br>
     pitchfork
@@ -17,9 +17,9 @@
 <p><b>Daemons with DX</b></p>
 
 <p align="center">
-  <a href="https://pitchfork.en.dev/quickstart.html">Quick Start</a> •
-  <a href="https://pitchfork.en.dev">Documentation</a> •
-  <a href="https://pitchfork.en.dev/cli">CLI Reference</a>
+  <a href="https://pitchfork.jdx.dev/quickstart.html">Quick Start</a> •
+  <a href="https://pitchfork.jdx.dev">Documentation</a> •
+  <a href="https://pitchfork.jdx.dev/cli">CLI Reference</a>
 </p>
 
 <p align="center">
@@ -172,7 +172,7 @@ $ pitchfork start --all
 
 ## Full Documentation
 
-See [pitchfork.en.dev](https://pitchfork.en.dev)
+See [pitchfork.jdx.dev](https://pitchfork.jdx.dev)
 
 ## Contributors
 

--- a/communique.toml
+++ b/communique.toml
@@ -1,6 +1,6 @@
 context = "pitchfork is a daemon supervisor CLI for developers. It manages background processes with features like auto-start/stop, cron scheduling, retry logic, and HTTP ready checks."
 
-system_extra = "Do not include a 'Sponsor pitchfork' section, sponsorship blurb, or any en.dev/funding callout in the generated notes. A sponsor section is appended by a separate CI step; emitting one here causes a duplicate."
+system_extra = "Do not include a 'Sponsor pitchfork' section, sponsorship blurb, or any funding callout in the generated notes. A sponsor section is appended by a separate CI step; emitting one here causes a duplicate."
 
 [defaults]
 emoji = false

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -155,7 +155,7 @@ export default defineConfig({
       "meta",
       {
         property: "og:image",
-        content: "https://pitchfork.en.dev/img/android-chrome-512x512.png",
+        content: "https://pitchfork.jdx.dev/img/android-chrome-512x512.png",
       },
     ],
     ["meta", { name: "twitter:card", content: "summary" }],
@@ -163,7 +163,7 @@ export default defineConfig({
       "meta",
       {
         name: "twitter:image",
-        content: "https://pitchfork.en.dev/img/android-chrome-512x512.png",
+        content: "https://pitchfork.jdx.dev/img/android-chrome-512x512.png",
       },
     ],
   ],

--- a/docs/.vitepress/theme/EndevFooter.vue
+++ b/docs/.vitepress/theme/EndevFooter.vue
@@ -4,15 +4,15 @@
     <span aria-hidden="true">·</span>
     <span>Copyright © {{ year }}</span>
     <span aria-hidden="true">·</span>
-    <a class="EndevFooterLink" href="https://en.dev">
+    <a class="EndevFooterLink" href="https://jdx.dev">
       <img
         alt=""
         class="EndevFooterLogo"
         height="28"
-        src="https://github.com/endevco.png?size=96"
+        src="https://github.com/jdx.png?size=96"
         width="28"
       />
-      <span>en.dev</span>
+      <span>jdx.dev</span>
     </a>
   </footer>
 </template>

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -1,6 +1,5 @@
 <template>
   <section
-    v-if="sponsors.length || error"
     aria-labelledby="endev-sponsors-title"
     class="EndevSponsors"
   >
@@ -8,77 +7,12 @@
       <p id="endev-sponsors-title" class="EndevSponsorsTitle">
         sponsors
       </p>
-      <p v-if="error" class="EndevSponsorsError">
-        Sponsor feed unavailable.
-      </p>
-      <div v-else class="EndevSponsorsLogos">
-        <a
-          v-for="sponsor in sponsors"
-          :key="sponsor.url"
-          class="EndevSponsorsLogo"
-          :href="sponsor.url"
-          rel="noopener noreferrer sponsored"
-          target="_blank"
-        >
-          <img :alt="sponsor.name" :src="sponsor.logo" loading="lazy" decoding="async" />
-        </a>
-      </div>
-      <a class="EndevSponsorsCta" href="https://en.dev/sponsors.html">
-        View all sponsors
+      <a class="EndevSponsorsCta" href="https://github.com/sponsors/jdx">
+        Sponsor on GitHub
       </a>
     </div>
   </section>
 </template>
-
-<script setup>
-import { onMounted, ref } from "vue";
-
-const sponsors = ref([]);
-const error = ref(false);
-const footerTiers = new Set(["anchor", "premier", "partner"]);
-const sponsorFeedTimeoutMs = 5000;
-
-const sponsorItems = (items) => (Array.isArray(items) ? items : []);
-const isSafeUrl = (url) => {
-  try {
-    const { protocol } = new URL(url);
-    return protocol === "https:" || protocol === "http:";
-  } catch {
-    return false;
-  }
-};
-const isSponsor = (sponsor) =>
-  sponsor &&
-  typeof sponsor === "object" &&
-  typeof sponsor.name === "string" &&
-  typeof sponsor.url === "string" &&
-  typeof sponsor.logo === "string" &&
-  isSafeUrl(sponsor.url) &&
-  isSafeUrl(sponsor.logo);
-
-onMounted(async () => {
-  const controller = new AbortController();
-  const timeout = window.setTimeout(() => controller.abort(), sponsorFeedTimeoutMs);
-
-  try {
-    const res = await fetch("https://en.dev/sponsors.json", {
-      headers: { Accept: "application/json" },
-      signal: controller.signal,
-    });
-    if (!res.ok) throw new Error(`Sponsor feed returned ${res.status}`);
-
-    const payload = await res.json();
-    sponsors.value = sponsorItems(payload?.sponsors).filter((sponsor) =>
-      isSponsor(sponsor) && footerTiers.has(sponsor.tier),
-    );
-  } catch {
-    error.value = true;
-    sponsors.value = [];
-  } finally {
-    window.clearTimeout(timeout);
-  }
-});
-</script>
 
 <style scoped>
 .EndevSponsors {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1870,7 +1870,7 @@
         "flags": [],
         "mounts": [],
         "hide": false,
-        "help": "Show the companies sponsoring pitchfork and the en.dev project family",
+        "help": "Show the companies sponsoring pitchfork and the jdx project family",
         "name": "sponsors",
         "aliases": [],
         "hidden_aliases": [],

--- a/docs/cli/sponsors.md
+++ b/docs/cli/sponsors.md
@@ -3,4 +3,4 @@
 
 - **Usage**: `pitchfork sponsors`
 
-Show the companies sponsoring pitchfork and the en.dev project family
+Show the companies sponsoring pitchfork and the jdx project family

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -22,14 +22,14 @@ This mirrors [mise](https://mise.jdx.dev/configuration.html) behavior, allowing 
 
 A JSON Schema is available for editor autocompletion and validation:
 
-**URL:** [`https://pitchfork.en.dev/schema.json`](/schema.json)
+**URL:** [`https://pitchfork.jdx.dev/schema.json`](/schema.json)
 
 ### Editor Setup
 
 **VS Code** with [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml):
 
 ```toml
-#:schema https://pitchfork.en.dev/schema.json
+#:schema https://pitchfork.jdx.dev/schema.json
 
 [daemons.api]
 run = "npm run server"

--- a/pitchfork.toml
+++ b/pitchfork.toml
@@ -1,4 +1,4 @@
-#:schema https://pitchfork.en.dev/schema.json
+#:schema https://pitchfork.jdx.dev/schema.json
 
 [daemons.docs]
 run = "mise run -q docs"

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -269,7 +269,7 @@ cmd settings help="View and modify pitchfork settings" {
         arg <VALUE> help="Value to set (type must match the setting: string, integer, boolean, or duration)"
     }
 }
-cmd sponsors help="Show the companies sponsoring pitchfork and the en.dev project family"
+cmd sponsors help="Show the companies sponsoring pitchfork and the jdx project family"
 cmd start help="Starts a daemon from a pitchfork.toml file" {
     alias s
     long_help "Starts a daemon from a pitchfork.toml file\n\nDaemons are defined in pitchfork.toml with a `[daemons.<name>]` section.\nThe command waits for the daemon to be ready before returning.\n\nExamples:\n  pitchfork start api           Start a single daemon\n  pitchfork start api worker    Start multiple daemons\n  pitchfork start --group backend Start all daemons in the 'backend' group\n  pitchfork start -l            Start all local daemons in pitchfork.toml\n  pitchfork start -g            Start all global daemons in config.toml\n  pitchfork start -a            Start all daemons (local and global)\n  pitchfork start api -f        Restart daemon if already running\n  pitchfork start api --delay 5 Wait 5 seconds for daemon to be ready\n  pitchfork start api --output 'Listening on'\n                                Wait for output pattern before ready\n  pitchfork start api --http http://localhost:8080/health\n                                Wait for HTTP endpoint to return 2xx\n  pitchfork start api --port 8080\n                                Wait for TCP port to be listening"

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -1,17 +1,17 @@
 use crate::Result;
 
-/// Show the companies sponsoring pitchfork and the en.dev project family
+/// Show the companies sponsoring pitchfork and the jdx project family
 #[derive(Debug, clap::Args)]
 pub struct Sponsors;
 
 impl Sponsors {
     pub async fn run() -> Result<()> {
         println!(
-            r#"pitchfork and the en.dev project family are sponsored by:
+            r#"pitchfork and the jdx project family are sponsored by:
 
   37signals - https://37signals.com
 
-View all sponsors: https://en.dev/sponsors.html"#
+View all sponsors: https://github.com/sponsors/jdx"#
         );
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub enum DaemonIdError {
     #[error("daemon ID cannot be empty")]
     #[diagnostic(
         code(pitchfork::daemon::empty_id),
-        url("https://pitchfork.en.dev/configuration"),
+        url("https://pitchfork.jdx.dev/configuration"),
         help("provide a non-empty identifier for the daemon")
     )]
     Empty,
@@ -25,7 +25,7 @@ pub enum DaemonIdError {
     #[error("daemon ID {component} cannot be empty")]
     #[diagnostic(
         code(pitchfork::daemon::empty_component),
-        url("https://pitchfork.en.dev/configuration"),
+        url("https://pitchfork.jdx.dev/configuration"),
         help("both namespace and name must be non-empty")
     )]
     EmptyComponent { component: String },
@@ -33,7 +33,7 @@ pub enum DaemonIdError {
     #[error("daemon ID '{id}' contains path separator '{sep}'")]
     #[diagnostic(
         code(pitchfork::daemon::path_separator),
-        url("https://pitchfork.en.dev/configuration"),
+        url("https://pitchfork.jdx.dev/configuration"),
         help("daemon IDs cannot contain '/' or '\\' to prevent path traversal")
     )]
     PathSeparator { id: String, sep: char },
@@ -41,7 +41,7 @@ pub enum DaemonIdError {
     #[error("daemon ID '{id}' contains parent directory reference '..'")]
     #[diagnostic(
         code(pitchfork::daemon::parent_dir_ref),
-        url("https://pitchfork.en.dev/configuration"),
+        url("https://pitchfork.jdx.dev/configuration"),
         help("daemon IDs cannot contain '..' to prevent path traversal")
     )]
     ParentDirRef { id: String },
@@ -49,7 +49,7 @@ pub enum DaemonIdError {
     #[error("daemon ID '{id}' contains reserved sequence '--'")]
     #[diagnostic(
         code(pitchfork::daemon::reserved_sequence),
-        url("https://pitchfork.en.dev/configuration"),
+        url("https://pitchfork.jdx.dev/configuration"),
         help("'--' is reserved for internal path encoding; use single dashes instead")
     )]
     ReservedSequence { id: String },
@@ -57,7 +57,7 @@ pub enum DaemonIdError {
     #[error("daemon ID component '{id}' starts or ends with a dash '-'")]
     #[diagnostic(
         code(pitchfork::daemon::leading_trailing_dash),
-        url("https://pitchfork.en.dev/configuration"),
+        url("https://pitchfork.jdx.dev/configuration"),
         help(
             "remove the leading or trailing dash (e.g. 'my-daemon' not '-my-daemon' or 'my-daemon-')"
         )
@@ -67,7 +67,7 @@ pub enum DaemonIdError {
     #[error("daemon ID '{id}' contains spaces")]
     #[diagnostic(
         code(pitchfork::daemon::contains_space),
-        url("https://pitchfork.en.dev/configuration"),
+        url("https://pitchfork.jdx.dev/configuration"),
         help("use hyphens or underscores instead of spaces (e.g., 'my-daemon' or 'my_daemon')")
     )]
     ContainsSpace { id: String },
@@ -75,7 +75,7 @@ pub enum DaemonIdError {
     #[error("daemon ID cannot be '.'")]
     #[diagnostic(
         code(pitchfork::daemon::current_dir),
-        url("https://pitchfork.en.dev/configuration"),
+        url("https://pitchfork.jdx.dev/configuration"),
         help("'.' refers to the current directory; use a descriptive name instead")
     )]
     CurrentDir,
@@ -83,7 +83,7 @@ pub enum DaemonIdError {
     #[error("daemon ID '{id}' contains non-printable or non-ASCII character")]
     #[diagnostic(
         code(pitchfork::daemon::invalid_chars),
-        url("https://pitchfork.en.dev/configuration"),
+        url("https://pitchfork.jdx.dev/configuration"),
         help(
             "daemon IDs must contain only printable ASCII characters (letters, numbers, hyphens, underscores, dots)"
         )
@@ -93,7 +93,7 @@ pub enum DaemonIdError {
     #[error("daemon ID '{id}' is missing namespace (expected format: namespace/name)")]
     #[diagnostic(
         code(pitchfork::daemon::missing_namespace),
-        url("https://pitchfork.en.dev/configuration"),
+        url("https://pitchfork.jdx.dev/configuration"),
         help("use qualified format like 'global/myapp' or 'project-name/daemon'")
     )]
     MissingNamespace { id: String },
@@ -123,7 +123,7 @@ pub enum DependencyError {
     #[error("daemon '{name}' not found in configuration")]
     #[diagnostic(
         code(pitchfork::deps::not_found),
-        url("https://pitchfork.en.dev/configuration#depends")
+        url("https://pitchfork.jdx.dev/configuration#depends")
     )]
     DaemonNotFound {
         name: String,
@@ -134,7 +134,7 @@ pub enum DependencyError {
     #[error("daemon '{daemon}' depends on '{dependency}' which is not defined")]
     #[diagnostic(
         code(pitchfork::deps::missing_dependency),
-        url("https://pitchfork.en.dev/configuration#depends"),
+        url("https://pitchfork.jdx.dev/configuration#depends"),
         help("add the missing daemon to your pitchfork.toml or remove it from the depends list")
     )]
     MissingDependency { daemon: String, dependency: String },
@@ -142,7 +142,7 @@ pub enum DependencyError {
     #[error("circular dependency detected involving: {}", involved.join(", "))]
     #[diagnostic(
         code(pitchfork::deps::circular),
-        url("https://pitchfork.en.dev/configuration#depends"),
+        url("https://pitchfork.jdx.dev/configuration#depends"),
         help("break the cycle by removing one of the dependencies")
     )]
     CircularDependency {
@@ -157,7 +157,7 @@ pub enum PortError {
     #[error("port {port} is already in use by process '{process}' (PID: {pid})")]
     #[diagnostic(
         code(pitchfork::port::in_use),
-        url("https://pitchfork.en.dev/configuration#port"),
+        url("https://pitchfork.jdx.dev/configuration#port"),
         help(
             "choose a different port, stop the existing process, or enable auto_bump_port to automatically find an available port"
         )
@@ -173,7 +173,7 @@ pub enum PortError {
     )]
     #[diagnostic(
         code(pitchfork::port::no_available_port),
-        url("https://pitchfork.en.dev/configuration#port"),
+        url("https://pitchfork.jdx.dev/configuration#port"),
         help("manually specify an available port or reduce the number of concurrent services")
     )]
     NoAvailablePort { start_port: u16, attempts: u32 },
@@ -204,7 +204,7 @@ pub enum ConfigParseError {
     #[error("invalid daemon name '{name}' in {}", path.display())]
     #[diagnostic(
         code(pitchfork::config::invalid_daemon_name),
-        url("https://pitchfork.en.dev/configuration"),
+        url("https://pitchfork.jdx.dev/configuration"),
         help("daemon names must be valid identifiers without spaces, '--', or special characters")
     )]
     InvalidDaemonName {
@@ -219,7 +219,7 @@ pub enum ConfigParseError {
     )]
     #[diagnostic(
         code(pitchfork::config::invalid_dependency),
-        url("https://pitchfork.en.dev/configuration#depends"),
+        url("https://pitchfork.jdx.dev/configuration#depends"),
         help(
             "dependency IDs must be valid daemon IDs; use 'name' for same namespace or 'namespace/name' for cross-namespace"
         )
@@ -238,7 +238,7 @@ pub enum ConfigParseError {
     )]
     #[diagnostic(
         code(pitchfork::config::namespace_collision),
-        url("https://pitchfork.en.dev/concepts/namespaces"),
+        url("https://pitchfork.jdx.dev/concepts/namespaces"),
         help(
             "rename one of the directories so that no two project configs share the same namespace"
         )
@@ -255,7 +255,7 @@ pub enum ConfigParseError {
     )]
     #[diagnostic(
         code(pitchfork::config::invalid_namespace),
-        url("https://pitchfork.en.dev/concepts/namespaces"),
+        url("https://pitchfork.jdx.dev/concepts/namespaces"),
         help(
             "set a valid top-level namespace in your pitchfork.toml, e.g. namespace = \"my-project\""
         )
@@ -331,7 +331,7 @@ pub enum IpcError {
     #[error("failed to connect to supervisor after {attempts} attempts")]
     #[diagnostic(
         code(pitchfork::ipc::connection_failed),
-        url("https://pitchfork.en.dev/supervisor")
+        url("https://pitchfork.jdx.dev/supervisor")
     )]
     ConnectionFailed {
         attempts: u32,
@@ -344,7 +344,7 @@ pub enum IpcError {
     #[error("IPC request timed out after {seconds}s")]
     #[diagnostic(
         code(pitchfork::ipc::timeout),
-        url("https://pitchfork.en.dev/supervisor"),
+        url("https://pitchfork.jdx.dev/supervisor"),
         help(
             "the supervisor may be unresponsive or overloaded.\nCheck supervisor status: pitchfork supervisor status\nView logs: pitchfork logs"
         )
@@ -354,7 +354,7 @@ pub enum IpcError {
     #[error("IPC connection closed unexpectedly")]
     #[diagnostic(
         code(pitchfork::ipc::connection_closed),
-        url("https://pitchfork.en.dev/supervisor"),
+        url("https://pitchfork.jdx.dev/supervisor"),
         help(
             "the supervisor may have crashed or been stopped.\nRestart with: pitchfork supervisor start"
         )

--- a/tests/test_hooks.rs
+++ b/tests/test_hooks.rs
@@ -1,7 +1,20 @@
 mod common;
 
 use common::TestEnv;
+use std::path::Path;
 use std::time::Duration;
+
+fn wait_for_marker_content(path: &Path, expected: &str) -> String {
+    let mut content = String::new();
+    for _ in 0..30 {
+        content = std::fs::read_to_string(path).unwrap_or_default();
+        if content.trim() == expected {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    content
+}
 
 /// Test that the on_ready hook fires when a daemon becomes ready
 #[test]
@@ -393,19 +406,7 @@ on_stop = "sh -c 'echo $PITCHFORK_EXIT_REASON > {}'"
 
     env.run_command(&["stop", "stop_reason_test"]);
 
-    // Poll for marker file
-    for _ in 0..30 {
-        if marker.exists() {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(200));
-    }
-    assert!(
-        marker.exists(),
-        "on_stop hook should have created marker file"
-    );
-
-    let content = std::fs::read_to_string(&marker).unwrap();
+    let content = wait_for_marker_content(&marker, "stop");
     assert_eq!(
         content.trim(),
         "stop",
@@ -480,19 +481,7 @@ on_exit = "sh -c 'echo $PITCHFORK_EXIT_REASON > {}'"
     let output = env.run_command(&["start", "exit_fail_test"]);
     println!("start stdout: {}", String::from_utf8_lossy(&output.stdout));
 
-    // Poll for marker file
-    for _ in 0..30 {
-        if marker.exists() {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(200));
-    }
-    assert!(
-        marker.exists(),
-        "on_exit hook should fire when daemon crashes"
-    );
-
-    let content = std::fs::read_to_string(&marker).unwrap();
+    let content = wait_for_marker_content(&marker, "fail");
     assert_eq!(
         content.trim(),
         "fail",
@@ -524,19 +513,7 @@ on_exit = "sh -c 'echo $PITCHFORK_EXIT_REASON > {}'"
     let output = env.run_command(&["start", "exit_clean_test"]);
     println!("start stdout: {}", String::from_utf8_lossy(&output.stdout));
 
-    // Poll for marker file
-    for _ in 0..30 {
-        if marker.exists() {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(200));
-    }
-    assert!(
-        marker.exists(),
-        "on_exit hook should fire when daemon exits cleanly on its own"
-    );
-
-    let content = std::fs::read_to_string(&marker).unwrap();
+    let content = wait_for_marker_content(&marker, "exit");
     assert_eq!(
         content.trim(),
         "exit",


### PR DESCRIPTION
## Summary
- move project docs and metadata from pitchfork.en.dev to pitchfork.jdx.dev
- switch recent release/changelog and automation references from endevco/pitchfork to jdx/pitchfork
- simplify sponsor links to jdx GitHub Sponsors
- make hook exit-reason tests wait for marker content to avoid shell redirection races

## Checks
- mise run render
- mise run docs:build
- cargo fmt --check
- cargo nextest run test_hook_on_exit_on_fail
- cargo nextest run --test test_hooks
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly URLs, docs, and release-note copy; release-plz only runs for owner `jdx`. Hook test changes are test-only reliability fixes with no runtime behavior change.
> 
> **Overview**
> Rebrands pitchfork from **en.dev** / **endevco** to **jdx**: docs and package metadata now point at `pitchfork.jdx.dev`, changelog and GitHub links use `jdx/pitchfork`, and miette help URLs in `src/error.rs` follow the new domain.
> 
> **Release automation** runs release-plz jobs only when `github.repository_owner == 'jdx'`, and the appended release-notes sponsor section now credits [@jdx](https://github.com/jdx) and [GitHub Sponsors](https://github.com/sponsors/jdx) instead of en.dev. `communique.toml` no longer mentions en.dev in its duplicate-sponsor guard.
> 
> **Docs site** updates OG/Twitter image URLs, footer links to `jdx.dev`, and replaces the dynamic en.dev sponsor feed in `EndevSponsors.vue` with a static “Sponsor on GitHub” CTA. The `pitchfork sponsors` CLI text and generated usage/docs reference the “jdx project family” and GitHub sponsors URL.
> 
> **Tests:** hook exit-reason cases in `tests/test_hooks.rs` poll until marker file *content* matches the expected `PITCHFORK_EXIT_REASON`, reducing flakes from checking file existence before the shell redirect finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4021be3ba71f5775a11421380f625e469437efd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation domain and links from pitchfork.en.dev to pitchfork.jdx.dev
  * Updated CLI help text and command descriptions to reference the "jdx project family"
  * Updated schema reference URLs in configuration documentation

* **Chores**
  * Updated project branding and sponsorship references throughout
  * Simplified sponsors UI to a single static sponsor CTA
  * Updated social sharing images and footer branding assets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->