### PR TITLE
chore: release v2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.17.0](https://github.com/jdx/pitchfork/compare/v2.16.0...v2.17.0) - 2026-07-17
+
+### Added
+
+- *(ready-check)* add optional overall timeout for all readiness check types ([#597](https://github.com/jdx/pitchfork/pull/597))
+- *(config)* support tera templates in ready check fields ([#600](https://github.com/jdx/pitchfork/pull/600))
+- *(logs)* structured log improvements ([#595](https://github.com/jdx/pitchfork/pull/595))
+- *(logs)* structured log highlighting ([#592](https://github.com/jdx/pitchfork/pull/592))
+- *(start)* allow omitting subcommand for implicit start ([#593](https://github.com/jdx/pitchfork/pull/593))
+- support structured logs ([#584](https://github.com/jdx/pitchfork/pull/584))
+
+### Fixed
+
+- *(schema)* do not require daemons field ([#605](https://github.com/jdx/pitchfork/pull/605))
+- *(deps)* update rust crate rmcp to v2 ([#590](https://github.com/jdx/pitchfork/pull/590))
+
+### Other
+
+- *(deps)* lock file maintenance ([#598](https://github.com/jdx/pitchfork/pull/598))
+- *(test)* migrate Rust e2e tests to bats with parallel execution ([#585](https://github.com/jdx/pitchfork/pull/585))
+- *(deps)* update rust crate rcgen to v0.14.8 ([#588](https://github.com/jdx/pitchfork/pull/588))
+
 ## [2.16.0](https://github.com/jdx/pitchfork/compare/v2.15.0...v2.16.0) - 2026-07-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2973,7 +2973,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.16.0"
+version = "2.17.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.16.0"
+version = "2.17.0"
 edition = "2024"
 rust-version = "1.87"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2786,7 +2786,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.16.0",
+  "version": "2.17.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.16.0
+**Version**: 2.17.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.16.0"
+version "2.17.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -387,7 +387,7 @@ fn namespace_from_path_with_override(path: &Path, explicit: Option<&str>) -> Res
 fn namespace_from_file(path: &Path) -> Result<String> {
     let explicit = read_namespace_override_from_file(path)?;
     let base_explicit = sibling_base_config(path)
-        .and_then(|p| if p.exists() { Some(p) } else { None })
+        .filter(|p| p.exists())
         .map(|p| read_namespace_override_from_file(&p))
         .transpose()?
         .flatten();
@@ -975,7 +975,7 @@ impl PitchforkToml {
 
         let namespace = {
             let base_explicit = sibling_base_config(path)
-                .and_then(|p| if p.exists() { Some(p) } else { None })
+                .filter(|p| p.exists())
                 .map(|p| read_namespace_override_from_file(&p))
                 .transpose()?
                 .flatten();


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.16.0 -> 2.17.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.17.0](https://github.com/jdx/pitchfork/compare/v2.16.0...v2.17.0) - 2026-07-17

### Added

- *(ready-check)* add optional overall timeout for all readiness check types ([#597](https://github.com/jdx/pitchfork/pull/597))
- *(config)* support tera templates in ready check fields ([#600](https://github.com/jdx/pitchfork/pull/600))
- *(logs)* structured log improvements ([#595](https://github.com/jdx/pitchfork/pull/595))
- *(logs)* structured log highlighting ([#592](https://github.com/jdx/pitchfork/pull/592))
- *(start)* allow omitting subcommand for implicit start ([#593](https://github.com/jdx/pitchfork/pull/593))
- support structured logs ([#584](https://github.com/jdx/pitchfork/pull/584))

### Fixed

- *(schema)* do not require daemons field ([#605](https://github.com/jdx/pitchfork/pull/605))
- *(deps)* update rust crate rmcp to v2 ([#590](https://github.com/jdx/pitchfork/pull/590))

### Other

- *(deps)* lock file maintenance ([#598](https://github.com/jdx/pitchfork/pull/598))
- *(test)* migrate Rust e2e tests to bats with parallel execution ([#585](https://github.com/jdx/pitchfork/pull/585))
- *(deps)* update rust crate rcgen to v0.14.8 ([#588](https://github.com/jdx/pitchfork/pull/588))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release tagging and a behavior-neutral config-parse refactor; no new features or security-sensitive logic in this diff.
> 
> **Overview**
> **Release v2.17.0** bumps `pitchfork-cli` from 2.16.0 to 2.17.0 across `Cargo.toml`, `Cargo.lock`, `pitchfork.usage.kdl`, and generated CLI docs. **CHANGELOG** adds the 2.17.0 section (structured logs, ready-check timeout and Tera templates, implicit `start`, schema fix, rmcp v2, bats e2e migration, etc.).
> 
> The only runtime code change is a small refactor in `pitchfork_toml.rs`: resolving the sibling `pitchfork.toml` for namespace validation now uses `.filter(|p| p.exists())` instead of `and_then` with an explicit exists check—same behavior, clearer style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a03a761c011aaa7a67ced479216085f20830b33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->