### PR TITLE
feat(logs): add --no-timestamp flag and logs.timestamp setting

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1033,6 +1033,18 @@
             ],
             "hide": false,
             "global": false
+          },
+          {
+            "name": "no-timestamp",
+            "usage": "--no-timestamp",
+            "help": "Omit timestamps from log output",
+            "help_first_line": "Omit timestamps from log output",
+            "short": [],
+            "long": [
+              "no-timestamp"
+            ],
+            "hide": false,
+            "global": false
           }
         ],
         "mounts": [],

--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -72,3 +72,7 @@ Output raw log lines without color or formatting
 ### `--json`
 
 Output in JSON format
+
+### `--no-timestamp`
+
+Omit timestamps from log output

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -669,6 +669,13 @@
             "string",
             "null"
           ]
+        },
+        "timestamp": {
+          "description": "Show timestamps in log output",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -151,6 +151,7 @@ cmd logs help="Displays logs for daemon(s)" {
     flag --no-pager help="Disable pager even in interactive terminal"
     flag --raw help="Output raw log lines without color or formatting"
     flag --json help="Output in JSON format"
+    flag --no-timestamp help="Omit timestamps from log output"
     arg "[ID]…" help="Show only logs for the specified daemon(s)" required=#false var=#true
 }
 cmd mcp help="Runs a Model Context Protocol (MCP) server over stdin/stdout" {

--- a/settings.toml
+++ b/settings.toml
@@ -174,6 +174,22 @@ Logs are pruned automatically by the supervisor during its interval watcher
 cycle (no more than once per hour). No manual rotation command is needed.
 """
 
+[logs.timestamp]
+type = "Bool"
+env = "PITCHFORK_LOG_TIMESTAMP"
+default = "true"
+description = "Show timestamps in log output"
+docs = """
+When enabled (default), pitchfork prefixes each log line with a timestamp
+(e.g. `2024-01-15 10:30:00`).
+
+When disabled, timestamps are omitted from `pitchfork logs` output. This is
+useful when piping logs to tools like `lnav` that expect raw JSON or when
+you want to process log output without the timestamp prefix.
+
+Can be overridden per-invocation with `pitchfork logs --no-timestamp`.
+"""
+
 [logs.line_retention]
 type = "Integer"
 env = "PITCHFORK_LOG_LINE_RETENTION"

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -3,6 +3,7 @@ use crate::daemon_id::DaemonId;
 use crate::log_store::sqlite::LOG_STORE;
 use crate::log_store::{LogQuery, LogStore};
 use crate::pitchfork_toml::PitchforkToml;
+use crate::settings::settings;
 use crate::state_file::StateFile;
 use crate::ui::style::{edim, estyle, ndim};
 use crate::{Result, env};
@@ -62,6 +63,7 @@ fn format_log_line(
     single_daemon: bool,
     id_width: usize,
     strip_ansi: bool,
+    show_timestamp: bool,
 ) -> String {
     let msg = if strip_ansi {
         console::strip_ansi_codes(msg).to_string()
@@ -69,12 +71,20 @@ fn format_log_line(
         msg.to_string()
     };
     if single_daemon {
-        format!("{} {}", ndim(date), msg)
+        if show_timestamp {
+            format!("{} {}", ndim(date), msg)
+        } else {
+            msg
+        }
     } else {
         let colors_on = !strip_ansi && console::colors_enabled();
         let colored = dimmed_id(id, colors_on);
         let padded = console::pad_str(&colored, id_width, console::Alignment::Left, None);
-        format!("{}  {} {}", padded, ndim(date), msg)
+        if show_timestamp {
+            format!("{}  {} {}", padded, ndim(date), msg)
+        } else {
+            format!("{}  {}", padded, msg)
+        }
     }
 }
 
@@ -194,6 +204,10 @@ pub struct Logs {
     /// Output in JSON format
     #[clap(long, conflicts_with = "raw", conflicts_with = "tail")]
     json: bool,
+
+    /// Omit timestamps from log output
+    #[clap(long)]
+    no_timestamp: bool,
 }
 
 impl Logs {
@@ -227,11 +241,18 @@ impl Logs {
         }
 
         let single_daemon = resolved_ids.len() == 1;
+        let show_timestamp = settings().logs.timestamp && !self.no_timestamp;
         let log_lines = self.fetch_log_lines(&resolved_ids, from, to)?;
         let has_time_filter = from.is_some() || to.is_some();
-        self.output_logs(log_lines, single_daemon, has_time_filter, self.tail)?;
+        self.output_logs(
+            log_lines,
+            single_daemon,
+            has_time_filter,
+            self.tail,
+            show_timestamp,
+        )?;
         if self.tail {
-            tail_logs(&resolved_ids, single_daemon, true).await?;
+            tail_logs(&resolved_ids, single_daemon, true, show_timestamp).await?;
         }
 
         Ok(())
@@ -314,6 +335,7 @@ impl Logs {
         single_daemon: bool,
         has_time_filter: bool,
         force_no_pager: bool,
+        show_timestamp: bool,
     ) -> Result<()> {
         if log_lines.is_empty() {
             return Ok(());
@@ -328,7 +350,15 @@ impl Logs {
 
         if self.raw {
             for (date, id, msg) in log_lines {
-                let line = format_log_line(&date, &id, &msg, single_daemon, id_width, strip_ansi);
+                let line = format_log_line(
+                    &date,
+                    &id,
+                    &msg,
+                    single_daemon,
+                    id_width,
+                    strip_ansi,
+                    show_timestamp,
+                );
                 println!("{line}");
             }
             return Ok(());
@@ -343,12 +373,21 @@ impl Logs {
                 id_width,
                 has_time_filter,
                 strip_ansi,
+                show_timestamp,
             )?;
         } else {
             for (date, id, msg) in log_lines {
                 println!(
                     "{}",
-                    format_log_line(&date, &id, &msg, single_daemon, id_width, strip_ansi)
+                    format_log_line(
+                        &date,
+                        &id,
+                        &msg,
+                        single_daemon,
+                        id_width,
+                        strip_ansi,
+                        show_timestamp,
+                    )
                 );
             }
         }
@@ -363,6 +402,7 @@ impl Logs {
         id_width: usize,
         has_time_filter: bool,
         strip_ansi: bool,
+        show_timestamp: bool,
     ) -> Result<()> {
         // When time filter is used, start at top; otherwise start at end
         let pager_config = PagerConfig::new(!has_time_filter);
@@ -373,7 +413,15 @@ impl Logs {
                     for (date, id, msg) in log_lines {
                         let line = format!(
                             "{}\n",
-                            format_log_line(&date, &id, &msg, single_daemon, id_width, strip_ansi)
+                            format_log_line(
+                                &date,
+                                &id,
+                                &msg,
+                                single_daemon,
+                                id_width,
+                                strip_ansi,
+                                show_timestamp,
+                            )
                         );
                         if stdin.write_all(line.as_bytes()).is_err() {
                             break;
@@ -385,7 +433,15 @@ impl Logs {
                     for (date, id, msg) in log_lines {
                         println!(
                             "{}",
-                            format_log_line(&date, &id, &msg, single_daemon, id_width, strip_ansi)
+                            format_log_line(
+                                &date,
+                                &id,
+                                &msg,
+                                single_daemon,
+                                id_width,
+                                strip_ansi,
+                                show_timestamp,
+                            )
                         );
                     }
                 }
@@ -395,7 +451,15 @@ impl Logs {
                 for (date, id, msg) in log_lines {
                     println!(
                         "{}",
-                        format_log_line(&date, &id, &msg, single_daemon, id_width, strip_ansi)
+                        format_log_line(
+                            &date,
+                            &id,
+                            &msg,
+                            single_daemon,
+                            id_width,
+                            strip_ansi,
+                            show_timestamp,
+                        )
                     );
                 }
             }
@@ -553,6 +617,7 @@ pub async fn tail_logs(
     names: &[DaemonId],
     single_daemon: bool,
     start_from_end: bool,
+    show_timestamp: bool,
 ) -> Result<()> {
     // Poll SQLite log store for new entries since last known row id.
     let id_width = names
@@ -618,7 +683,15 @@ pub async fn tail_logs(
             for (date, name, msg) in out {
                 println!(
                     "{}",
-                    format_log_line(&date, &name, &msg, single_daemon, id_width, strip_ansi)
+                    format_log_line(
+                        &date,
+                        &name,
+                        &msg,
+                        single_daemon,
+                        id_width,
+                        strip_ansi,
+                        show_timestamp,
+                    )
                 );
             }
         }

--- a/src/cli/wait.rs
+++ b/src/cli/wait.rs
@@ -2,6 +2,7 @@ use crate::Result;
 use crate::cli::logs;
 use crate::pitchfork_toml::PitchforkToml;
 use crate::procs::PROCS;
+use crate::settings::settings;
 use crate::state_file::StateFile;
 use tokio::time;
 
@@ -45,7 +46,7 @@ impl Wait {
 
         let tail_names = vec![qualified_id.clone()];
         tokio::spawn(async move {
-            logs::tail_logs(&tail_names, true, false)
+            logs::tail_logs(&tail_names, true, false, settings().logs.timestamp)
                 .await
                 .unwrap_or_default();
         });


### PR DESCRIPTION
Add a `logs.timestamp` setting (default: true) and a `--no-timestamp` CLI flag to `pitchfork logs` that omits timestamps from log output.

This is useful when piping logs to tools like lnav that expect raw JSON or when processing log output without the timestamp prefix.

The setting can be configured via:
- `PITCHFORK_LOG_TIMESTAMP` env var
- `logs.timestamp` in settings config

The `--no-timestamp` flag overrides the setting per-invocation.

Related: #507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new settings option to control whether log output includes timestamps.
  * Added a `--no-timestamp` flag to `pitchfork logs` to suppress timestamps at runtime.
* **Documentation**
  * Updated `pitchfork logs` CLI help and documentation to describe the `--no-timestamp` flag.
  * Extended the public settings schema to include the new logs timestamp option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->