### PR TITLE
refactor(config): upgrade humanbyte to 0.4, consolidate byte formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -927,7 +927,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1020,7 +1020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1501,19 +1501,20 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humanbyte"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7258bdf92a7320bcd18213b0b6826804996a6c8e2223b5fc2e9b9dbbeef8d174"
+checksum = "1e6c646ef4edbed4574a9747d0f67c785815e0072e4899b0120b2f3205719b98"
 dependencies = [
  "humanbyte-derive",
+ "schemars",
  "serde",
 ]
 
 [[package]]
 name = "humanbyte-derive"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a699d0047ec551fbe92f28f4199e29fd739b141f9c05ff775b08298092223afa"
+checksum = "4b18cdc8d39e76a90c4cbe7f857db8dee7b4711ab7082fbab2366cb5f08bf883"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2692,7 +2693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3496,7 +3497,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3561,7 +3562,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3849,7 +3850,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 
@@ -3911,7 +3912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4089,7 +4090,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4133,7 +4134,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4143,7 +4144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4902,7 +4903,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ crossterm = "0.29"
 fuzzy-matcher = "0.3.7"
 glob = "0.3"
 globset = "0.4"
-humanbyte = { version = "0.2", features = ["serde", "derive"] }
+humanbyte = { version = "0.4", features = ["serde", "derive", "schemars"] }
 humantime = "2"
 listeners = "0.6"
 lru = "0.18"

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -67,8 +67,11 @@
       "pattern": "^[\\w.-]+(/[\\w.-]+)?$"
     },
     "MemoryLimit": {
-      "description": "Memory limit in human-readable format, e.g. '50MB', '1GiB', '512KB'",
-      "type": "string"
+      "description": "A byte size, as either a human-readable string (e.g. \"1.5 KiB\") or a number of bytes",
+      "type": [
+        "string",
+        "integer"
+      ]
     },
     "OnOutputHook": {
       "description": "Output hook configuration.\n\nAccepts two forms:\n```toml\non_output = \"echo matched\"                              # shorthand (run only)\non_output = { run = \"echo matched\", filter = \"ready\" }  # full\n```\n\nPattern matching (`filter` / `regex`) is performed against ANSI-stripped\noutput and covers both stdout and stderr.",

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -130,19 +130,6 @@ pub trait BoolOrU32: Sized + Copy + From<u32> + Into<u32> {
 #[derive(Clone, Copy, PartialEq, Eq, humanbyte::HumanByte)]
 pub struct MemoryLimit(pub u64);
 
-impl JsonSchema for MemoryLimit {
-    fn schema_name() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("MemoryLimit")
-    }
-
-    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        schemars::json_schema!({
-            "type": "string",
-            "description": "Memory limit in human-readable format, e.g. '50MB', '1GiB', '512KB'"
-        })
-    }
-}
-
 // ---------------------------------------------------------------------------
 // CpuLimit
 // ---------------------------------------------------------------------------

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -632,6 +632,29 @@ fn signal_name(sig: i32) -> &'static str {
     }
 }
 
