### PR TITLE
chore(release): verify crate includes ui assets

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -36,6 +36,8 @@ jobs:
         run: |
           aube install
           aube run build
+      - name: Verify published crate includes UI assets
+        run: mise run test:package
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130

--- a/mise.toml
+++ b/mise.toml
@@ -15,10 +15,10 @@ depends = ["build"]
 run = "pitchfork sup start -f"
 
 [tasks.ci]
-depends = ["lint", "build", "build:docs", "test", "test:web-ui"]
+depends = ["lint", "build", "build:docs", "test", "test:web-ui", "test:package"]
 
 [tasks.ci-dev]
-depends = ["lint-fix", "build", "build:docs", "test", "test:web-ui"]
+depends = ["lint-fix", "build", "build:docs", "test", "test:web-ui", "test:package"]
 
 [tasks.docs]
 dir = "docs"
@@ -44,6 +44,17 @@ run = [
   "if [ \"$(uname -s)\" = \"Linux\" ]; then node_modules/.bin/playwright install --with-deps chromium; else node_modules/.bin/playwright install chromium; fi",
   "node_modules/.bin/playwright test",
 ]
+
+[tasks."test:package"]
+depends = ["build:ui"]
+run = '''
+rm -f target/package/pitchfork-cli-*.crate
+cargo package --allow-dirty --no-verify
+crate=$(find target/package -maxdepth 1 -type f -name 'pitchfork-cli-*.crate' -print -quit)
+test -n "$crate"
+tar -tf "$crate" | grep -q '/ui/dist/index.html$'
+tar -tf "$crate" | grep -q '/ui/dist/assets/'
+'''
 
 [tasks."build:ui"]
 dir = "ui"

--- a/ui/tests/web-ui-smoke.spec.ts
+++ b/ui/tests/web-ui-smoke.spec.ts
@@ -17,7 +17,8 @@ type WebSupervisor = {
 }
 
 async function startWebSupervisor(): Promise<WebSupervisor> {
-  const root = await mkdtemp(path.join(tmpdir(), 'pitchfork-web-ui-'))
+  const tmpRoot = process.platform === 'win32' ? tmpdir() : '/tmp'
+  const root = await mkdtemp(path.join(tmpRoot, 'pitchfork-web-ui-'))
   const home = path.join(root, 'home')
   const project = path.join(root, 'project')
   await mkdir(path.join(home, '.config'), { recursive: true })


### PR DESCRIPTION
## Summary
- add a `test:package` task that builds the same crate archive Cargo publishes and verifies bundled web UI files are present
- run that package verification in CI and immediately before `release-plz` publishes to crates.io
- keep the web UI smoke test temp path short on POSIX to avoid Unix socket path limits during local `ci-dev`

## Tests
- `mise run test:package`
- workflow YAML parse for `release.yml` and `release-plz.yml`
- `mise run ci-dev`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release guardrails and a smoke-test temp-path tweak; no runtime product logic changes.
> 
> **Overview**
> Adds **`mise run test:package`**, which runs `cargo package` and asserts the tarball contains `ui/dist/index.html` and `ui/dist/assets/`, so a release cannot ship without bundled web UI files.
> 
> That check runs in the **release-plz** workflow after the UI build and is wired into **`ci`** / **`ci-dev`** alongside existing tests.
> 
> The Playwright web UI smoke test now creates temp dirs under **`/tmp`** on POSIX (still OS temp on Windows) to keep paths short and avoid Unix socket length limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db1c6f8931d84c6d324e623ccef0802c1617dcf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smoke test workspace setup on Windows and other platforms for more reliable temporary file handling.
  * Added an extra release-time check to ensure packaged builds include the expected UI assets.
* **Tests**
  * Expanded CI and release validation to verify package contents before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->