### PR TITLE
chore(ci): bump pr-closer action

### DIFF
--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -18,4 +18,4 @@ jobs:
       checks: read
       statuses: read
     steps:
-      - uses: jdx/pr-closer@44b9e7859d29e01b4b38e50e2ad6b5c5d00a6973 # v1.0.1
+      - uses: jdx/pr-closer@ddc40dfad5567fc7296a2463880c618344d26055 # v1.1.0


### PR DESCRIPTION
## Summary
- Bump `jdx/pr-closer` from `v1.0.1` to `v1.1.0`.
- Keep the action pinned by full commit SHA.

## Verification
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single third-party action version bump in a maintenance workflow; no application or auth logic changes.
> 
> **Overview**
> Updates the scheduled **pr-closer** workflow to use **`jdx/pr-closer` v1.1.0**, replacing the v1.0.1 pin with commit `ddc40dfad5567fc7296a2463880c618344d26055`. Permissions and job setup are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e3490c9fdbc8ed1f0c0f425dba4c83c5ff086b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR management workflow automation to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->