### PR TITLE
schedule releases for Monday morning

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -19,8 +19,10 @@ jobs:
     steps:
       - name: Merge release into main
         run: |
-          PR_NUMBER=$(gh pr list -R jdx/pitchfork --base main --state open --json number,headRefName,updatedAt \
-            --jq '[.[] | select(.headRefName | startswith("release-plz-"))] | sort_by(.updatedAt) | reverse | .[0].number // empty')
+          set -euo pipefail
+
+          PR_NUMBER=$(gh pr list -R jdx/pitchfork --base main --state open --limit 100 --json number,headRefName,headRepositoryOwner,updatedAt \
+            --jq '[.[] | select(.headRefName | startswith("release-plz-")) | select(.headRepositoryOwner.login == "jdx")] | sort_by(.updatedAt) | reverse | .[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             echo "No open release-plz release PR to main"
             exit 0

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,37 @@
+name: auto-merge-release
+
+on:
+  schedule:
+    # 10:00 UTC = 4am CST (winter) / 5am CDT (summer)
+    - cron: "0 10 * * 1"
+  workflow_dispatch:
+
+jobs:
+  merge:
+    if: github.repository == 'jdx/pitchfork'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge release into main
+        run: |
+          PR_NUMBER=$(gh pr list -R jdx/pitchfork --base main --state open --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release-plz-"))][0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open release-plz release PR to main"
+            exit 0
+          fi
+
+          BODY=$(gh pr view "$PR_NUMBER" -R jdx/pitchfork --json body --jq '.body // ""')
+          TRIMMED_BODY=$(echo "$BODY" | tr -d '[:space:]')
+          if [ -z "$TRIMMED_BODY" ]; then
+            echo "PR #$PR_NUMBER has no description, never merging"
+            exit 0
+          fi
+
+          echo "PR #$PR_NUMBER is ready for the Monday morning release window"
+
+          gh pr merge "$PR_NUMBER" -R jdx/pitchfork --squash --auto || {
+            echo "Merge failed or PR not ready, will retry on the next run"
+            exit 0
+          }
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -6,11 +6,16 @@ on:
     - cron: "0 10 * * 1"
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: auto-merge-release
+  cancel-in-progress: false
+
 jobs:
   merge:
     if: github.repository == 'jdx/pitchfork'
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Merge release into main
         run: |
@@ -29,10 +34,6 @@ jobs:
           fi
 
           echo "PR #$PR_NUMBER is ready for the Monday morning release window"
-
-          gh pr merge "$PR_NUMBER" -R jdx/pitchfork --squash --auto || {
-            echo "Merge failed or PR not ready, will retry on the next run"
-            exit 0
-          }
+          gh pr merge "$PR_NUMBER" -R jdx/pitchfork --squash --auto
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -10,11 +10,12 @@ jobs:
   merge:
     if: github.repository == 'jdx/pitchfork'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Merge release into main
         run: |
-          PR_NUMBER=$(gh pr list -R jdx/pitchfork --base main --state open --json number,headRefName \
-            --jq '[.[] | select(.headRefName | startswith("release-plz-"))][0].number // empty')
+          PR_NUMBER=$(gh pr list -R jdx/pitchfork --base main --state open --json number,headRefName,updatedAt \
+            --jq '[.[] | select(.headRefName | startswith("release-plz-"))] | sort_by(.updatedAt) | reverse | .[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             echo "No open release-plz release PR to main"
             exit 0
@@ -23,7 +24,7 @@ jobs:
           BODY=$(gh pr view "$PR_NUMBER" -R jdx/pitchfork --json body --jq '.body // ""')
           TRIMMED_BODY=$(echo "$BODY" | tr -d '[:space:]')
           if [ -z "$TRIMMED_BODY" ]; then
-            echo "PR #$PR_NUMBER has no description, never merging"
+            echo "Skipping merge: PR #$PR_NUMBER has an empty body; will retry on the next scheduled run"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

- Add an auto-merge workflow for release-plz release PRs.
- Run it Monday morning only at `0 10 * * 1` UTC.
- Target open `release-plz-*` PR branches.

## Validation

- `actionlint -stdin-filename .github/workflows/auto-merge-release.yml -`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change affecting when release PRs merge; uses an existing token and guards (repo filter, empty-body skip) with no application code impact.
> 
> **Overview**
> Adds a new **`auto-merge-release`** GitHub Actions workflow that merges open **`release-plz-*`** PRs into **`main`** on a fixed weekly window instead of merging them as soon as they appear.
> 
> The job runs **Mondays at 10:00 UTC** (with **`workflow_dispatch`** for manual runs), is limited to **`jdx/pitchfork`**, and uses a concurrency group so overlapping runs do not cancel each other. It picks the newest matching open PR from **`jdx`**, skips merge when no PR exists or the body is empty (retry next week), then runs **`gh pr merge --squash --auto`** using **`RELEASE_PLZ_TOKEN`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef2f6e2364a46286538886eb508a624595bdb7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->