### PR TITLE
chore: release v2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.15.0](https://github.com/jdx/pitchfork/compare/v2.14.0...v2.15.0) - 2026-07-01
+
+### Added
+
+- *(logs)* add archive hook before retention pruning ([#534](https://github.com/jdx/pitchfork/pull/534))
+
+### Fixed
+
+- *(logs)* anchor startup log stream to max id instead of timestamp ([#560](https://github.com/jdx/pitchfork/pull/560))
+- *(deps)* update rust crate tower-http to 0.7 ([#558](https://github.com/jdx/pitchfork/pull/558))
+- *(deps)* update rust crate cron to 0.17 ([#556](https://github.com/jdx/pitchfork/pull/556))
+- *(deps)* update rust crate itertools to 0.15 ([#557](https://github.com/jdx/pitchfork/pull/557))
+- *(cron)* fire config-only cron daemons without boot_start ([#548](https://github.com/jdx/pitchfork/pull/548))
+- *(supervisor)* drain output channel on daemon exit to prevent trailing log loss ([#540](https://github.com/jdx/pitchfork/pull/540))
+
+### Other
+
+- *(deps)* update rust crate rcgen to v0.14.8 ([#552](https://github.com/jdx/pitchfork/pull/552))
+- *(deps)* lock file maintenance ([#561](https://github.com/jdx/pitchfork/pull/561))
+- *(deps)* update rust crate xx to v2.6.1 ([#554](https://github.com/jdx/pitchfork/pull/554))
+- *(deps)* update rust crate ratatui to v0.30.2 ([#551](https://github.com/jdx/pitchfork/pull/551))
+- *(deps)* lock file maintenance lockfile maintenance ([#538](https://github.com/jdx/pitchfork/pull/538))
+
 ## [2.14.0](https://github.com/jdx/pitchfork/compare/v2.13.1...v2.14.0) - 2026-06-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.14.0"
+version = "2.15.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.14.0"
+version = "2.15.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2673,7 +2673,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.14.0",
+  "version": "2.15.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.14.0
+**Version**: 2.15.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.14.0"
+version "2.15.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.14.0 -> 2.15.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.15.0](https://github.com/jdx/pitchfork/compare/v2.14.0...v2.15.0) - 2026-07-01

### Added

- *(logs)* add archive hook before retention pruning ([#534](https://github.com/jdx/pitchfork/pull/534))

### Fixed

- *(logs)* anchor startup log stream to max id instead of timestamp ([#560](https://github.com/jdx/pitchfork/pull/560))
- *(deps)* update rust crate tower-http to 0.7 ([#558](https://github.com/jdx/pitchfork/pull/558))
- *(deps)* update rust crate cron to 0.17 ([#556](https://github.com/jdx/pitchfork/pull/556))
- *(deps)* update rust crate itertools to 0.15 ([#557](https://github.com/jdx/pitchfork/pull/557))
- *(cron)* fire config-only cron daemons without boot_start ([#548](https://github.com/jdx/pitchfork/pull/548))
- *(supervisor)* drain output channel on daemon exit to prevent trailing log loss ([#540](https://github.com/jdx/pitchfork/pull/540))

### Other

- *(deps)* update rust crate rcgen to v0.14.8 ([#552](https://github.com/jdx/pitchfork/pull/552))
- *(deps)* lock file maintenance ([#561](https://github.com/jdx/pitchfork/pull/561))
- *(deps)* update rust crate xx to v2.6.1 ([#554](https://github.com/jdx/pitchfork/pull/554))
- *(deps)* update rust crate ratatui to v0.30.2 ([#551](https://github.com/jdx/pitchfork/pull/551))
- *(deps)* lock file maintenance lockfile maintenance ([#538](https://github.com/jdx/pitchfork/pull/538))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation updates only; behavioral changes ship in prior PRs listed in the changelog.
> 
> **Overview**
> **Release-only PR** bumping `pitchfork-cli` from **2.14.0** to **2.15.0** via release-plz.
> 
> `CHANGELOG.md` gains a **[2.15.0]** section (dated 2026-07-01) documenting work already merged since v2.14.0—not new code in this diff. Highlights called out there: log **archive hook** before retention pruning; startup log stream anchored to **max id**; supervisor **output channel drain** on exit; cron daemons firing without `boot_start`; plus dependency bumps (`tower-http`, `cron`, `itertools`, etc.).
> 
> Version strings are updated consistently in `Cargo.toml`, `Cargo.lock` (`pitchfork-cli` package), `pitchfork.usage.kdl`, and generated CLI docs (`docs/cli/index.md`, `docs/cli/commands.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6feb8e89a9de49b5b7ad1a81a9a06372e9a9be40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->