### PR TITLE
chore(ci): link merged PRs to discussions

### DIFF
--- a/.github/workflows/link-discussion.yml
+++ b/.github/workflows/link-discussion.yml
@@ -1,0 +1,17 @@
+name: link-discussion
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  link-discussion:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      discussions: write
+      pull-requests: read
+    steps:
+      - uses: gaojunran/link-discussion-action@38e7537b4b00d6b04a08de54c2f38b3001c9cd8d # v0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds a `link-discussion` workflow that runs when a PR is merged. It scans the PR body for references to Discussions and:

- posts a comment on each referenced discussion linking back to the PR
- closes the discussion (reason: `RESOLVED`) if a closing keyword was used

## Why

GitHub links merged PRs to **issues** via `closes #N`, but **Discussions have no equivalent** — there is no "Linked pull requests" sidebar on discussions and `closes #N` does not close a discussion. This workflow fills that gap using [`gaojunran/link-discussion-action`](https://github.com/gaojunran/link-discussion-action), which calls the `addDiscussionComment` / `closeDiscussion` GraphQL mutations.

## Supported syntax

All GitHub-native linking keywords work. The action checks at runtime whether a referenced number is a discussion; if it's an issue, GitHub's native linking handles it and the action skips.

| Keyword | Example | Behavior |
|---------|---------|----------|
| `closes` / `fixes` / `resolves` | `Closes #42` | Comment + close discussion |
| `refs` / `ref` / `reference` / `references` | `Refs #42` | Comment only |
| `discussion` | `Discussion: #42` or `discussion #42` | Comment only |

## Notes

- Requires `discussions: write` permission, declared explicitly on the job (uses the default `GITHUB_TOKEN`).
- No `actions/checkout` needed — the action reads the PR body from the event payload.
- Action is pinned to a commit SHA (`# v0.1`) following the existing `pr-closer.yml` convention.

---

*This PR was generated by Claude Code.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automation to link merged pull requests with relevant project discussions.
  * This process runs automatically after a pull request is merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->