### PR TITLE
Update sponsor references for jdx.dev

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -94,9 +94,9 @@ jobs:
 
           ## 💚 Sponsor pitchfork
 
-          pitchfork is built by [@jdx](https://github.com/jdx), who ships developer tools like [mise](https://mise.jdx.dev/), hk, pitchfork, and more. Development is sustained by sponsorships.
+          pitchfork is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Development is sustained by sponsorships.
 
-          If pitchfork has a place in your dev workflow, please consider [sponsoring on GitHub](https://github.com/sponsors/jdx). Individual and company sponsorships are what keep the project healthy and moving forward.
+          If pitchfork has a place in your dev workflow, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Individual and company sponsorships are what keep the project healthy and moving forward.
           EOF
           } > /tmp/release-notes.md
           gh release edit "$TAG" --notes-file /tmp/release-notes.md

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, and <a href="https://coderabbit.link/mise">CodeRabbit</a>.<br>
+  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://37signals.com">37signals</a>.<br>
   <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://37signals.com">37signals</a>.<br>
-  <a href="https://en.dev/sponsors.html">View all sponsors</a>.
+  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, <a href="https://coderabbit.link/mise">CodeRabbit</a>, and <a href="https://supabase.com">Supabase</a>.<br>
+  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 
 <hr />

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, <a href="https://coderabbit.link/mise">CodeRabbit</a>, and <a href="https://supabase.com">Supabase</a>.<br>
+  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, and <a href="https://coderabbit.link/mise">CodeRabbit</a>.<br>
   <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -35,7 +35,7 @@ import { onMounted, ref } from "vue";
 
 const sponsors = ref([]);
 const error = ref(false);
-const footerTiers = new Set(["anchor", "premier", "partner"]);
+const footerTiers = new Set(["title", "premier", "partner"]);
 const sponsorFeedTimeoutMs = 5000;
 
 const sponsorItems = (items) => (Array.isArray(items) ? items : []);

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -1,5 +1,6 @@
 <template>
   <section
+    v-if="sponsors.length || error"
     aria-labelledby="endev-sponsors-title"
     class="EndevSponsors"
   >
@@ -7,12 +8,77 @@
       <p id="endev-sponsors-title" class="EndevSponsorsTitle">
         sponsors
       </p>
-      <a class="EndevSponsorsCta" href="https://github.com/sponsors/jdx">
-        Sponsor on GitHub
+      <p v-if="error" class="EndevSponsorsError">
+        Sponsor feed unavailable.
+      </p>
+      <div v-else class="EndevSponsorsLogos">
+        <a
+          v-for="sponsor in sponsors"
+          :key="sponsor.url"
+          class="EndevSponsorsLogo"
+          :href="sponsor.url"
+          rel="noopener noreferrer sponsored"
+          target="_blank"
+        >
+          <img :alt="sponsor.name" :src="sponsor.logo" loading="lazy" decoding="async" />
+        </a>
+      </div>
+      <a class="EndevSponsorsCta" href="https://jdx.dev/sponsors.html">
+        View all sponsors
       </a>
     </div>
   </section>
 </template>
+
+<script setup>
+import { onMounted, ref } from "vue";
+
+const sponsors = ref([]);
+const error = ref(false);
+const footerTiers = new Set(["anchor", "premier", "partner"]);
+const sponsorFeedTimeoutMs = 5000;
+
+const sponsorItems = (items) => (Array.isArray(items) ? items : []);
+const isSafeUrl = (url) => {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
+};
+const isSponsor = (sponsor) =>
+  sponsor &&
+  typeof sponsor === "object" &&
+  typeof sponsor.name === "string" &&
+  typeof sponsor.url === "string" &&
+  typeof sponsor.logo === "string" &&
+  isSafeUrl(sponsor.url) &&
+  isSafeUrl(sponsor.logo);
+
+onMounted(async () => {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), sponsorFeedTimeoutMs);
+
+  try {
+    const res = await fetch("https://jdx.dev/sponsors.json", {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`Sponsor feed returned ${res.status}`);
+
+    const payload = await res.json();
+    sponsors.value = sponsorItems(payload?.sponsors).filter((sponsor) =>
+      isSponsor(sponsor) && footerTiers.has(sponsor.tier),
+    );
+  } catch {
+    error.value = true;
+    sponsors.value = [];
+  } finally {
+    window.clearTimeout(timeout);
+  }
+});
+</script>
 
 <style scoped>
 .EndevSponsors {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2055,7 +2055,7 @@
         "flags": [],
         "mounts": [],
         "hide": false,
-        "help": "Show the companies sponsoring pitchfork and the jdx project family",
+        "help": "Show the companies sponsoring pitchfork and the jdx.dev open source tools",
         "name": "sponsors",
         "aliases": [],
         "hidden_aliases": [],

--- a/docs/cli/sponsors.md
+++ b/docs/cli/sponsors.md
@@ -3,4 +3,4 @@
 
 - **Usage**: `pitchfork sponsors`
 
-Show the companies sponsoring pitchfork and the jdx project family
+Show the companies sponsoring pitchfork and the jdx.dev open source tools

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -291,7 +291,7 @@ cmd settings help="View and modify pitchfork settings" {
         arg <VALUE> help="Value to set (type must match the setting: string, integer, boolean, or duration)"
     }
 }
