### PR TITLE
feat(start): allow omitting subcommand for implicit start

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Start all daemons or multiple daemons **in parallel**:
 $ pitchfork start --all
 
 $ pitchfork start redis api
+
+$ pitchfork redis api # shorthand for `pitchfork start redis api`
 ```
 
 ### Shell hook (auto start/stop)

--- a/docs/first-daemon.md
+++ b/docs/first-daemon.md
@@ -31,6 +31,8 @@ Or start specific ones:
 
 ```bash
 pitchfork start api redis
+
+pitchfork api redis # shorthand for `pitchfork start api redis`
 ```
 
 ## Check Status

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,26 +36,47 @@ Pitchfork supports tab completion for bash, zsh, and fish.
 Shell completion requires the [`usage`](https://usage.jdx.dev) CLI tool to be installed.
 :::
 
-### Bash
+::: code-group
 
-```bash
+```bash [bash]
 mkdir -p ~/.local/share/bash-completion/completions
 pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork
 ```
 
-### Zsh
-
-```bash
+```bash [zsh]
 mkdir -p ~/.zfunc
 pitchfork completion zsh > ~/.zfunc/_pitchfork
 # Add to ~/.zshrc: fpath=(~/.zfunc $fpath)
 ```
 
-### Fish
-
-```bash
+```bash [fish]
 pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish
 ```
+
+:::
+
+## Shell Alias (Optional)
+
+For a shorter command, add a `pf` alias to your shell. Combined with the
+implicit `start` shorthand, you can then start a daemon with just `pf api`:
+
+::: code-group
+
+```bash [bash]
+echo 'alias pf=pitchfork' >> ~/.bashrc
+```
+
+```bash [zsh]
+echo 'alias pf=pitchfork' >> ~/.zshrc
+```
+
+```bash [fish]
+echo 'alias pf pitchfork' >> ~/.config/fish/config.fish
+```
+
+:::
+
+Restart your shell or `source` the file, then `pf api` runs `pitchfork start api`.
 
 ## What's Next?
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -75,7 +75,7 @@ enum Commands {
     name = "pitchfork",
     bin_name = "pitchfork start",
     version = env!("CARGO_PKG_VERSION"),
-    about = env!("CARGO_PKG_DESCRIPTION")
+    long_about = start::LONG_ABOUT
 )]
 struct StartFallback {
     #[clap(flatten)]
@@ -221,6 +221,20 @@ mod tests {
         assert!(
             rendered.contains("Usage: pitchfork start"),
             "expected usage to contain 'pitchfork start', got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn fallback_help_shows_start_long_about() {
+        let err = StartFallback::try_parse_from(["pitchfork", "mydaemon", "--help"]).unwrap_err();
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("Examples:"),
+            "expected help to include Start long_about examples, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("pitchfork start api"),
+            "expected help to reference `pitchfork start api`, got: {rendered}"
         );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,6 @@
 use crate::Result;
 use clap::Parser;
+use std::ffi::OsString;
 
 mod activate;
 mod api_schema;
@@ -63,10 +64,29 @@ enum Commands {
     Tui(tui::Tui),
     Usage(usage::Usage),
     Wait(wait::Wait),
+    #[clap(external_subcommand)]
+    Fallback(Vec<OsString>),
+}
+
+/// Parses tokens captured by the implicit subcommand fallback as a
+/// `pitchfork start` invocation, so usage/help/error output reflects that.
+#[derive(Debug, clap::Parser)]
+#[clap(
+    name = "pitchfork",
+    bin_name = "pitchfork start",
+    version = env!("CARGO_PKG_VERSION"),
+    about = env!("CARGO_PKG_DESCRIPTION")
+)]
+struct StartFallback {
+    #[clap(flatten)]
+    start: start::Start,
 }
 
 pub async fn run() -> Result<()> {
     let args = Cli::parse();
+    let program = std::env::args_os()
+        .next()
+        .unwrap_or_else(|| "pitchfork".into());
     match args.command {
         Commands::Activate(activate) => activate.run().await,
         Commands::Boot(boot) => boot.run().await,
@@ -93,6 +113,11 @@ pub async fn run() -> Result<()> {
         Commands::Tui(tui) => tui.run().await,
         Commands::Usage(usage) => usage.run().await,
         Commands::Wait(wait) => wait.run().await,
+        Commands::Fallback(tokens) => {
+            let mut argv = vec![program];
+            argv.extend(tokens);
+            StartFallback::parse_from(argv).start.run().await
+        }
     }
 }
 
@@ -115,5 +140,87 @@ pub(crate) async fn drain_notifications(ipc: &crate::ipc::client::IpcClient) {
                 _ => {}
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn unknown_subcommand_captured_as_fallback() {
+        let args = Cli::parse_from(["pitchfork", "mydaemon", "--force"]);
+        match args.command {
+            Commands::Fallback(tokens) => {
+                assert_eq!(
+                    tokens,
+                    vec![OsString::from("mydaemon"), OsString::from("--force")]
+                );
+            }
+            _ => panic!("expected Fallback variant, got {:?}", args.command),
+        }
+    }
+
+    #[test]
+    fn unknown_subcommand_captures_multiple_args() {
+        let args = Cli::parse_from(["pitchfork", "api", "worker", "--force"]);
+        match args.command {
+            Commands::Fallback(tokens) => {
+                assert_eq!(
+                    tokens,
+                    vec![
+                        OsString::from("api"),
+                        OsString::from("worker"),
+                        OsString::from("--force")
+                    ]
+                );
+            }
+            _ => panic!("expected Fallback variant, got {:?}", args.command),
+        }
+    }
+
+    #[test]
+    fn known_start_parses_as_start() {
+        let args = Cli::parse_from(["pitchfork", "start", "mydaemon"]);
+        match args.command {
+            Commands::Start(_) => {}
+            _ => panic!("expected Start variant, got {:?}", args.command),
+        }
+    }
+
+    #[test]
+    fn start_alias_still_works() {
+        let args = Cli::parse_from(["pitchfork", "s", "mydaemon"]);
+        match args.command {
+            Commands::Start(_) => {}
+            _ => panic!("expected Start variant, got {:?}", args.command),
+        }
+    }
+
+    #[test]
+    fn fallback_reparse_as_start() {
+        StartFallback::try_parse_from(["pitchfork", "mydaemon", "--force"])
+            .expect("should re-parse captured tokens as Start");
+    }
+
+    #[test]
+    fn fallback_reparse_rejects_invalid_start_flag() {
+        let result = StartFallback::try_parse_from(["pitchfork", "mydaemon", "--not-a-start-flag"]);
+        assert!(
+            result.is_err(),
+            "expected re-parse to fail for invalid Start flag"
+        );
+    }
+
+    #[test]
+    fn fallback_invalid_start_usage_renders_pitchfork_start() {
+        let err = StartFallback::try_parse_from(["pitchfork", "mydaemon", "--not-a-start-flag"])
+            .unwrap_err();
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("Usage: pitchfork start"),
+            "expected usage to contain 'pitchfork start', got: {rendered}"
+        );
     }
 }

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -9,12 +9,8 @@ use crate::ui::style::{ncyan, ndim};
 use miette::ensure;
 use std::sync::Arc;
 
