### PR TITLE
chore: release v2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.1](https://github.com/jdx/pitchfork/compare/v2.13.0...v2.13.1) - 2026-06-08
+
+### Other
+
+- move pitchfork back to jdx ([#474](https://github.com/jdx/pitchfork/pull/474))
+
 ## [2.13.0](https://github.com/jdx/pitchfork/compare/v2.12.1...v2.13.0) - 2026-06-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,7 +2792,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.13.0"
+version = "2.13.1"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2527,7 +2527,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.13.0",
+  "version": "2.13.1",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.13.0
+**Version**: 2.13.1
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.13.0"
+version "2.13.1"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.13.0 -> 2.13.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.13.1](https://github.com/jdx/pitchfork/compare/v2.13.0...v2.13.1) - 2026-06-08

### Other

- move pitchfork back to jdx ([#474](https://github.com/jdx/pitchfork/pull/474))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only release with no runtime code changes in the diff.
> 
> **Overview**
> **Release v2.13.1** bumps `pitchfork-cli` from **2.13.0** to **2.13.1** across `Cargo.toml`, `Cargo.lock`, the usage spec (`pitchfork.usage.kdl`), and generated CLI docs (`docs/cli/index.md`, `docs/cli/commands.json`).
> 
> `CHANGELOG.md` adds a **[2.13.1]** entry (2026-06-08) under **Other**, noting the project move back to **jdx** ([#474](https://github.com/jdx/pitchfork/pull/474)). No supervisor, daemon, or CLI behavior changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 852fa6c660fd421c3b470d4ef1a143f5f7365b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to v2.13.1
  * CHANGELOG updated with new release entry dated 2026-06-08
  * CLI documentation and usage metadata updated to reflect v2.13.1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->