### PR TITLE
docs: document $PORTN env vars and fix misleading template note

### DIFF
--- a/docs/guides/configuration-templates.md
+++ b/docs/guides/configuration-templates.md
@@ -123,7 +123,7 @@ Level 2: worker   (depends on api, templates can reference redis and api)
 
 - Daemons within the same level start concurrently and **cannot** reference each other's ports
 - A daemon can reference any daemon that completed successfully in a previous level
-- `port` and `ports` for the current daemon are **not** available at template rendering time (ports are resolved after the command is constructed). Use <code v-pre>{{ daemons.xxx.port }}</code> to reference dependencies' ports instead
+- `port` and `ports` for the current daemon are **not** available at template rendering time (ports are resolved after the command is constructed). Use the `$PORT` / `$PORT0`, `$PORT1`, ... environment variables to access the current daemon's own resolved ports. Use <code v-pre>{{ daemons.xxx.port }}</code> to reference **dependencies'** ports instead
 
 ## Error Handling
 

--- a/docs/guides/port-management.md
+++ b/docs/guides/port-management.md
@@ -22,6 +22,23 @@ port = [8080, 8443]
 
 Pitchfork checks if the port is available before starting, injects it into the daemon's environment, and fails with a clear error if the port is already in use.
 
+Resolved ports are exposed via the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `$PORT` | First resolved port (alias for `$PORT0`) |
+| `$PORT0` | First resolved port |
+| `$PORT1` | Second resolved port |
+| `$PORTN` | Nth resolved port (0-indexed) |
+
+When a single port is configured, both `$PORT` and `$PORT0` are set to the same value. For multiple ports, each port is available at its corresponding index:
+
+```toml
+[daemons.multi]
+run = "./start.sh --http-port $PORT0 --grpc-port $PORT1"
+port = [8080, 8443]
+```
+
 ### Auto Port Bumping
 
 When a port is occupied, enable `bump` to automatically find the next available port:
@@ -40,24 +57,7 @@ run = "node server.js"
 port = { expect = [3000], bump = true }
 ```
 
-The daemon receives the actual allocated port via the following environment variables:
-
-| Variable | Description |
-|----------|-------------|
-| `$PORT` | First resolved port (alias for `$PORT0`) |
-| `$PORT0` | First resolved port |
-| `$PORT1` | Second resolved port |
-| `$PORTN` | Nth resolved port (0-indexed) |
-
-When a single port is configured, both `$PORT` and `$PORT0` are set to the same value. For multiple ports, each port is available at its corresponding index:
-
-```toml
-[daemons.multi]
-run = "./start.sh --http-port $PORT0 --grpc-port $PORT1"
-port = [8080, 8443]
-```
-
-These environment variables reflect the **resolved** port, so they work correctly with auto-bumping.
+These environment variables reflect the **resolved** port, so they work correctly with auto-bumping. See [Port Assignment](#port-assignment) for the full list of available variables.
 
 ### Active Port Tracking
 

--- a/docs/guides/port-management.md
+++ b/docs/guides/port-management.md
@@ -20,7 +20,7 @@ run = "./start.sh"
 port = [8080, 8443]
 ```
 
-Pitchfork checks if the port is available before starting, injects `PORT=3000` into the daemon's environment, and fails with a clear error if the port is already in use.
+Pitchfork checks if the port is available before starting, injects it into the daemon's environment, and fails with a clear error if the port is already in use.
 
 ### Auto Port Bumping
 
@@ -40,7 +40,24 @@ run = "node server.js"
 port = { expect = [3000], bump = true }
 ```
 
-The daemon receives the actual allocated port via `$PORT`.
+The daemon receives the actual allocated port via the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `$PORT` | First resolved port (alias for `$PORT0`) |
+| `$PORT0` | First resolved port |
+| `$PORT1` | Second resolved port |
+| `$PORTN` | Nth resolved port (0-indexed) |
+
+When a single port is configured, both `$PORT` and `$PORT0` are set to the same value. For multiple ports, each port is available at its corresponding index:
+
+```toml
+[daemons.multi]
+run = "./start.sh --http-port $PORT0 --grpc-port $PORT1"
+port = [8080, 8443]
+```
+
+These environment variables reflect the **resolved** port, so they work correctly with auto-bumping.
 
 ### Active Port Tracking
 


### PR DESCRIPTION
- Document the `$PORT0`, `$PORT1`, ... environment variables that expose all resolved ports to daemons (not just the first one via `$PORT`)
- Fix the misleading note in `configuration-templates.md` that suggested using `{{ daemons.xxx.port }}` for the current daemon's own ports. Clarify that templates can only reference **dependencies'** ports, and the current daemon's own ports should be accessed via `$PORT` / `$PORT0`, `$PORT1`, ... environment variables

Closes #562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how template rendering resolves port values, including using `$PORT` / `$PORT0`, `$PORT1`, etc. for the current daemon while keeping `{{ daemons.xxx.port }}` for dependency ports.
  * Expanded “Port Assignment” guidance to explain pre-start port availability checks and clearer errors when a port is already in use.
  * Expanded “Auto Port Bumping” documentation to specify the environment variables provided (`$PORT`, `$PORT0`, `$PORT1`, …) and that they reflect resolved port values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->