### PR TITLE
chore: release v2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.0](https://github.com/jdx/pitchfork/compare/v2.13.1...v2.14.0) - 2026-06-21
+
+### Added
+
+- *(cli)* add `list --status` and optimize shell completion ([#529](https://github.com/jdx/pitchfork/pull/529))
+- *(logs)* add --no-timestamp flag and logs.timestamp setting ([#526](https://github.com/jdx/pitchfork/pull/526))
+- *(cli)* add --json flag to display commands ([#527](https://github.com/jdx/pitchfork/pull/527))
+- *(supervisor)* support configurable shell for daemon run commands ([#531](https://github.com/jdx/pitchfork/pull/531))
+
+### Fixed
+
+- *(deps)* update rust crate listeners to 0.6 ([#525](https://github.com/jdx/pitchfork/pull/525))
+- *(tui)* scroll daemon list to keep selection visible ([#519](https://github.com/jdx/pitchfork/pull/519))
+- *(proxy)* downgrade forwarded requests to HTTP/1.1 ([#515](https://github.com/jdx/pitchfork/pull/515))
+- *(deps)* update dependency vue-router to v5 ([#506](https://github.com/jdx/pitchfork/pull/506))
+- *(deps)* update rust crate sysinfo to 0.39 ([#500](https://github.com/jdx/pitchfork/pull/500))
+- *(deps)* update rust crate rusqlite to 0.40 ([#498](https://github.com/jdx/pitchfork/pull/498))
+- *(deps)* update rust crate mdns-sd to 0.20 ([#497](https://github.com/jdx/pitchfork/pull/497))
+
+### Other
+
+- *(deps)* update rust crate xx to v2.6.0 ([#530](https://github.com/jdx/pitchfork/pull/530))
+- *(deps)* update rust crate uuid to v1.23.3 ([#523](https://github.com/jdx/pitchfork/pull/523))
+- *(deps)* update rust crate regex to v1.12.4 ([#522](https://github.com/jdx/pitchfork/pull/522))
+- link to all sponsors ([#513](https://github.com/jdx/pitchfork/pull/513))
+- *(ui)* stop committing compiled assets ([#511](https://github.com/jdx/pitchfork/pull/511))
+- *(deps)* update dependency typescript to v6 ([#503](https://github.com/jdx/pitchfork/pull/503))
+- *(deps)* update rust crate xx to v2.5.4 ([#494](https://github.com/jdx/pitchfork/pull/494))
+
 ## [2.13.1](https://github.com/jdx/pitchfork/compare/v2.13.0...v2.13.1) - 2026-06-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,7 +2862,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.13.1"
+version = "2.14.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2673,7 +2673,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.13.1",
+  "version": "2.14.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.13.1
+**Version**: 2.14.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.13.1"
+version "2.14.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.13.1 -> 2.14.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.14.0](https://github.com/jdx/pitchfork/compare/v2.13.1...v2.14.0) - 2026-06-21

### Added

- *(cli)* add `list --status` and optimize shell completion ([#529](https://github.com/jdx/pitchfork/pull/529))
- *(logs)* add --no-timestamp flag and logs.timestamp setting ([#526](https://github.com/jdx/pitchfork/pull/526))
- *(cli)* add --json flag to display commands ([#527](https://github.com/jdx/pitchfork/pull/527))
- *(supervisor)* support configurable shell for daemon run commands ([#531](https://github.com/jdx/pitchfork/pull/531))

### Fixed

- *(deps)* update rust crate listeners to 0.6 ([#525](https://github.com/jdx/pitchfork/pull/525))
- *(tui)* scroll daemon list to keep selection visible ([#519](https://github.com/jdx/pitchfork/pull/519))
- *(proxy)* downgrade forwarded requests to HTTP/1.1 ([#515](https://github.com/jdx/pitchfork/pull/515))
- *(deps)* update dependency vue-router to v5 ([#506](https://github.com/jdx/pitchfork/pull/506))
- *(deps)* update rust crate sysinfo to 0.39 ([#500](https://github.com/jdx/pitchfork/pull/500))
- *(deps)* update rust crate rusqlite to 0.40 ([#498](https://github.com/jdx/pitchfork/pull/498))
- *(deps)* update rust crate mdns-sd to 0.20 ([#497](https://github.com/jdx/pitchfork/pull/497))

### Other

- *(deps)* update rust crate xx to v2.6.0 ([#530](https://github.com/jdx/pitchfork/pull/530))
- *(deps)* update rust crate uuid to v1.23.3 ([#523](https://github.com/jdx/pitchfork/pull/523))
- *(deps)* update rust crate regex to v1.12.4 ([#522](https://github.com/jdx/pitchfork/pull/522))
- link to all sponsors ([#513](https://github.com/jdx/pitchfork/pull/513))
- *(ui)* stop committing compiled assets ([#511](https://github.com/jdx/pitchfork/pull/511))
- *(deps)* update dependency typescript to v6 ([#503](https://github.com/jdx/pitchfork/pull/503))
- *(deps)* update rust crate xx to v2.5.4 ([#494](https://github.com/jdx/pitchfork/pull/494))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and changelog updates only; no runtime code changes in the diff.
> 
> **Overview**
> **Release v2.14.0** bumps `pitchfork-cli` from **2.13.1** to **2.14.0** and publishes the **2.14.0** changelog section (dated 2026-06-21).
> 
> The diff updates version strings in **`Cargo.toml`**, **`Cargo.lock`**, **`pitchfork.usage.kdl`**, and generated CLI docs (**`docs/cli/index.md`**, **`docs/cli/commands.json`**). No application source changes appear in this PR—it packages already-merged work for the release.
> 
> **2.14.0** highlights documented in **`CHANGELOG.md`**: `list --status` and faster shell completion, logs **`--no-timestamp`** / `logs.timestamp`, **`--json`** on display commands, configurable supervisor shell for daemon runs, proxy HTTP/1.1 downgrade, TUI list scrolling fix, and assorted dependency/UI maintenance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40c0ca5ab45c0fb32961fe61a193d18c4b885d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->