### PR TITLE
test(web): add browser smoke coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules
 /docs/.vitepress/dist
 /ui/dist
+/ui/playwright-report
+/ui/test-results

--- a/mise.toml
+++ b/mise.toml
@@ -41,7 +41,7 @@ depends = ["build"]
 dir = "ui"
 run = [
   "aube install",
-  "node_modules/.bin/playwright install --with-deps chromium",
+  "if [ \"$(uname -s)\" = \"Linux\" ]; then node_modules/.bin/playwright install --with-deps chromium; else node_modules/.bin/playwright install chromium; fi",
   "node_modules/.bin/playwright test",
 ]
 

--- a/mise.toml
+++ b/mise.toml
@@ -15,10 +15,10 @@ depends = ["build"]
 run = "pitchfork sup start -f"
 
 [tasks.ci]
-depends = ["lint", "build", "build:docs", "test"]
+depends = ["lint", "build", "build:docs", "test", "test:web-ui"]
 
 [tasks.ci-dev]
-depends = ["lint-fix", "build", "build:docs", "test"]
+depends = ["lint-fix", "build", "build:docs", "test", "test:web-ui"]
 
 [tasks.docs]
 dir = "docs"
@@ -35,6 +35,15 @@ run = "hk fix --all"
 [tasks.build]
 depends = ["build:ui"]
 run = ["cargo build"]
+
+[tasks."test:web-ui"]
+depends = ["build"]
+dir = "ui"
+run = [
+  "aube install",
+  "node_modules/.bin/playwright install --with-deps chromium",
+  "node_modules/.bin/playwright test",
+]
 
 [tasks."build:ui"]
 dir = "ui"

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "vue": "^3.5.13",
@@ -14,6 +15,7 @@
     "vue-sonner": "^2.0.9"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "@vue/tsconfig": "^0.9.0",
     "less": "^4.6.4",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, devices } from '@playwright/test'
 export default defineConfig({
   testDir: './tests',
   timeout: 30_000,
+  retries: process.env.CI ? 1 : 0,
   expect: {
     timeout: 10_000,
   },

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    ...devices['Desktop Chrome'],
+    trace: 'retain-on-failure',
+  },
+})

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^2.0.9
         version: 2.0.9
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.60.0
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
         version: 6.0.7(vite@8.0.16(less@4.6.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
@@ -110,6 +113,11 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -355,6 +363,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -533,6 +546,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -779,6 +802,10 @@ snapshots:
 
   '@oxc-project/types@0.133.0': {}
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -995,6 +1022,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1145,6 +1175,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.15:
     dependencies:

--- a/ui/tests/web-ui-smoke.spec.ts
+++ b/ui/tests/web-ui-smoke.spec.ts
@@ -96,12 +96,15 @@ async function stopProcess(child: ChildProcessWithoutNullStreams): Promise<void>
   if (child.exitCode !== null || child.signalCode !== null) return
 
   await new Promise<void>((resolve) => {
-    const timeout = setTimeout(() => {
+    const forceKillTimeout = setTimeout(() => {
       child.kill('SIGKILL')
-      resolve()
     }, 2_000)
+    const giveUpTimeout = setTimeout(() => {
+      resolve()
+    }, 5_000)
     child.once('exit', () => {
-      clearTimeout(timeout)
+      clearTimeout(forceKillTimeout)
+      clearTimeout(giveUpTimeout)
       resolve()
     })
     child.kill('SIGTERM')

--- a/ui/tests/web-ui-smoke.spec.ts
+++ b/ui/tests/web-ui-smoke.spec.ts
@@ -42,6 +42,11 @@ async function startWebSupervisor(): Promise<WebSupervisor> {
   })
   child.stdout.resume()
 
+  const cleanup = async () => {
+    await stopProcess(child)
+    await rm(root, { recursive: true, force: true })
+  }
+
   let stderr = ''
   let port: string
   try {
@@ -57,6 +62,10 @@ async function startWebSupervisor(): Promise<WebSupervisor> {
         finish(() => reject(new Error(`web supervisor did not start in time. stderr:\n${stderr}`)))
       }, 10_000)
 
+      child.once('error', error => {
+        finish(() => reject(new Error(`failed to spawn web supervisor: ${error.message}. stderr:\n${stderr}`)))
+      })
+
       child.on('exit', (code, signal) => {
         finish(() => reject(new Error(`web supervisor exited early (${code ?? signal}). stderr:\n${stderr}`)))
       })
@@ -70,21 +79,18 @@ async function startWebSupervisor(): Promise<WebSupervisor> {
       })
     })
   } catch (error) {
-    await stopProcess(child)
-    await rm(root, { recursive: true, force: true })
+    await cleanup()
     throw error
   }
 
   return {
     baseUrl: `http://127.0.0.1:${port}`,
-    cleanup: async () => {
-      await stopProcess(child)
-      await rm(root, { recursive: true, force: true })
-    },
+    cleanup,
   }
 }
 
 async function stopProcess(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.pid === undefined) return
   if (child.exitCode !== null || child.signalCode !== null) return
 
   await new Promise<void>((resolve) => {

--- a/ui/tests/web-ui-smoke.spec.ts
+++ b/ui/tests/web-ui-smoke.spec.ts
@@ -40,27 +40,40 @@ async function startWebSupervisor(): Promise<WebSupervisor> {
       PITCHFORK_WATCH_POLL_INTERVAL: '100ms',
     },
   })
