### PR TITLE
fix(supervisor): drain output channel on daemon exit to prevent trailing log loss

### DIFF
--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -915,6 +915,22 @@ impl Supervisor {
                 }
             }
 
+            // Drain any in-flight output lines that were still in the mpsc
+            // channel or the OS pipe buffer when the child exited. Without
+            // this, trailing log lines from short-lived daemons get dropped.
+            // The reader tasks drop their senders on EOF, so recv() returns
+            // None when all data has been consumed. A timeout guards against
+            // a stuck reader (e.g. PTY master FD not closing).
+            while let Ok(Some(line)) =
+                tokio::time::timeout(Duration::from_secs(5), output_rx.recv()).await
+            {
+                let formatted = format_line(line.clone());
+                if let Err(e) = log_store.append(&id, &formatted) {
+                    error!("Failed to write to log for daemon {id}: {e}");
+                }
+                trace!("output (drain): {id} {formatted}");
+            }
+
             // Clear active_port since the process is no longer running
             {
                 let mut state_file = SUPERVISOR.state_file.lock().await;

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -919,12 +919,21 @@ impl Supervisor {
             // channel or the OS pipe buffer when the child exited. Without
             // this, trailing log lines from short-lived daemons get dropped.
             // The reader tasks drop their senders on EOF, so recv() returns
-            // None when all data has been consumed. A timeout guards against
-            // a stuck reader (e.g. PTY master FD not closing).
-            while let Ok(Some(line)) =
-                tokio::time::timeout(Duration::from_secs(5), output_rx.recv()).await
-            {
-                let formatted = format_line(line.clone());
+            // None when all data has been consumed. A total deadline of 5 s
+            // guards against a stuck reader (e.g. PTY master FD not closing)
+            // while ensuring drain doesn't block post-exit cleanup indefinitely.
+            let drain_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+            loop {
+                let now = tokio::time::Instant::now();
+                if now >= drain_deadline {
+                    break;
+                }
+                let Ok(Some(line)) =
+                    tokio::time::timeout(drain_deadline - now, output_rx.recv()).await
+                else {
+                    break;
+                };
+                let formatted = format_line(line);
                 if let Err(e) = log_store.append(&id, &formatted) {
                     error!("Failed to write to log for daemon {id}: {e}");
                 }


### PR DESCRIPTION
When a daemon exits, the select! loop breaks immediately on exit_rx, dropping any lines still in the mpsc channel or OS pipe buffer. Add a post-loop drain with a 5s timeout to flush all in-flight output to the log store before proceeding to state cleanup.

Closes #537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log capture reliability during monitored process shutdown to prevent loss of final log entries by draining any remaining output with a short time limit before completing cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->