-cmd sponsors help="Show the companies sponsoring pitchfork and the jdx project family"
+cmd sponsors help="Show the companies sponsoring pitchfork and the jdx.dev open source tools"
 cmd start help="Starts a daemon from a pitchfork.toml file" {
     alias s
     long_help "Starts a daemon from a pitchfork.toml file\n\nDaemons are defined in pitchfork.toml with a `[daemons.<name>]` section.\nThe command waits for the daemon to be ready before returning.\n\nExamples:\n  pitchfork start api           Start a single daemon\n  pitchfork start api worker    Start multiple daemons\n  pitchfork start --group backend Start all daemons in the 'backend' group\n  pitchfork start -l            Start all local daemons in pitchfork.toml\n  pitchfork start -g            Start all global daemons in config.toml\n  pitchfork start -a            Start all daemons (local and global)\n  pitchfork start api -f        Restart daemon if already running\n  pitchfork start api --delay 5 Wait 5 seconds for daemon to be ready\n  pitchfork start api --output 'Listening on'\n                                Wait for output pattern before ready\n  pitchfork start api --http http://localhost:8080/health\n                                Wait for HTTP endpoint to return 2xx\n  pitchfork start api --port 8080\n                                Wait for TCP port to be listening"

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -12,7 +12,6 @@ impl Sponsors {
   entire.io - https://entire.io
   37signals - https://37signals.com
   CodeRabbit - https://coderabbit.link/mise
-  Supabase - https://supabase.com
 
 View all sponsors: https://jdx.dev/sponsors.html"#
         );

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -11,7 +11,6 @@ impl Sponsors {
 
   entire.io - https://entire.io
   37signals - https://37signals.com
-  CodeRabbit - https://coderabbit.link/mise
 
 View all sponsors: https://jdx.dev/sponsors.html"#
         );

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -1,17 +1,20 @@
 use crate::Result;
 
-/// Show the companies sponsoring pitchfork and the jdx project family
+/// Show the companies sponsoring pitchfork and the jdx.dev open source tools
 #[derive(Debug, clap::Args)]
 pub struct Sponsors;
 
 impl Sponsors {
     pub async fn run() -> Result<()> {
         println!(
-            r#"pitchfork and the jdx project family are sponsored by:
+            r#"pitchfork and the jdx.dev open source tools are sponsored by:
 
+  entire.io - https://entire.io
   37signals - https://37signals.com
+  CodeRabbit - https://coderabbit.link/mise
+  Supabase - https://supabase.com
 
-View all sponsors: https://github.com/sponsors/jdx"#
+View all sponsors: https://jdx.dev/sponsors.html"#
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- list Entire first in the README and sponsors command
- replace the static docs sponsor component with the jdx.dev sponsor feed
- update release blurb and generated CLI docs

## Tests
- git diff --check
- npm run docs:build from docs/
- npm install --package-lock=false && npm run build from ui/
- mise x rust@1.95.0 -- cargo run -q -p pitchfork-cli -- sponsors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy, docs, release-note append text, and a client-side sponsor JSON fetch in the docs theme only—no daemon, auth, or core runtime behavior changes.
> 
> **Overview**
> Sponsor messaging moves from GitHub Sponsors / **en.dev** to **jdx.dev**, with **entire.io** called out as title sponsor alongside **37signals**.
> 
> The **README**, **`pitchfork sponsors` CLI** (`sponsors.rs`), generated CLI docs (`pitchfork.usage.kdl`, `commands.json`, `sponsors.md`), and the **release-plz** sponsor blurb all use the new wording and point “view sponsors” links at `https://jdx.dev/sponsors.html`.
> 
> **`EndevSponsors.vue`** no longer shows only a static GitHub CTA: on mount it loads `https://jdx.dev/sponsors.json`, renders logo links for **title**, **premier**, and **partner** tiers (with http(s) URL checks and a 5s abort), and falls back to “Sponsor feed unavailable.” if the fetch fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74fee7317e66715d10f8b54710f9eed0c83f5346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->