### PR TITLE
fix(logs): anchor startup log stream to max id instead of timestamp

### DIFF
--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -932,7 +932,6 @@ pub fn collect_startup_logs(
 /// that stops the streaming when sent `true`.
 pub fn stream_startup_logs(
     daemon_id: &DaemonId,
-    from: DateTime<Local>,
     job: std::sync::Arc<clx::progress::ProgressJob>,
 ) -> (
     tokio::sync::watch::Sender<bool>,
@@ -942,6 +941,21 @@ pub fn stream_startup_logs(
     let id = daemon_id.clone();
 
     let show_ts = crate::settings::settings().general.startup_log_timestamps;
+
+    // Anchor to the daemon's current max log id *synchronously* before
+    // spawning the streaming task. This must happen before ipc.run() starts
+    // the daemon, otherwise early output could be written to the log store
+    // before the anchor is established and get skipped as "already seen".
+    let anchor_id: i64 = LOG_STORE
+        .query(&LogQuery {
+            daemon_ids: vec![id.qualified()],
+            limit: Some(1),
+            order_desc: true,
+            ..Default::default()
+        })
+        .ok()
+        .and_then(|entries| entries.last().map(|e| e.id))
+        .unwrap_or(0);
 
     let handle = tokio::spawn(async move {
         let is_tty = std::io::stderr().is_terminal();
@@ -953,19 +967,10 @@ pub fn stream_startup_logs(
             edim("•").to_string()
         };
 
-        let mut last_id: i64 = 0;
+        let mut last_id = anchor_id;
 
-        // Initial fetch: all logs since daemon start time
-        let initial_entries = LOG_STORE.query(&LogQuery {
-            daemon_ids: vec![id.qualified()],
-            from: Some(from),
-            to: None,
-            limit: None,
-            order_desc: false,
-            after_id: None,
-        });
-
-        if let Ok(entries) = initial_entries {
+        // Initial fetch: catch any logs already written since the anchor.
+        if let Ok(entries) = LOG_STORE.tail(&id, Some(last_id)) {
             for entry in &entries {
                 let time = entry.timestamp.format("%H:%M:%S").to_string();
                 let msg = strip_pty_controls(&entry.message);

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -122,11 +122,9 @@ impl Run {
             None
         };
 
-        let start_time = chrono::Local::now();
-
         // Start streaming logs for this daemon
         let (log_stop_tx, log_handle) = if let Some(ref job) = job {
-            let (tx, handle) = stream_startup_logs(&daemon_id, start_time, job.clone());
+            let (tx, handle) = stream_startup_logs(&daemon_id, job.clone());
             (Some(tx), Some(handle))
         } else {
             (None, None)

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -688,11 +688,9 @@ impl IpcClient {
                 None
             };
 
-            let start_time = chrono::Local::now();
-
             // Start streaming logs for this daemon
             let (log_stop_tx, log_handle) = if let Some(ref job) = job {
-                let (tx, handle) = stream_startup_logs(&id, start_time, job.clone());
+                let (tx, handle) = stream_startup_logs(&id, job.clone());
                 (Some(tx), Some(handle))
             } else {
                 (None, None)
@@ -779,11 +777,9 @@ impl IpcClient {
                 None
             };
 
-            let start_time = chrono::Local::now();
-
             // Start streaming logs for this daemon
             let (log_stop_tx, log_handle) = if let Some(ref job) = job {
-                let (tx, handle) = stream_startup_logs(&id, start_time, job.clone());
+                let (tx, handle) = stream_startup_logs(&id, job.clone());
                 (Some(tx), Some(handle))
             } else {
                 (None, None)


### PR DESCRIPTION
stream_startup_logs mixed two query bases: initial fetch used timestamp filtering (from: start_time) while polling used id filtering (tail after_id). start_time was captured before ipc.run(), so the initial fetch was always empty, leaving last_id at 0 and causing tail(0) to return all historical logs from previous runs.

Unify on id-based anchoring: query the daemon's current max row id on entry, then use tail(after_id) for both initial fetch and polling. This matches the existing pattern in tail_logs. Drop the now-unnecessary from parameter and start_time variables at call sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup log streaming now anchors on the latest available log entry, improving continuity when launching or attaching to jobs.
  * Eliminated reliance on a previously captured start timestamp to avoid duplicate or out-of-order startup logs.
  * Log output formatting behavior remains the same (including existing timestamp/prefix handling and terminal vs non-terminal message presentation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->