+#[cfg(test)]
+mod format_tests {
+    use super::*;
+
+    #[test]
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(1024), "1.0 KiB");
+        assert_eq!(format_bytes(1536), "1.5 KiB");
+        assert_eq!(format_bytes(50 * 1024 * 1024), "50.0 MiB");
+        assert_eq!(format_bytes(3 * 1024 * 1024 * 1024), "3.0 GiB");
+        // rolls over past GiB instead of showing e.g. "1100.0GB"
+        assert_eq!(format_bytes(1100 * 1024 * 1024 * 1024), "1.1 TiB");
+    }
+
+    #[test]
+    fn test_format_bytes_per_sec() {
+        assert_eq!(format_bytes_per_sec(512), "512 B/s");
+        assert_eq!(format_bytes_per_sec(1536), "1.5 KiB/s");
+        assert_eq!(format_bytes_per_sec(2 * 1024 * 1024), "2.0 MiB/s");
+    }
+}
+
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -595,15 +595,7 @@ pub struct ExtendedProcessStats {
 }
 
 fn format_bytes(bytes: u64) -> String {
-    if bytes < 1024 {
-        format!("{bytes}B")
-    } else if bytes < 1024 * 1024 {
-        format!("{:.1}KB", bytes as f64 / 1024.0)
-    } else if bytes < 1024 * 1024 * 1024 {
-        format!("{:.1}MB", bytes as f64 / (1024.0 * 1024.0))
-    } else {
-        format!("{:.1}GB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
-    }
+    humanbyte::to_string(bytes, humanbyte::Format::IEC)
 }
 
 fn format_duration(secs: u64) -> String {
@@ -623,15 +615,7 @@ fn format_duration(secs: u64) -> String {
 }
 
 fn format_bytes_per_sec(bytes: u64) -> String {
-    if bytes < 1024 {
-        format!("{bytes}B/s")
-    } else if bytes < 1024 * 1024 {
-        format!("{:.1}KB/s", bytes as f64 / 1024.0)
-    } else if bytes < 1024 * 1024 * 1024 {
-        format!("{:.1}MB/s", bytes as f64 / (1024.0 * 1024.0))
-    } else {
-        format!("{:.1}GB/s", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
-    }
+    format!("{}/s", humanbyte::to_string(bytes, humanbyte::Format::IEC))
 }
 
 #[cfg(unix)]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -468,13 +468,9 @@ fn render_memory_bar(bytes: u64, width: usize) -> Line<'static> {
     let empty_str: String = std::iter::repeat_n(BAR_EMPTY, empty).collect();
 
     // Format memory size
-    let size_str = if bytes < 1024 * 1024 {
-        format!("{:.0}K", bytes as f64 / 1024.0)
-    } else if bytes < 1024 * 1024 * 1024 {
-        format!("{:.0}M", bytes as f64 / (1024.0 * 1024.0))
-    } else {
-        format!("{:.1}G", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
-    };
+    let precision = if bytes >= humanbyte::GIB { 1 } else { 0 };
+    let size_str =
+        humanbyte::to_string_with_precision(bytes, humanbyte::Format::IECShort, precision);
 
     Line::from(vec![
         Span::styled(filled_str, Style::default().fg(bar_color)),
@@ -1125,26 +1121,16 @@ fn memory_color(bytes: u64) -> Color {
 
 /// Format memory in human-readable form
 fn format_memory(bytes: u64) -> String {
-    if bytes < 1024 * 1024 {
-        format!("{:.1}KB", bytes as f64 / 1024.0)
-    } else if bytes < 1024 * 1024 * 1024 {
-        format!("{:.1}MB", bytes as f64 / (1024.0 * 1024.0))
-    } else {
-        format!("{:.2}GB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
-    }
+    let precision = if bytes >= humanbyte::GIB { 2 } else { 1 };
+    humanbyte::to_string_with_precision(bytes, humanbyte::Format::IECShort, precision)
 }
 
 /// Format bytes per second rate
 fn format_rate(bytes: u64) -> String {
-    if bytes < 1024 {
-        format!("{bytes}B/s")
-    } else if bytes < 1024 * 1024 {
-        format!("{:.1}K/s", bytes as f64 / 1024.0)
-    } else if bytes < 1024 * 1024 * 1024 {
-        format!("{:.1}M/s", bytes as f64 / (1024.0 * 1024.0))
-    } else {
-        format!("{:.1}G/s", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
-    }
+    format!(
+        "{}/s",
+        humanbyte::to_string(bytes, humanbyte::Format::IECShort)
+    )
 }
 
 fn draw_log_search_bar(f: &mut Frame, area: Rect, app: &App) {


### PR DESCRIPTION
Hi! I maintain `humanbyte` and noticed pitchfork is its biggest public consumer — thanks for using it. While studying your usage I found a few places where recent releases can delete code and fix small display bugs, so here's a PR.

## What's in it

**`MemoryLimit`'s hand-written `JsonSchema` impl → humanbyte's new `schemars` feature.** The derive now emits the impl (you're already on schemars 1.x, which it targets). This also fixes a subtle schema mismatch: the hand-written schema advertised `"type": "string"` only, but the serde deserializer also accepts raw integer byte counts — so the published JSON schema rejected `memory_limit = 52428800`, which pitchfork itself accepts. The derived schema is `["string", "integer"]`, matching actual behavior.

**Four hand-rolled byte formatters → `humanbyte::to_string{,_with_precision}`.** `format_bytes`/`format_bytes_per_sec` in `procs.rs` and the memory-bar label/`format_memory`/`format_rate` in `tui/ui.rs` all divided by 1024 but labeled the result KB/MB/GB (decimal names on binary math). They now use the matching IEC units — `KiB` in log/CLI output, the compact `K`/`M`/`G` style (new in humanbyte 0.4, added for exactly this use case) in the TUI. Two behavior notes:
- values above GiB now roll over to TiB/PiB instead of showing `1100.0GB`
- your per-magnitude precision choices are preserved (bars: 0 decimals below GiB, 1 above; stats panel: 1 below GiB, 2 above)

## Compatibility

humanbyte 0.2 → 0.4 is transparent for your other usage: config parsing (`"50MB"`, `"1GiB"`) and serde round-trips are unchanged; the `FromStr` error type changed from `String` to a proper `std::error::Error` type, which you don't reference directly. Bonus you get for free: parsing large integer byte counts (≥ 2^53) is now exact instead of f64-rounded, and constructor/parse overflow errors instead of silently wrapping.

Verified: `cargo check --all-targets` clean, clippy adds no warnings, all 169 unit tests pass. The e2e suite doesn't run in my sandbox (daemon spawning) — it fails identically on unmodified master here, so no signal either way from me; CI should tell the truth.

Happy to adjust anything — including keeping the exact old label strings if you consider them intentional rather than accidental.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved, consistent IEC byte unit display across memory usage, memory bars, and transfer rates (KiB/MiB/GiB), including smarter precision handling.

* **Bug Fixes**
  * Replaced manual size/rate formatting paths with a unified formatter to reduce inconsistencies and formatting edge cases.

* **Documentation**
  * Updated the published JSON schema for `MemoryLimit` to accept both human-readable values and raw byte counts.

* **Tests**
  * Added unit tests covering IEC-formatted byte and rate outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->