### PR TITLE
fix(tui): scroll daemon list to keep selection visible

### DIFF
--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -347,11 +347,13 @@ fn draw_daemon_table(f: &mut Frame, area: Rect, app: &App) {
                 .title_style(Style::default().fg(RED).bold())
                 .borders(Borders::ALL)
                 .border_style(Style::default().fg(RED)),
-        )
-        .row_highlight_style(Style::default().bg(Color::Rgb(50, 20, 20)));
+        );
 
     // Use a stateful render so ratatui scrolls the viewport to keep the
     // selected row visible (a stateless render always starts at row 0).
+    // The cursor row is highlighted via each row's own `row_style`, so no
+    // `row_highlight_style` is set here — it would otherwise override the
+    // multi-select background on a row that is both selected and the cursor.
     let mut table_state = TableState::default().with_selected(Some(app.selected));
     f.render_stateful_widget(table, table_area, &mut table_state);
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -339,15 +339,13 @@ fn draw_daemon_table(f: &mut Frame, area: Rect, app: &App) {
         " Daemons ".to_string()
     };
 
-    let table = Table::new(rows, widths)
-        .header(header)
-        .block(
-            Block::default()
-                .title(title)
-                .title_style(Style::default().fg(RED).bold())
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(RED)),
-        );
+    let table = Table::new(rows, widths).header(header).block(
+        Block::default()
+            .title(title)
+            .title_style(Style::default().fg(RED).bold())
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(RED)),
+    );
 
     // Use a stateful render so ratatui scrolls the viewport to keep the
     // selected row visible (a stateless render always starts at row 0).

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -10,7 +10,7 @@ use ratatui::{
     symbols,
     widgets::{
         Axis, Block, Borders, Cell, Chart, Clear, Dataset, GraphType, Paragraph, Row, Scrollbar,
-        ScrollbarOrientation, ScrollbarState, Table, Wrap,
+        ScrollbarOrientation, ScrollbarState, Table, TableState, Wrap,
     },
 };
 
@@ -350,7 +350,10 @@ fn draw_daemon_table(f: &mut Frame, area: Rect, app: &App) {
         )
         .row_highlight_style(Style::default().bg(Color::Rgb(50, 20, 20)));
 
-    f.render_widget(table, table_area);
+    // Use a stateful render so ratatui scrolls the viewport to keep the
+    // selected row visible (a stateless render always starts at row 0).
+    let mut table_state = TableState::default().with_selected(Some(app.selected));
+    f.render_stateful_widget(table, table_area, &mut table_state);
 
     // Render scrollbar if there are more items than visible
     let visible_rows = table_area.height.saturating_sub(3) as usize; // -3 for borders and header


### PR DESCRIPTION
## Problem

In the TUI dashboard, the daemon list does not scroll when there are more daemons than fit on screen. Pressing the down arrow moves the scrollbar thumb and the row highlight, but the list itself stays put — so a selection past the visible area scrolls off-screen and can't be seen.

## Cause

`draw_daemon_table` rendered the table with the stateless `f.render_widget(table, ...)`, which always draws rows starting at index 0. `app.selected` only drives the highlight and the scrollbar position; nothing told the table to scroll its viewport.

## Fix

Render the table as a stateful widget with a `TableState` carrying the selected index. ratatui's `Table`/`TableState` tracks its own scroll offset and automatically keeps the selected row visible.

```rust
let mut table_state = TableState::default().with_selected(Some(app.selected));
f.render_stateful_widget(table, table_area, &mut table_state);
```

## Testing

- `mise run build-dev` builds cleanly.
- `cargo fmt --check` and `cargo clippy` pass.
- Verified the change is isolated to TUI rendering.

*This PR was generated by Claude Code.*

## Before


https://github.com/user-attachments/assets/d74ad995-c1cf-4103-862f-d90cc391a987

## After

https://github.com/user-attachments/assets/0648154d-b698-4706-94a7-45926ed021fb



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon list table rendering with better row selection tracking and visual feedback for selected and multi-selected rows.
  * Enhanced table scrolling and visibility handling during navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->