### PR TITLE
fix(logs): stop dropping first token and leaking timestamp in web UI

### DIFF
--- a/ui/src/utils/log.ts
+++ b/ui/src/utils/log.ts
@@ -4,7 +4,9 @@ export interface ParsedLogLine {
   html: string
 }
 
-const LOG_PREFIX_RE = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (\S+) (.+)$/
+// Strip the fixed `<ts> ` prefix prepended by the web log API
+// (src/web/routes/api/logs.rs: `{ts} {msg}`); keep the message verbatim.
+const LOG_PREFIX_RE = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (.*)$/
 
 // Match all CSI sequences (ESC[...X)
 const CSI_PATTERN = /\x1b\[[\d;?]*[A-Za-z]/g
@@ -216,7 +218,7 @@ export function parseLogLines(lines: string[]): ParsedLogLine[] {
 export function parseLogLine(line: string): ParsedLogLine {
   const match = line.match(LOG_PREFIX_RE)
   if (match) {
-    const [, timestamp, , content] = match
+    const [, timestamp, content] = match
     const cleaned = preprocess(content)
     return {
       timestamp,


### PR DESCRIPTION
The web log viewer's LOG_PREFIX_RE was modeled on pitchfork's own internal log format (<ts> <level> <msg>), where the middle token is a redundant log level. Applied to arbitrary daemon stdout, that same parser silently dropped the daemon's first content token (e.g. its log level) and failed to match indented/blank continuation lines, causing pitchfork's prepended timestamp to leak into the rendered content.

Strip only the fixed <ts> prefix prepended by the web log API and keep the message verbatim, so level-first, multi-line, and blank daemon output render correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log parsing so web log entries keep their message content intact after the timestamp.
  * Fixed handling of log-line prefixes to better support entries with no extra token between timestamp and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->