### PR TITLE
fix(cron): fire config-only cron daemons without boot_start

### DIFF
--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -282,7 +282,7 @@ impl ProxyStatus {
                         };
                         (status, port)
                     } else {
-                        ("not started".to_string(), None)
+                        ("available".to_string(), None)
                     }
                 } else {
                     ("unknown".to_string(), None)

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -247,6 +247,7 @@ impl ProxyStatus {
         };
 
         let slugs = PitchforkToml::read_global_slugs();
+        let config = PitchforkToml::all_merged_all_namespaces().ok();
         let state_file =
             crate::state_file::StateFile::read(&*crate::env::PITCHFORK_STATE_FILE).ok();
         let standard_port = if s.proxy.https { 443u16 } else { 80u16 };
@@ -282,7 +283,24 @@ impl ProxyStatus {
                         };
                         (status, port)
                     } else {
-                        ("available".to_string(), None)
+                        let configured = config.as_ref().is_some_and(|pt| {
+                            pt.daemons.keys().any(|id| {
+                                id.name() == daemon_name
+                                    && match &expected_ns {
+                                        Some(ns) => id.namespace() == ns,
+                                        None => true,
+                                    }
+                            })
+                        });
+                        (
+                            if configured {
+                                "available"
+                            } else {
+                                "unconfigured"
+                            }
+                            .to_string(),
+                            None,
+                        )
                     }
                 } else {
                     ("unknown".to_string(), None)

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -46,7 +46,7 @@ impl Status {
         // Try state file first, then fall back to config for "available" daemons.
         let (daemon, is_available): (Daemon, bool) =
             match StateFile::get().daemons.get(&qualified_id) {
-                Some(d) => (d.clone(), false),
+                Some(d) => (d.clone(), d.config_registered),
                 None => {
                     let config = PitchforkToml::all_merged_all_namespaces()?;
                     match config.daemons.get(&qualified_id) {

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -1,6 +1,8 @@
 use crate::Result;
 use crate::cli::json_output::{JsonStatusEntry, print_json};
 use crate::cli::list::build_proxy_url;
+use crate::daemon::Daemon;
+use crate::daemon_list::build_placeholder_daemon;
 use crate::pitchfork_toml::PitchforkToml;
 use crate::settings::settings;
 use crate::state_file::StateFile;
@@ -41,60 +43,74 @@ impl Status {
             .then(PitchforkToml::read_global_slugs)
             .unwrap_or_default();
 
-        let daemon = StateFile::get().daemons.get(&qualified_id);
-        if let Some(daemon) = daemon {
-            if self.json {
-                let s = settings();
-                let proxy_url = if s.proxy.enable
-                    && (daemon.active_port.is_some() || !daemon.resolved_port.is_empty())
-                {
-                    let slug = PitchforkToml::find_slug_for_daemon_in_registry(
-                        &qualified_id,
-                        &global_slugs,
-                    );
-                    build_proxy_url(slug.as_deref(), &s)
-                } else {
-                    None
-                };
-                let entry = JsonStatusEntry {
-                    id: qualified_id.qualified(),
-                    namespace: qualified_id.namespace().to_string(),
-                    name: qualified_id.name().to_string(),
-                    pid: daemon.pid,
-                    status: daemon.status.to_string(),
-                    active_port: daemon.active_port,
-                    port: daemon.resolved_port.clone(),
-                    proxy_url,
-                };
-                return print_json(&entry);
-            }
-            println!("Name: {qualified_id}");
-            if let Some(pid) = &daemon.pid {
-                println!("PID: {pid}");
-            }
-            println!("Status: {}", daemon.status.style());
-            if let Some(port) = daemon.active_port {
-                println!("Port: {port} (active)");
-            } else if !daemon.resolved_port.is_empty() {
-                let ports = daemon
-                    .resolved_port
-                    .iter()
-                    .map(|p| p.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                println!("Port: {ports}");
-            }
+        // Try state file first, then fall back to config for "available" daemons.
+        let (daemon, is_available): (Daemon, bool) =
+            match StateFile::get().daemons.get(&qualified_id) {
+                Some(d) => (d.clone(), false),
+                None => {
+                    let config = PitchforkToml::all_merged_all_namespaces()?;
+                    match config.daemons.get(&qualified_id) {
+                        Some(dc) => (build_placeholder_daemon(&qualified_id, dc), true),
+                        None => miette::bail!("Daemon {} not found", qualified_id),
+                    }
+                }
+            };
+
+        if self.json {
             let s = settings();
-            if s.proxy.enable && (daemon.active_port.is_some() || !daemon.resolved_port.is_empty())
+            let proxy_url = if s.proxy.enable
+                && (daemon.active_port.is_some() || !daemon.resolved_port.is_empty())
             {
                 let slug =
                     PitchforkToml::find_slug_for_daemon_in_registry(&qualified_id, &global_slugs);
-                if let Some(url) = build_proxy_url(slug.as_deref(), &s) {
-                    println!("Proxy: {url}");
-                }
-            }
+                build_proxy_url(slug.as_deref(), &s)
+            } else {
+                None
+            };
+            let entry = JsonStatusEntry {
+                id: qualified_id.qualified(),
+                namespace: qualified_id.namespace().to_string(),
+                name: qualified_id.name().to_string(),
+                pid: daemon.pid,
+                status: if is_available {
+                    "available".to_string()
+                } else {
+                    daemon.status.to_string()
+                },
+                active_port: daemon.active_port,
+                port: daemon.resolved_port.clone(),
+                proxy_url,
+            };
+            return print_json(&entry);
+        }
+
+        println!("Name: {qualified_id}");
+        if let Some(pid) = &daemon.pid {
+            println!("PID: {pid}");
+        }
+        if is_available {
+            println!("Status: available");
         } else {
-            miette::bail!("Daemon {} not found", qualified_id);
+            println!("Status: {}", daemon.status.style());
+        }
+        if let Some(port) = daemon.active_port {
+            println!("Port: {port} (active)");
+        } else if !daemon.resolved_port.is_empty() {
+            let ports = daemon
+                .resolved_port
+                .iter()
+                .map(|p| p.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            println!("Port: {ports}");
+        }
+        let s = settings();
+        if s.proxy.enable && (daemon.active_port.is_some() || !daemon.resolved_port.is_empty()) {
+            let slug =
+                PitchforkToml::find_slug_for_daemon_in_registry(&qualified_id, &global_slugs);
+            if let Some(url) = build_proxy_url(slug.as_deref(), &s) {
+                println!("Proxy: {url}");
+            }
         }
         Ok(())
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -123,6 +123,10 @@ pub struct Daemon {
     /// Allocate a pseudo-terminal for the daemon process.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub pty: Option<bool>,
+    /// True for daemons auto-registered from config by the cron watcher,
+    /// not yet started. Treated as "available" by list/status/stats.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub config_registered: bool,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Default)]

--- a/src/daemon_list.rs
+++ b/src/daemon_list.rs
@@ -130,7 +130,7 @@ pub async fn get_daemon_direct(
 }
 
 /// Build a placeholder Daemon from config for daemons that exist in config but not state.
-fn build_placeholder_daemon(
+pub fn build_placeholder_daemon(
     id: &DaemonId,
     daemon_config: &crate::pitchfork_toml::PitchforkTomlDaemon,
 ) -> Daemon {

--- a/src/daemon_list.rs
+++ b/src/daemon_list.rs
@@ -87,9 +87,9 @@ pub async fn get_daemon_direct(
         drop(state_file);
         return Ok(Some(DaemonListEntry {
             id: id.clone(),
+            is_available: daemon.config_registered,
             daemon,
             is_disabled,
-            is_available: false,
         }));
     }
     let is_disabled = state_file.disabled.contains(id);
@@ -180,7 +180,7 @@ fn build_daemon_list(
         entries.push(DaemonListEntry {
             id: daemon.id.clone(),
             is_disabled: disabled_set.contains(&daemon.id),
-            is_available: false,
+            is_available: daemon.config_registered,
             daemon,
         });
     }

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -440,41 +440,16 @@ impl Supervisor {
         PROCS.refresh_pids(&[pid]);
         let daemon = self
             .upsert_daemon(
-                UpsertDaemonOpts::builder(id.clone())
+                UpsertDaemonOpts::from_run_options(&opts, DaemonStatus::Running)
                     .set(|o| {
                         o.pid = Some(pid);
-                        o.status = DaemonStatus::Running;
-                        o.shell_pid = opts.shell_pid;
-                        o.dir = Some(opts.dir.0.clone());
                         o.cmd = Some(original_cmd);
-                        o.run = opts.run.clone();
-                        o.autostop = opts.autostop;
-                        o.cron_schedule = opts.cron_schedule.clone();
-                        o.cron_retrigger = opts.cron_retrigger;
-                        o.cron_immediate = opts.cron_immediate;
-                        o.retry = Some(opts.retry);
-                        o.retry_count = Some(opts.retry_count);
-                        o.ready_delay = opts.ready_delay;
-                        o.ready_output = opts.ready_output.clone();
-                        o.ready_http = opts.ready_http.clone();
                         o.ready_port = effective_ready_port;
-                        o.ready_cmd = opts.ready_cmd.clone();
                         o.port = crate::config_types::PortConfig::from_parts(
                             expected_ports,
                             opts.port.as_ref().map(|p| p.bump).unwrap_or_default(),
                         );
                         o.resolved_port = resolved_ports;
-                        o.depends = Some(opts.depends.clone());
-                        o.env = opts.env.clone();
-                        o.watch = Some(opts.watch.clone());
-                        o.watch_mode = Some(opts.watch_mode);
-                        o.watch_base_dir = opts.watch_base_dir.clone();
-                        o.mise = opts.mise;
-                        o.user = opts.user.clone();
-                        o.memory_limit = opts.memory_limit;
-                        o.cpu_limit = opts.cpu_limit;
-                        o.stop_signal = opts.stop_signal;
-                        o.pty = opts.pty;
                     })
                     .build(),
             )

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -72,6 +72,8 @@ pub(crate) struct UpsertDaemonOpts {
     pub stop_signal: Option<StopConfig>,
     /// Allocate a pseudo-terminal for the daemon process
     pub pty: Option<bool>,
+    /// True for config-only cron daemons auto-registered into state.
+    pub config_registered: bool,
 }
 
 /// Builder for UpsertDaemonOpts - ensures daemon ID is always provided.
@@ -240,6 +242,7 @@ impl Supervisor {
             cpu_limit: opts.cpu_limit.or(existing.and_then(|d| d.cpu_limit)),
             stop_signal: opts.stop_signal.or(existing.and_then(|d| d.stop_signal)),
             pty: opts.pty.or(existing.and_then(|d| d.pty)),
+            config_registered: opts.config_registered,
         };
         state_file.insert_daemon(&opts.id, daemon.clone());
         Ok(daemon)
@@ -341,7 +344,7 @@ impl Supervisor {
     /// Clean up daemons that have no PID
     pub(crate) async fn clean(&self) -> Result<()> {
         let mut state_file = self.state_file.lock().await;
-        state_file.retain_daemons(|_id, d| d.pid.is_some() || d.cron_schedule.is_some());
+        state_file.retain_daemons(|_id, d| d.pid.is_some());
         Ok(())
     }
 }

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -5,6 +5,7 @@
 use super::Supervisor;
 use crate::Result;
 use crate::daemon::Daemon;
+use crate::daemon::RunOptions;
 use crate::daemon_id::DaemonId;
 use crate::daemon_status::DaemonStatus;
 use crate::pitchfork_toml::CpuLimit;
@@ -98,6 +99,45 @@ impl UpsertDaemonOpts {
                 ..Default::default()
             },
         }
+    }
+
+    /// Build an `UpsertDaemonOptsBuilder` from `RunOptions`, mapping all
+    /// config-carried fields. Callers chain `.set()` to add runtime-specific
+    /// fields (pid, resolved_port, etc.) and then call `.build()`.
+    pub(crate) fn from_run_options(
+        opts: &RunOptions,
+        status: DaemonStatus,
+    ) -> UpsertDaemonOptsBuilder {
+        UpsertDaemonOpts::builder(opts.id.clone()).set(|o| {
+            o.status = status;
+            o.shell_pid = opts.shell_pid;
+            o.dir = Some(opts.dir.0.clone());
+            o.cmd = Some(opts.cmd.clone());
+            o.run = opts.run.clone();
+            o.autostop = opts.autostop;
+            o.cron_schedule = opts.cron_schedule.clone();
+            o.cron_retrigger = opts.cron_retrigger;
+            o.cron_immediate = opts.cron_immediate;
+            o.retry = Some(opts.retry);
+            o.retry_count = Some(opts.retry_count);
+            o.ready_delay = opts.ready_delay;
+            o.ready_output = opts.ready_output.clone();
+            o.ready_http = opts.ready_http.clone();
+            o.ready_port = opts.ready_port;
+            o.ready_cmd = opts.ready_cmd.clone();
+            o.port = opts.port.clone();
+            o.depends = Some(opts.depends.clone());
+            o.env = opts.env.clone();
+            o.watch = Some(opts.watch.clone());
+            o.watch_mode = Some(opts.watch_mode);
+            o.watch_base_dir = opts.watch_base_dir.clone();
+            o.mise = opts.mise;
+            o.user = opts.user.clone();
+            o.memory_limit = opts.memory_limit;
+            o.cpu_limit = opts.cpu_limit;
+            o.stop_signal = opts.stop_signal;
+            o.pty = opts.pty;
+        })
     }
 }
 
@@ -301,7 +341,7 @@ impl Supervisor {
     /// Clean up daemons that have no PID
     pub(crate) async fn clean(&self) -> Result<()> {
         let mut state_file = self.state_file.lock().await;
-        state_file.retain_daemons(|_id, d| d.pid.is_some());
+        state_file.retain_daemons(|_id, d| d.pid.is_some() || d.cron_schedule.is_some());
         Ok(())
     }
 }

--- a/src/supervisor/watchers.rs
+++ b/src/supervisor/watchers.rs
@@ -460,17 +460,42 @@ impl Supervisor {
         Ok(())
     }
 
-    /// Register config-only cron daemons into state.
+    /// Register config-only cron daemons into state and remove stale entries.
     ///
     /// Daemons defined in config with `cron` but never started are not in
     /// `state_file.daemons`, so the cron watcher cannot see them. This method
     /// scans the merged config and upserts any cron daemons that are missing
-    /// from state, using `Stopped` status with no PID. Once registered, the
-    /// cron watcher picks them up on subsequent ticks.
+    /// from state, marking them with `config_registered = true` so that
+    /// list/status/stats treat them as "available" rather than "stopped".
+    ///
+    /// Also removes stale `config_registered` entries for daemons whose cron
+    /// config has been removed, so they stop firing.
     async fn register_config_cron_daemons(&self) -> Result<()> {
         let config = PitchforkToml::all_merged_all_namespaces()?;
 
-        // Find config-only cron daemons not yet in state.
+        let config_cron_ids: HashSet<&DaemonId> = config
+            .daemons
+            .iter()
+            .filter(|(_, d)| d.cron.is_some())
+            .map(|(id, _)| id)
+            .collect();
+
+        // Remove stale config_registered entries no longer in config.
+        let stale_ids: Vec<DaemonId> = {
+            let state = self.state_file.lock().await;
+            state
+                .daemons
+                .iter()
+                .filter(|(id, d)| d.config_registered && !config_cron_ids.contains(*id))
+                .map(|(id, _)| id.clone())
+                .collect()
+        };
+        for id in &stale_ids {
+            self.remove_daemon(id).await?;
+            info!("removed stale config-only cron daemon {id} from state");
+        }
+
+        // Register config-only cron daemons not yet in state.
         let to_register: Vec<_> = {
             let state = self.state_file.lock().await;
             config
@@ -490,7 +515,11 @@ impl Supervisor {
             };
             let run_opts = d.to_run_options(id, cmd);
             self.upsert_daemon(
-                UpsertDaemonOpts::from_run_options(&run_opts, DaemonStatus::Stopped).build(),
+                UpsertDaemonOpts::from_run_options(&run_opts, DaemonStatus::Stopped)
+                    .set(|o| {
+                        o.config_registered = true;
+                    })
+                    .build(),
             )
             .await?;
             info!("registered config-only cron daemon {id} into state");

--- a/src/supervisor/watchers.rs
+++ b/src/supervisor/watchers.rs
@@ -634,12 +634,16 @@ impl Supervisor {
                             true
                         }
                         crate::pitchfork_toml::CronRetrigger::Success => {
-                            // Run only if previous command succeeded
-                            daemon.pid.is_none() && daemon.last_exit_success.unwrap_or(false)
+                            // Run if not currently running and the previous run
+                            // succeeded. A never-started daemon (None) is allowed
+                            // to fire its first run.
+                            daemon.pid.is_none() && daemon.last_exit_success.unwrap_or(true)
                         }
                         crate::pitchfork_toml::CronRetrigger::Fail => {
-                            // Run only if previous command failed
-                            daemon.pid.is_none() && !daemon.last_exit_success.unwrap_or(true)
+                            // Run if not currently running and the previous run
+                            // failed. A never-started daemon (None) is allowed
+                            // to fire its first run.
+                            daemon.pid.is_none() && !daemon.last_exit_success.unwrap_or(false)
                         }
                     };
 

--- a/src/supervisor/watchers.rs
+++ b/src/supervisor/watchers.rs
@@ -5,8 +5,9 @@
 //! - Cron scheduling
 //! - File watching for daemon auto-restart
 
-use super::{SUPERVISOR, Supervisor, interval_duration};
+use super::{SUPERVISOR, Supervisor, UpsertDaemonOpts, interval_duration};
 use crate::daemon_id::DaemonId;
+use crate::daemon_status::DaemonStatus;
 use crate::ipc::IpcResponse;
 use crate::log_store::sqlite::LOG_STORE;
 use crate::log_store::{LogStore, RetentionPolicy};
@@ -459,10 +460,55 @@ impl Supervisor {
         Ok(())
     }
 
+    /// Register config-only cron daemons into state.
+    ///
+    /// Daemons defined in config with `cron` but never started are not in
+    /// `state_file.daemons`, so the cron watcher cannot see them. This method
+    /// scans the merged config and upserts any cron daemons that are missing
+    /// from state, using `Stopped` status with no PID. Once registered, the
+    /// cron watcher picks them up on subsequent ticks.
+    async fn register_config_cron_daemons(&self) -> Result<()> {
+        let config = PitchforkToml::all_merged_all_namespaces()?;
+
+        // Find config-only cron daemons not yet in state.
+        let to_register: Vec<_> = {
+            let state = self.state_file.lock().await;
+            config
+                .daemons
+                .iter()
+                .filter(|(id, d)| d.cron.is_some() && !state.daemons.contains_key(*id))
+                .collect()
+        };
+
+        for (id, d) in to_register {
+            let cmd = match shell_words::split(&d.run) {
+                Ok(cmd) => cmd,
+                Err(e) => {
+                    error!("failed to parse command for cron daemon {id}: {e}");
+                    continue;
+                }
+            };
+            let run_opts = d.to_run_options(id, cmd);
+            self.upsert_daemon(
+                UpsertDaemonOpts::from_run_options(&run_opts, DaemonStatus::Stopped).build(),
+            )
+            .await?;
+            info!("registered config-only cron daemon {id} into state");
+        }
+
+        Ok(())
+    }
+
     /// Check cron schedules and trigger daemons as needed
     pub(crate) async fn check_cron_schedules(&self) -> Result<()> {
         use cron::Schedule;
         use std::str::FromStr;
+
+        // Register config-only cron daemons into state so the cron watcher
+        // can see them. Without this, daemons defined in config with `cron`
+        // but never started (no `boot_start`, no manual `pitchfork start`)
+        // are invisible to the cron checker.
+        self.register_config_cron_daemons().await?;
 
         let now = chrono::Local::now();
 

--- a/src/web/routes/api/stats.rs
+++ b/src/web/routes/api/stats.rs
@@ -43,25 +43,30 @@ pub async fn stats() -> Json<ApiStats> {
 
     let running = user_daemons
         .iter()
-        .filter(|(_, d)| d.status.is_running())
+        .filter(|(_, d)| d.status.is_running() && !d.config_registered)
         .count();
     let stopped = user_daemons
         .iter()
-        .filter(|(_, d)| d.status.is_stopped())
+        .filter(|(_, d)| d.status.is_stopped() && !d.config_registered)
         .count();
     let errored = user_daemons
         .iter()
-        .filter(|(_, d)| d.status.is_errored())
+        .filter(|(_, d)| d.status.is_errored() && !d.config_registered)
         .count();
 
-    // Config-only daemons (in config but not in state) are "available".
+    // Available: config-only daemons not in state, plus config_registered
+    // daemons in state (registered by cron watcher but never started).
     let state_ids: std::collections::HashSet<&DaemonId> =
         user_daemons.iter().map(|(id, _)| *id).collect();
     let available = pt
         .daemons
         .keys()
         .filter(|id| **id != pitchfork_id && !state_ids.contains(id))
-        .count();
+        .count()
+        + user_daemons
+            .iter()
+            .filter(|(_, d)| d.config_registered)
+            .count();
 
     let mut all_ids = std::collections::HashSet::new();
     for (id, _) in user_daemons {

--- a/src/web/routes/api/stats.rs
+++ b/src/web/routes/api/stats.rs
@@ -12,6 +12,7 @@ pub struct ApiStats {
     running: usize,
     stopped: usize,
     errored: usize,
+    available: usize,
 }
 
 pub async fn stats() -> Json<ApiStats> {
@@ -28,6 +29,7 @@ pub async fn stats() -> Json<ApiStats> {
                 running: 0,
                 stopped: 0,
                 errored: 0,
+                available: 0,
             });
         }
     };
@@ -52,6 +54,15 @@ pub async fn stats() -> Json<ApiStats> {
         .filter(|(_, d)| d.status.is_errored())
         .count();
 
+    // Config-only daemons (in config but not in state) are "available".
+    let state_ids: std::collections::HashSet<&DaemonId> =
+        user_daemons.iter().map(|(id, _)| *id).collect();
+    let available = pt
+        .daemons
+        .keys()
+        .filter(|id| **id != pitchfork_id && !state_ids.contains(id))
+        .count();
+
     let mut all_ids = std::collections::HashSet::new();
     for (id, _) in user_daemons {
         all_ids.insert(id.clone());
@@ -66,5 +77,6 @@ pub async fn stats() -> Json<ApiStats> {
         running,
         stopped,
         errored,
+        available,
     })
 }


### PR DESCRIPTION
Daemons defined in config with `cron = ...` but no `boot_start` were never triggered by the cron watcher because it only iterated `state_file.daemons`. Config-only daemons (never started) were not in state, so the cron filter returned an empty set for them.

Changes:
- Cron watcher registers config-only cron daemons into state at the start of each `check_cron_schedules` tick, using Stopped status with no PID so the cron checker can see them.
- `pitchfork status` now falls back to config lookup and shows "available" instead of "not found" for config-only daemons.
- `clean()` preserves daemons with `cron_schedule` so registered cron daemons are not removed by `pitchfork clean`.
- Web API `/stats` adds `available` count for config-only daemons.
- `proxy list` shows "available" instead of "not started" for config-only daemons, consistent with `pitchfork list`.
- Added `UpsertDaemonOpts::from_run_options` to share the RunOptions-to-UpsertDaemonOpts field mapping, eliminating duplicate code in `lifecycle.rs`.

Closes #542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI status (including proxy status) now shows config-defined daemons as **available** when present in merged configuration, and as **unconfigured** when not.
  * Cron-configured daemons are auto-registered from configuration and appear in status even before first start.
  * API stats now include an **available** count and adjust running/stopped/errored to exclude config-registered (not-yet-started) daemons.
* **Bug Fixes**
  * Status output no longer fails when a daemon is missing from saved state.
  * Cron-configured daemons are preserved/registered correctly and cron retrigger allows first runs for never-started daemons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->