### PR TITLE
fix(release): pin aarch64 cross image

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -11,5 +11,4 @@ passthrough = [
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
 
 [target.aarch64-unknown-linux-gnu]
-# Use newer image for aarch64 to get assembler that supports ARMv8.2-A crypto instructions
-image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5"


### PR DESCRIPTION
## What changed

Pins the `aarch64-unknown-linux-gnu` cross image to `ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5`, matching the existing x86_64 Linux compatibility image.

## Why

The ARM64 Linux release image currently uses the mutable `:main` cross image. In a private Amazon Linux 2023 ARM64 deployment, `pitchfork 2.14.0` works perfectly, but `pitchfork 2.15.0` fails on the same host with:

```text
GLIBC_2.39 not found
```

That host has glibc 2.34, so the v2.15.0 ARM64 GNU release artifact appears to have picked up a newer glibc requirement from the mutable build image.

Using the pinned 0.2.5 image keeps the ARM64 GNU release artifact compatible with older Linux hosts while preserving the existing asset name selected by package managers.

## Impact

ARM64 Linux release artifacts should run on hosts such as Amazon Linux 2023 again without requiring a musl asset or downstream package-registry changes.

One caveat: this older image uses binutils 2.26.1. It cannot assemble newer ARMv8.2/SHA3-family mnemonics such as `eor3`. I verified the current dependency graph does not require those instructions; if a future dependency does, the release build should fail clearly rather than silently producing a bad artifact.

## Validation

- Built UI bundle with `pnpm build`.
- Built the official ARM64 GNU release profile:

```text
$ cross build --target aarch64-unknown-linux-gnu --profile serious
Finished `serious` profile [optimized] target(s) in 20m 43s
```

- Verified the resulting binary requires max `GLIBC_2.18`:

```text
$ readelf -Ws target/aarch64-unknown-linux-gnu/serious/pitchfork | grep -o 'GLIBC_[0-9.]*' | sort -Vu | tail -1
GLIBC_2.18
```

- Verified it runs on `amazonlinux:2023` ARM64 / glibc 2.34:

```text
$ docker run --rm --platform linux/arm64 amazonlinux:2023 sh -lc 'ldd --version | head -1; pitchfork --version'
ldd (GNU libc) 2.34
pitchfork 2.15.0
```

- Ran an ARM64 release-binary smoke test on `amazonlinux:2023`:

```text
$ amazonlinux:2023 ARM64 release-binary smoke
pitchfork 2.15.0
✔ [pf-project/smoke] started
Name: pf-project/smoke
Status: running
pitchfork Stopped daemon pf-project/smoke
pitchfork Stopped pitchfork daemon
```

- Ran an HTTPS proxy smoke test on `amazonlinux:2023` ARM64; TLS handshake succeeded and returned the expected proxy response without a backend:

```text
$ amazonlinux:2023 ARM64 HTTPS proxy smoke
pitchfork Supervisor started
https_proxy_http_code=502
```

This PR was prepared with Codex using GPT-5.5 xhigh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AArch64 build environment to use a fixed container image instead of a moving latest-style tag.
  * This should make builds more predictable and reduce unexpected changes over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
