### PR TITLE
Fix broken link in configuration-templates.md

### DIFF
--- a/docs/guides/configuration-templates.md
+++ b/docs/guides/configuration-templates.md
@@ -1,6 +1,6 @@
 # Configuration Templates
 
-Use [Tera](https://tera.netlify.app/) templates in configuration fields to reference values from other daemons, settings, and runtime state.
+Use [Tera](https://keats.github.io/tera/) templates in configuration fields to reference values from other daemons, settings, and runtime state.
 
 ## Why Templates?
 


### PR DESCRIPTION
The link to the Tera docs are broken, I updated it to the correct link.

Maybe the docs should state that you can use the templating to read values from env vars?
It was not clear to me that it was possible, and the syntax is a bit verbose (something like `get_env(name="my_env", default="default_val")`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Tera template documentation link in configuration guides to point to the current resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->