### PR TITLE
perf(procs): avoid full process refresh on PROCS init and is_running

### DIFF
--- a/src/cli/supervisor/mod.rs
+++ b/src/cli/supervisor/mod.rs
@@ -52,7 +52,6 @@ impl Supervisor {
 ///
 /// This is a low-level helper — callers are responsible for user-facing messages.
 pub async fn kill_or_stop(existing_pid: u32, force: bool) -> Result<KillOrStopOutcome> {
-    PROCS.refresh_pids(&[existing_pid]);
     if PROCS.is_running(existing_pid) {
         if force {
             debug!("killing pid {existing_pid}");

--- a/src/cli/supervisor/start.rs
+++ b/src/cli/supervisor/start.rs
@@ -31,7 +31,6 @@ impl Start {
                 let pid = existing_pid.expect("Killed implies a pid exists");
                 // Wait briefly for the old process to fully exit
                 for _ in 0..20 {
-                    PROCS.refresh_pids(&[pid]);
                     if !PROCS.is_running(pid) {
                         break;
                     }

--- a/src/cli/wait.rs
+++ b/src/cli/wait.rs
@@ -59,7 +59,6 @@ impl Wait {
 
         let mut interval = time::interval(time::Duration::from_millis(100));
         loop {
-            PROCS.refresh_pids(&[pid]);
             if !PROCS.is_running(pid) {
                 break;
             }

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -27,11 +27,21 @@ impl Default for Procs {
 
 impl Procs {
     pub fn new() -> Self {
-        let procs = Self {
-            system: Mutex::new(sysinfo::System::new_all()),
-        };
-        procs.refresh_processes();
-        procs
+        // IMPORTANT: Do NOT call refresh_processes() or System::new_all() here.
+        //
+        // Both refresh the state of every process in the system, which takes
+        // ~500ms on a typical machine. Since PROCS is a Lazy static, the first
+        // access triggers this constructor — and `pitchfork cd` (which only
+        // needs to check if the supervisor PID is alive) would block for that
+        // duration on every directory change.
+        //
+        // See https://github.com/jdx/pitchfork/discussions/439
+        //
+        // Callers that need process info must call refresh_pids() (for specific
+        // PIDs) or refresh_processes() (for full-system stats) explicitly.
+        Self {
+            system: Mutex::new(sysinfo::System::new()),
+        }
     }
 
     fn lock_system(&self) -> std::sync::MutexGuard<'_, sysinfo::System> {
@@ -48,9 +58,27 @@ impl Procs {
     }
 
     pub fn is_running(&self, pid: u32) -> bool {
-        self.lock_system()
-            .process(sysinfo::Pid::from_u32(pid))
-            .is_some()
+        // Use kill(pid, 0) on Unix for an O(1) liveness check that does not
+        // depend on the process cache being populated. This avoids the need
+        // for a full process refresh just to check a single PID.
+        // ESRCH = process does not exist; EPERM = process exists but owned
+        // by another user (still "running" from our perspective).
+        #[cfg(unix)]
+        {
+            unsafe {
+                if libc::kill(pid as i32, 0) == 0 {
+                    return true;
+                }
+                std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            self.refresh_pids(&[pid]);
+            self.lock_system()
+                .process(sysinfo::Pid::from_u32(pid))
+                .is_some()
+        }
     }
 
     /// Walk the /proc tree to find all descendant PIDs.
@@ -240,16 +268,12 @@ impl Procs {
     ) -> Result<bool> {
         let sysinfo_pid = sysinfo::Pid::from_u32(pid);
 
-        // Check if process exists or is a zombie (already terminated but not reaped)
-        if self.is_terminated_or_zombie(sysinfo_pid) {
-            return Ok(false);
-        }
-
         debug!("killing process {pid}");
 
         #[cfg(windows)]
         {
             let _ = (stop_signal, stop_timeout);
+            self.refresh_pids(&[pid]);
             if let Some(process) = self.lock_system().process(sysinfo_pid) {
                 process.kill();
                 process.wait();

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -1118,7 +1118,6 @@ impl Supervisor {
             trace!("daemon to stop: {daemon}");
             if let Some(pid) = daemon.pid {
                 trace!("killing pid: {pid}");
-                PROCS.refresh_pids(&[pid]);
                 if PROCS.is_running(pid) {
                     // First set status to Stopping (preserve PID for monitoring task)
                     self.upsert_daemon(
@@ -1141,7 +1140,6 @@ impl Supervisor {
                     {
                         debug!("failed to kill pid {pid}: {e}");
                         // Check if the process is actually stopped despite the error
-                        PROCS.refresh_processes();
                         if PROCS.is_running(pid) {
                             // Process still running after kill attempt - set back to Running
                             debug!("failed to stop pid {pid}: process still running after kill");

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -104,11 +104,9 @@ pub fn start_if_not_running() -> Result<()> {
     let sf = StateFile::get();
     if let Some(d) = sf.daemons.get(&DaemonId::pitchfork())
         && let Some(pid) = d.pid
+        && PROCS.is_running(pid)
     {
-        PROCS.refresh_pids(&[pid]);
-        if PROCS.is_running(pid) {
-            return Ok(());
-        }
+        return Ok(());
     }
     start_in_background()
 }
@@ -526,17 +524,7 @@ impl Supervisor {
     pub(crate) async fn refresh(&self) -> Result<()> {
         trace!("refreshing");
 
-        // Collect PIDs we need to check (shell PIDs only)
-        // This is more efficient than refreshing all processes on the system
         let dirs_with_pids = self.get_dirs_with_shell_pids().await;
-        let pids_to_check: Vec<u32> = dirs_with_pids.values().flatten().copied().collect();
-
-        if pids_to_check.is_empty() {
-            // No PIDs to check, skip the expensive refresh
-            trace!("no shell PIDs to check, skipping process refresh");
-        } else {
-            PROCS.refresh_pids(&pids_to_check);
-        }
 
         let mut last_refreshed_at = self.last_refreshed_at.lock().await;
         *last_refreshed_at = time::Instant::now();
@@ -1084,8 +1072,6 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
 
     for daemon in candidates {
         let Some(pid) = daemon.pid else { continue };
-
-        PROCS.refresh_pids(&[pid]);
 
         if !PROCS.is_running(pid) {
             // PID already dead — just reset its state


### PR DESCRIPTION
Fixes #439

- Procs::new() no longer calls refresh_processes()/System::new_all(), which refreshed every process in the system (~500ms). Since PROCS is a Lazy static, the first access (e.g. pitchfork cd checking if the supervisor is alive) would block for that duration.
- is_running() now uses kill(pid, 0) on Unix for an O(1) liveness check that does not depend on the process cache.
- kill() no longer relies on a pre-refreshed cache; removed the is_terminated_or_zombie pre-check (Unix kill already handles ESRCH).
- Removed 7 caller-side refresh_pids/refresh_processes calls that existed only to serve is_running().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process liveness detection across start/stop/wait by relying on direct “is running” checks instead of refreshed/stale PID state.
  * Start and wait now poll for shutdown completion without extra PID-cache refresh steps.
  * Cleanup of orphaned daemons now uses live running checks to reduce lingering processes.
  * Updated cross-platform process handling: Unix now uses `kill(pid, 0)` for liveness, and Windows refreshes only the target PID for consistent stop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->