+  child.stdout.resume()
 
   let stderr = ''
-  const port = await new Promise<string>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error(`web supervisor did not start in time. stderr:\n${stderr}`))
-    }, 10_000)
-
-    child.on('exit', (code, signal) => {
-      clearTimeout(timeout)
-      reject(new Error(`web supervisor exited early (${code ?? signal}). stderr:\n${stderr}`))
-    })
-
-    child.stderr.on('data', (chunk: Buffer) => {
-      stderr += chunk.toString()
-      const match = stderr.match(/Web UI listening on http:\/\/127\.0\.0\.1:(\d+)/)
-      if (match) {
+  let port: string
+  try {
+    port = await new Promise<string>((resolve, reject) => {
+      let settled = false
+      const finish = (callback: () => void) => {
+        if (settled) return
+        settled = true
         clearTimeout(timeout)
-        resolve(match[1])
+        callback()
       }
+      const timeout = setTimeout(() => {
+        finish(() => reject(new Error(`web supervisor did not start in time. stderr:\n${stderr}`)))
+      }, 10_000)
+
+      child.on('exit', (code, signal) => {
+        finish(() => reject(new Error(`web supervisor exited early (${code ?? signal}). stderr:\n${stderr}`)))
+      })
+
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString()
+        const match = stderr.match(/Web UI listening on http:\/\/127\.0\.0\.1:(\d+)/)
+        if (match) {
+          finish(() => resolve(match[1]))
+        }
+      })
     })
-  })
+  } catch (error) {
+    await stopProcess(child)
+    await rm(root, { recursive: true, force: true })
+    throw error
+  }
 
   return {
     baseUrl: `http://127.0.0.1:${port}`,

--- a/ui/tests/web-ui-smoke.spec.ts
+++ b/ui/tests/web-ui-smoke.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test, type Page } from '@playwright/test'
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '../..')
+const pitchforkBin = process.env.PITCHFORK_BIN
+  ? path.resolve(process.env.PITCHFORK_BIN)
+  : path.join(repoRoot, 'target/debug/pitchfork')
+
+type WebSupervisor = {
+  baseUrl: string
+  cleanup: () => Promise<void>
+}
+
+async function startWebSupervisor(): Promise<WebSupervisor> {
+  const root = await mkdtemp(path.join(tmpdir(), 'pitchfork-web-ui-'))
+  const home = path.join(root, 'home')
+  const project = path.join(root, 'project')
+  await mkdir(path.join(home, '.config'), { recursive: true })
+  await mkdir(path.join(home, '.local/state'), { recursive: true })
+  await mkdir(project, { recursive: true })
+  await writeFile(
+    path.join(project, 'pitchfork.toml'),
+    `[daemons.smoke]\nrun = "node -e 'setInterval(() => {}, 1000)'"\nready_delay = 0\n`,
+  )
+
+  const child = spawn(pitchforkBin, ['supervisor', 'run', '--web-port', '0'], {
+    cwd: project,
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: path.join(home, '.config'),
+      XDG_STATE_HOME: path.join(home, '.local/state'),
+      PITCHFORK_LOG: 'debug',
+      PITCHFORK_WATCH_INTERVAL: '100ms',
+      PITCHFORK_WATCH_POLL_INTERVAL: '100ms',
+    },
+  })
+
+  let stderr = ''
+  const port = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`web supervisor did not start in time. stderr:\n${stderr}`))
+    }, 10_000)
+
+    child.on('exit', (code, signal) => {
+      clearTimeout(timeout)
+      reject(new Error(`web supervisor exited early (${code ?? signal}). stderr:\n${stderr}`))
+    })
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+      const match = stderr.match(/Web UI listening on http:\/\/127\.0\.0\.1:(\d+)/)
+      if (match) {
+        clearTimeout(timeout)
+        resolve(match[1])
+      }
+    })
+  })
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    cleanup: async () => {
+      await stopProcess(child)
+      await rm(root, { recursive: true, force: true })
+    },
+  }
+}
+
+async function stopProcess(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return
+
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL')
+      resolve()
+    }, 2_000)
+    child.once('exit', () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+    child.kill('SIGTERM')
+  })
+}
+
+function collectPageFailures(page: Page): string[] {
+  const failures: string[] = []
+  page.on('pageerror', error => failures.push(error.message))
+  page.on('console', message => {
+    if (message.type() === 'error') {
+      failures.push(message.text())
+    }
+  })
+  return failures
+}
+
+test('bundled web UI mounts, loads daemon data, and navigates routes', async ({ page }) => {
+  const supervisor = await startWebSupervisor()
+  const failures = collectPageFailures(page)
+
+  try {
+    await page.goto(supervisor.baseUrl)
+    await expect(page.getByRole('heading', { name: 'Daemons', exact: true })).toBeVisible()
+    await expect(page.getByText('smoke').first()).toBeVisible()
+
+    await page.goto(`${supervisor.baseUrl}/proxies`)
+    await expect(page.getByRole('heading', { name: 'Proxies', exact: true })).toBeVisible()
+    await expect(page.getByText('No proxies registered')).toBeVisible()
+
+    expect(failures).toEqual([])
+  } finally {
+    await supervisor.cleanup()
+  }
+})

