### PR TITLE
chore(ci): use shared coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+remote_config:
+  repository: "jdx/coderabbit"
+  ref: "main"
+  path: ".coderabbit.yaml"


### PR DESCRIPTION
## Summary
- Point this repository's CodeRabbit YAML at the shared `jdx/coderabbit` configuration.
- Keep CodeRabbit settings centralized across the en.dev CLI repositories.

## Validation
- YAML-only configuration change; not run.

*This PR was created by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only CI/tooling configuration with no application, auth, or data-path changes.
> 
> **Overview**
> Adds a new **`.coderabbit.yaml`** that does not define review rules locally. Instead it uses **`remote_config`** to load settings from **`jdx/coderabbit`** on **`main`** at **`.coderabbit.yaml`**, so CodeRabbit behavior matches the shared org config used across en.dev CLI repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12fdc9906debb747fb04bfeb52d21b5341644c6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->