### PR TITLE
fix(config): preserve settings on config write

### DIFF
--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -1175,8 +1175,11 @@ impl PitchforkToml {
             };
 
             // Convert back to raw format for writing (use short names as keys)
+            // Preserve settings so read-modify-write (e.g. `settings set`, `proxy add`)
+            // doesn't drop `[settings.*]`. Gate on is_empty to avoid a bare `[settings]`.
             let mut raw = PitchforkTomlRaw {
                 namespace: self.namespace.clone(),
+                settings: (!self.settings.is_empty()).then(|| self.settings.clone()),
                 ..PitchforkTomlRaw::default()
             };
             for (id, daemon) in &self.daemons {
@@ -1721,5 +1724,67 @@ user = "postgres"
             .get(&DaemonId::new("test-project", "api"))
             .unwrap();
         assert_eq!(daemon.user.as_deref(), Some("postgres"));
+    }
+
+    #[test]
+    fn test_settings_write_roundtrip() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pitchfork.toml");
+        let mut pt = PitchforkToml::new(path.clone());
+        pt.namespace = Some("test-project".to_string());
+        pt.settings.web.auto_start = Some(true);
+        pt.settings.general.log_level = Some("debug".to_string());
+
+        pt.write().unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            raw.contains("[settings.web]"),
+            "settings.web section should be written, got:\n{raw}"
+        );
+        assert!(raw.contains("auto_start = true"));
+        assert!(raw.contains("log_level = \"debug\""));
+
+        let parsed = PitchforkToml::read(&path).unwrap();
+        assert_eq!(parsed.settings.web.auto_start, Some(true));
+        assert_eq!(parsed.settings.general.log_level.as_deref(), Some("debug"));
+    }
+
+    #[test]
+    fn test_settings_preserved_on_unrelated_write() {
+        // Regression test for https://github.com/jdx/pitchfork/discussions/574
+        // A read-modify-write of slugs/namespaces must not drop existing [settings].
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pitchfork.toml");
+        std::fs::write(&path, "[settings.web]\nauto_start = true\n").unwrap();
+
+        let mut pt = PitchforkToml::read(&path).unwrap();
+        pt.slugs.insert(
+            "api".to_string(),
+            SlugEntry {
+                dir: None,
+                namespace: Some("myproject".to_string()),
+                daemon: None,
+            },
+        );
+        pt.namespaces.insert(
+            "myproject".to_string(),
+            NamespaceEntry {
+                dir: PathBuf::from("/tmp/myproject"),
+            },
+        );
+        pt.write().unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            raw.contains("[settings.web]"),
+            "existing settings must be preserved, got:\n{raw}"
+        );
+        assert!(raw.contains("auto_start = true"));
+        assert!(raw.contains("[slugs.api]"));
+
+        let parsed = PitchforkToml::read(&path).unwrap();
+        assert_eq!(parsed.settings.web.auto_start, Some(true));
+        assert!(parsed.slugs.contains_key("api"));
     }
 }


### PR DESCRIPTION
write_unlocked() constructed PitchforkTomlRaw without copying the settings field, so any read-modify-write cycle silently dropped existing [settings.*] entries. This broke `settings set` (the new value was discarded) and `proxy add`/`register_namespace`/ `remove_slug` (existing settings were wiped).

Copy self.settings into the raw struct, gated on is_empty() to avoid emitting a bare [settings] header for empty partials.

Fixes #574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing settings when saving configuration changes, so unrelated updates no longer remove previously saved settings.
  * Avoided creating an empty settings section during writes when no settings are present.
* **Tests**
  * Added coverage for settings round-tripping to confirm values are saved and read back correctly.
  * Added a regression test to ensure existing settings remain intact after unrelated configuration edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->