### PR TITLE
chore: release v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.0](https://github.com/jdx/pitchfork/compare/v2.15.0...v2.16.0) - 2026-07-07
+
+### Added
+
+- *(logs)* add message filtering with --grep, --regex ([#532](https://github.com/jdx/pitchfork/pull/532))
+
+### Fixed
+
+- *(config)* preserve settings on config write ([#575](https://github.com/jdx/pitchfork/pull/575))
+- *(deps)* update rust crate tera to v2 ([#571](https://github.com/jdx/pitchfork/pull/571))
+
+### Other
+
+- *(config)* upgrade humanbyte to 0.4, consolidate byte formatting ([#582](https://github.com/jdx/pitchfork/pull/582))
+- *(deps)* update rust crate ratatui to v0.30.2 ([#567](https://github.com/jdx/pitchfork/pull/567))
+- *(procs)* avoid full process refresh on PROCS init and is_running ([#576](https://github.com/jdx/pitchfork/pull/576))
+- *(deps)* update rust crate xx to v2.6.1 ([#570](https://github.com/jdx/pitchfork/pull/570))
+- *(deps)* lock file maintenance ([#578](https://github.com/jdx/pitchfork/pull/578))
+- Update sponsor references for jdx.dev ([#566](https://github.com/jdx/pitchfork/pull/566))
+
 ## [2.15.0](https://github.com/jdx/pitchfork/compare/v2.14.0...v2.15.0) - 2026-07-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,7 +2882,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.15.0"
+version = "2.16.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.15.0"
+version = "2.16.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2725,7 +2725,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.15.0",
+  "version": "2.16.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.15.0
+**Version**: 2.16.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.15.0"
+version "2.16.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.15.0 -> 2.16.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.16.0](https://github.com/jdx/pitchfork/compare/v2.15.0...v2.16.0) - 2026-07-07

### Added

- *(logs)* add message filtering with --grep, --regex ([#532](https://github.com/jdx/pitchfork/pull/532))

### Fixed

- *(config)* preserve settings on config write ([#575](https://github.com/jdx/pitchfork/pull/575))
- *(deps)* update rust crate tera to v2 ([#571](https://github.com/jdx/pitchfork/pull/571))

### Other

- *(config)* upgrade humanbyte to 0.4, consolidate byte formatting ([#582](https://github.com/jdx/pitchfork/pull/582))
- *(deps)* update rust crate ratatui to v0.30.2 ([#567](https://github.com/jdx/pitchfork/pull/567))
- *(procs)* avoid full process refresh on PROCS init and is_running ([#576](https://github.com/jdx/pitchfork/pull/576))
- *(deps)* update rust crate xx to v2.6.1 ([#570](https://github.com/jdx/pitchfork/pull/570))
- *(deps)* lock file maintenance ([#578](https://github.com/jdx/pitchfork/pull/578))
- Update sponsor references for jdx.dev ([#566](https://github.com/jdx/pitchfork/pull/566))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and changelog/documentation sync only; no runtime code changes in this PR.
> 
> **Overview**
> **Release v2.16.0** bumps `pitchfork-cli` from **2.15.0** to **2.16.0** and publishes the matching **CHANGELOG** entry. Version strings are updated in `Cargo.toml`, `Cargo.lock`, `pitchfork.usage.kdl`, and generated CLI docs (`docs/cli/commands.json`, `docs/cli/index.md`).
> 
> The release notes document shipped work since 2.15.0, including **`pitchfork logs`** filtering via **`--grep`** / **`--regex`**, a fix so **config writes preserve existing settings**, **PROCS** avoiding full process refresh on init/`is_running`, **humanbyte 0.4** for byte formatting, and assorted dependency updates (e.g. **tera v2**, **ratatui**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77cec82120f410b9fb38a833d932447b399a6943. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->