### PR TITLE
docs: link to all sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://37signals.com">37signals</a>.
+  Sponsored by <a href="https://37signals.com">37signals</a>.<br>
+  <a href="https://en.dev/sponsors.html">View all sponsors</a>.
 </p>
 
 <hr />


### PR DESCRIPTION
## Summary
- add a README link to the full en.dev sponsors page

## Tests
- not run (README-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation change with no runtime or security impact.
> 
> **Overview**
> Updates the README sponsor footer so readers can see **all** sponsors, not only 37signals.
> 
> Adds a line break after the existing 37signals credit and a **View all sponsors** link to `https://en.dev/sponsors.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 506b7cf331523724ff3ca1fb91b3695d4fb01888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the README sponsor section with improved formatting and added a link to view all sponsors, spreading the information across multiple lines for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->