-/// Starts a daemon from a pitchfork.toml file
-#[derive(Debug, clap::Args)]
-#[clap(
-    visible_alias = "s",
-    verbatim_doc_comment,
-    long_about = "\
+/// Shared long help for the `start` command and its implicit fallback form.
+pub(crate) const LONG_ABOUT: &str = "\
 Starts a daemon from a pitchfork.toml file
 
 Daemons are defined in pitchfork.toml with a `[daemons.<name>]` section.
@@ -34,7 +30,14 @@ Examples:
   pitchfork start api --http http://localhost:8080/health
                                 Wait for HTTP endpoint to return 2xx
   pitchfork start api --port 8080
-                                Wait for TCP port to be listening"
+                                Wait for TCP port to be listening";
+
+/// Starts a daemon from a pitchfork.toml file
+#[derive(Debug, clap::Args)]
+#[clap(
+    visible_alias = "s",
+    verbatim_doc_comment,
+    long_about = LONG_ABOUT
 )]
 pub struct Start {
     /// ID of the daemon(s) in pitchfork.toml to start


### PR DESCRIPTION
## Summary

When the first argument doesn't match any known subcommand, treat it as a daemon ID and forward to `start`, so `pitchfork api` equals `pitchfork start api`.

Unknown subcommands are captured via clap's `external_subcommand` and re-parsed through the existing `Start` args struct, so all validation, flags, conflicts, and help/error output are reused as-is. Known subcommands and the `s` alias are unaffected.

```sh-session
$ pitchfork api              # shorthand for `pitchfork start api`
$ pitchfork api redis --force # shorthand for `pitchfork start api redis --force`
```

## Changes

- `src/cli/mod.rs`: add `Fallback(Vec<OsString>)` variant with `#[clap(external_subcommand)]`; re-parse captured tokens via a `StartFallback` wrapper that flattens `Start`, so usage/help/errors render as `pitchfork start`. Added 7 unit tests covering capture, known-command precedence, alias, re-parse success/failure, and usage rendering.
- `README.md` / `docs/first-daemon.md`: note the shorthand in existing `start` command blocks.
- `docs/installation.md`: add a Shell Alias section (code-group tabs for bash/zsh/fish) and convert Shell Completion to code-group tabs as well.

## Notes

- No changes to generated docs (`docs/cli/*`, `schema.json`): the `external_subcommand` variant is intentionally invisible to clap's schema/usage generators, so `mise run render` output is unchanged.
- `mise run test` passes: 571 Rust tests + 32 bats tests.

*This PR was generated by Claude Code.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added implicit subcommand fallback so unknown commands can be interpreted as `start` when compatible.
  * Added optional `pf` shell aliases for Bash, Zsh, and Fish (including `start` shorthand).
* **Documentation**
  * Updated quickstart and daemon start guides with shorthand command examples.
  * Reformatted shell completion instructions into a single tabbed layout and added alias setup guidance.
* **Refactor**
  * Centralized shared `start` long help text for reuse.
* **Tests**
  * Expanded CLI parsing and fallback behavior test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->