--- a/ui/tests/web-ui-smoke.spec.ts
+++ b/ui/tests/web-ui-smoke.spec.ts
@@ -36,6 +36,8 @@ async function startWebSupervisor(): Promise<WebSupervisor> {
       XDG_CONFIG_HOME: path.join(home, '.config'),
       XDG_STATE_HOME: path.join(home, '.local/state'),
       PITCHFORK_LOG: 'debug',
+      PITCHFORK_WEB_BIND_ADDRESS: '127.0.0.1',
+      PITCHFORK_WEB_PATH: '',
       PITCHFORK_WATCH_INTERVAL: '100ms',
       PITCHFORK_WATCH_POLL_INTERVAL: '100ms',
     },


### PR DESCRIPTION
## Summary

- add a Playwright browser smoke test for the bundled Vue web UI
- launch the real `pitchfork supervisor run --web-port 0` binary in an isolated temp HOME/project
- verify the app mounts, loads daemon data, navigates to `/proxies`, and has no console/page errors
- wire the smoke test into `mise run ci`/`ci-dev` via `test:web-ui`

## Verification

- `rm -rf ui/dist && mise run test:web-ui`
- `mise run ci-dev`

*This PR was generated by AI.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and CI wiring changes; no production runtime or auth paths are modified.
> 
> **Overview**
> Adds **Playwright end-to-end smoke coverage** for the bundled Vue web UI and runs it in CI.
> 
> A new `web-ui-smoke.spec.ts` boots the real `pitchfork supervisor run --web-port 0` binary in an isolated temp HOME/project (configurable via `PITCHFORK_BIN`), parses the listening URL from stderr, then asserts the Daemons view shows configured daemon data, `/proxies` renders, and there are no page or console errors. `playwright.config.ts`, `test:e2e` in `ui/package.json`, and `@playwright/test` complete the harness; `.gitignore` excludes Playwright artifacts.
> 
> **`mise`** gains a `test:web-ui` task (Chromium install, including Linux deps in CI) that depends on `build`, and **`ci` / `ci-dev`** now depend on that task so browser smoke runs with the rest of the pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae38f8767004860a32e91396ddc4e9d04a25d195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated end-to-end (Playwright) smoke tests for the web UI.
  * Added an npm script to run the web UI test suite and added Playwright as a dev dependency.

* **Chores**
  * Integrated web UI testing into CI so tests run in the pipeline.
  * Added test runner configuration and tooling.

* **Style/Ignore**
  * Ignore Playwright test output and report directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->