### PR TITLE
fix(logs): respect --raw when --jq filter is active

### DIFF
--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -137,10 +137,14 @@ fn format_fields(fields_json: &str) -> String {
 
 /// Format and write a single log entry with structured field highlighting.
 ///
-/// When the entry has structured fields (`fields_json` is `Some`), renders as:
-/// `<timestamp> |LEVEL| logger  message  key=value key=value`
+/// When `raw` is set, the original message is emitted verbatim (after ANSI
+/// stripping if requested), ignoring any structured fields. This keeps `--raw`
+/// honored even when `--jq` populates `fields_json` for filtering.
 ///
-/// Otherwise falls back to plain display: `<timestamp> message`
+/// Otherwise, when the entry has structured fields (`fields_json` is `Some`),
+/// renders as: `<timestamp> |LEVEL| logger  message  key=value key=value`
+///
+/// Falls back to plain display: `<timestamp> message`
 #[allow(clippy::too_many_arguments)]
 fn write_formatted_log(
     w: &mut dyn Write,
@@ -149,6 +153,7 @@ fn write_formatted_log(
     single_daemon: bool,
     strip_ansi: bool,
     show_timestamp: bool,
+    raw: bool,
 ) -> io::Result<()> {
     // Always strip PTY control sequences (cursor moves, clear screen, etc.)
     // while preserving SGR color codes. PTY daemons emit these sequences which
@@ -176,7 +181,12 @@ fn write_formatted_log(
         out.push(' ');
     }
 
-    if entry.fields_json.is_some() {
+    if raw {
+        // Raw mode: emit the original log line verbatim. Structured
+        // fields may still be populated (e.g. --jq needs them for
+        // filtering) but must not alter the raw output format.
+        out.push_str(&raw_msg);
+    } else if entry.fields_json.is_some() {
         // Structured display: level badge, logger, message, fields
         let mut need_sep = false;
 
@@ -589,6 +599,7 @@ impl Logs {
                     single_daemon,
                     strip_ansi,
                     show_timestamp,
+                    self.raw,
                 )?;
             }
             Ok(())
@@ -958,6 +969,7 @@ pub async fn tail_logs(
                     single_daemon,
                     strip_ansi,
                     show_timestamp,
+                    raw,
                 )
                 .into_diagnostic()?;
             }


### PR DESCRIPTION
## Problem

After #585 migrated the Rust e2e tests to bats, 3 tests in `test/structured_logs.bats` fail on `upstream/main`:

- `logs --jq filters by structured level field`
- `logs --jq can access numeric fields`
- `logs --jq composes with --level (SQL prefilter then jq postfilter)`

## Root cause

When `--jq` is combined with `--raw`, `write_formatted_log` selected the structured-display branch (level badge, logger, formatted fields) instead of emitting the raw log line. This happened because `--jq` forces `include_structured = true` (the jq filter needs the parsed fields), which populates `entry.fields_json`, and the output function keyed off `fields_json.is_some()` to decide the format. As a result `--raw` was silently ignored whenever `--jq` was present:

```
$ pitchfork logs jq_level --jq '.level == "error"' --raw --no-timestamp
|ERR|  err_msg          # expected: {"level":"error","msg":"err_msg"}
```

The `--tail --jq` test passed only because its assertion matched a substring that survives formatting.

## Fix

Pass `raw: bool` through to `write_formatted_log`. When `raw` is set, emit the original message verbatim regardless of whether structured fields are populated. `--jq` now only filters entries and never alters their output format.

## Verification

- `test/bats/bin/bats --jobs 16 test` — **274/274 pass** (was 271/274)
- `cargo fmt --check` + `cargo clippy --all-targets --all-features -- -D warnings` — clean

*This PR was generated by Claude Code.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added raw log output support to display original log messages verbatim (with optional ANSI stripping) when enabled.
* **Bug Fixes**
  * Ensured existing structured log formatting remains unchanged when raw mode is disabled, including rendering of log fields when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->