### PR TITLE
feat(ready-check): add optional overall timeout for all readiness check types

### DIFF
--- a/docs/guides/ready-checks.md
+++ b/docs/guides/ready-checks.md
@@ -71,7 +71,7 @@ ready_http = "http://localhost:3000/ready"
 
 [daemons.private_api]
 run = "node server.js"
-ready_http = { url = "http://localhost:3000/health", status = [200, 401] }
+ready_http = { url = "http://localhost:3000/health", status = [200, 401], timeout = "30s" }
 ```
 
 **Best for:** Web services with health check endpoints.
@@ -79,7 +79,7 @@ ready_http = { url = "http://localhost:3000/health", status = [200, 401] }
 ::: tip
 The HTTP check polls every 500ms with a 5 second timeout per request. The string
 form accepts any 2xx response; the object form accepts the exact `status` codes
-you list.
+you list and an optional overall `timeout` for the entire readiness polling period.
 :::
 
 ## Port Check
@@ -101,12 +101,18 @@ ready_port = 3000
 [daemons.database]
 run = "postgres -D /var/lib/pgsql/data"
 ready_port = 5432
+
+[daemons.api_with_timeout]
+run = "node server.js"
+ready_port = { port = 3000, timeout = "30s" }
 ```
 
 **Best for:** Services that listen on a known port but don't have a health endpoint.
 
 ::: tip
 The port check polls every 500ms by attempting a TCP connection to 127.0.0.1:port.
+Add a `timeout` to cap how long the check will poll. Without a timeout, the check
+remains open until the daemon starts listening.
 :::
 
 ## Command Check
@@ -128,12 +134,17 @@ ready_cmd = "curl -sf http://localhost:3000/health"
 [daemons.database]
 run = "postgres -D /var/lib/pgsql/data"
 ready_cmd = "pg_isready -h localhost"
+
+[daemons.worker]
+run = "./start-worker.sh"
+ready_cmd = { run = "test -f /tmp/worker.ready", timeout = "60s" }
 ```
 
 **Best for:** Services that require custom readiness logic or external tools.
 
 ::: tip
-The command check polls every 500ms. Use this when you need more complex readiness checks than the built-in options provide.
+The command check polls every 500ms. Add a `timeout` to cap how long the check
+will poll. Use this when you need more complex readiness checks than the built-in options provide.
 :::
 
 ## Behaviors
@@ -149,6 +160,7 @@ The command check polls every 500ms. Use this when you need more complex readine
 - If multiple checks are configured (HTTP, port, command), the first one to succeed marks the daemon as ready
 - **Delay check** only fires when no other check type (`ready_output`, `ready_http`, `ready_port`, `ready_cmd`) is configured. It acts as the fallback default.
 - If the daemon exits with a non-zero code before becoming ready, `pitchfork start/run` exits with that same code
+- A timed `ready_http`, `ready_port`, or `ready_cmd` stops polling when its deadline is reached. Startup fails only when every configured check has reached its deadline; any unbounded check keeps startup open. When startup fails because all checks are exhausted, pitchfork exits with code `124`, kills the daemon, and applies normal retry and dependency behavior.
 
 ## Common Patterns
 

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -284,9 +284,13 @@
         },
         "ready_cmd": {
           "description": "Shell command to poll for readiness (exit code 0 = ready)",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReadyCmd"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "ready_delay": {
@@ -311,20 +315,25 @@
         },
         "ready_output": {
           "description": "Regex pattern to match in ANSI-stripped stdout/stderr to determine readiness",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReadyOutput"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "ready_port": {
           "description": "TCP port to check for readiness (connection success = ready)",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint16",
-          "maximum": 65535,
-          "minimum": 1
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReadyPort"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "retry": {
           "description": "Number of times to retry if the daemon fails.\nCan be a number (e.g., `3`) or `true` for infinite retries.",
@@ -514,8 +523,33 @@
         }
       ]
     },
+    "ReadyCmd": {
+      "description": "Command readiness check: a shell command string, or { run, timeout } object with an optional overall polling timeout",
+      "oneOf": [
+        {
+          "description": "Shell command that returns exit code 0 when ready",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "run": {
+              "description": "Shell command that returns exit code 0 when ready",
+              "type": "string"
+            },
+            "timeout": {
+              "description": "Overall readiness polling timeout (e.g. '30s', '5m')",
+              "type": "string"
+            }
+          },
+          "required": [
+            "run"
+          ]
+        }
+      ]
+    },
     "ReadyHttp": {
-      "description": "HTTP readiness check: a URL string accepting any 2xx response, or { url, status } object with exact accepted status codes",
+      "description": "HTTP readiness check: a URL string accepting any 2xx response, or { url, status, timeout } object with exact accepted status codes and optional overall polling timeout",
       "oneOf": [
         {
           "description": "HTTP URL to poll for readiness; any 2xx response is ready",
@@ -533,6 +567,10 @@
                 "minimum": 100
               }
             },
+            "timeout": {
+              "description": "Overall readiness polling timeout (e.g. '30s', '5m'). Distinct from per-request http_client_timeout.",
+              "type": "string"
+            },
             "url": {
               "description": "HTTP URL to poll for readiness",
               "type": "string"
@@ -540,6 +578,60 @@
           },
           "required": [
             "url"
+          ]
+        }
+      ]
+    },
+    "ReadyOutput": {
+      "description": "Output readiness check: a regex pattern string, or { pattern, timeout } object with an optional overall polling timeout",
+      "oneOf": [
+        {
+          "description": "Regex pattern matched against ANSI-stripped stdout/stderr lines",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "pattern": {
+              "description": "Regex pattern matched against ANSI-stripped stdout/stderr lines",
+              "type": "string"
+            },
+            "timeout": {
+              "description": "Overall readiness polling timeout (e.g. '30s', '5m')",
+              "type": "string"
+            }
+          },
+          "required": [
+            "pattern"
+          ]
+        }
+      ]
+    },
+    "ReadyPort": {
+      "description": "TCP port readiness check: a port number, or { port, timeout } object with an optional overall polling timeout",
+      "oneOf": [
+        {
+          "description": "TCP port number to check for readiness",
+          "type": "integer",
+          "maximum": 65535,
+          "minimum": 1
+        },
+        {
+          "type": "object",
+          "properties": {
+            "port": {
+              "description": "TCP port number to check for readiness",
+              "type": "integer",
+              "maximum": 65535,
+              "minimum": 1
+            },
+            "timeout": {
+              "description": "Overall readiness polling timeout (e.g. '30s', '5m')",
+              "type": "string"
+            }
+          },
+          "required": [
+            "port"
           ]
         }
       ]

--- a/src/cli/daemons/add.rs
+++ b/src/cli/daemons/add.rs
@@ -3,7 +3,8 @@ use crate::cli::daemons::resolve_project_config_path;
 use crate::daemon_id::DaemonId;
 use crate::pitchfork_toml::{
     CronRetrigger, PitchforkToml, PitchforkTomlAuto, PitchforkTomlCron, PitchforkTomlDaemon,
-    PitchforkTomlHooks, PortBump, PortConfig, ReadyHttp, Retry, namespace_from_path,
+    PitchforkTomlHooks, PortBump, PortConfig, ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort, Retry,
+    namespace_from_path,
 };
 use crate::settings::settings;
 use indexmap::IndexMap;
@@ -244,10 +245,10 @@ impl Add {
                 cron,
                 retry,
                 ready_delay: self.ready_delay,
-                ready_output: self.ready_output.clone(),
+                ready_output: self.ready_output.clone().map(ReadyOutput::new),
                 ready_http: self.ready_http.clone().map(ReadyHttp::new),
-                ready_port: self.ready_port,
-                ready_cmd: self.ready_cmd.clone(),
+                ready_port: self.ready_port.map(ReadyPort::new),
+                ready_cmd: self.ready_cmd.clone().map(ReadyCmd::new),
                 port: {
                     let expect = self.expected_port.clone();
                     let bump = match self.bump {

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -123,6 +123,23 @@ pub trait BoolOrU32: Sized + Copy + From<u32> + Into<u32> {
 }
 
 // ---------------------------------------------------------------------------
+// Shared readiness timeout helpers
+// ---------------------------------------------------------------------------
+
+/// Parse a humantime duration string (e.g. "30s", "5m") into a `Duration`.
+/// Returns `Ok(None)` when the input is `None`.
+fn parse_timeout(raw: &Option<String>) -> std::result::Result<Option<std::time::Duration>, String> {
+    raw.as_ref()
+        .map(|s| humantime::parse_duration(s).map_err(|e| format!("invalid timeout: {e}")))
+        .transpose()
+}
+
+/// Format a `Duration` as a humantime string, or `None` when unset.
+fn format_timeout(timeout: Option<std::time::Duration>) -> Option<String> {
+    timeout.map(|d| humantime::format_duration(d).to_string())
+}
+
+// ---------------------------------------------------------------------------
 // MemoryLimit
 // ---------------------------------------------------------------------------
 
@@ -177,13 +194,16 @@ impl JsonSchema for CpuLimit {
 /// Accepts two TOML forms:
 /// ```toml
 /// ready_http = "http://localhost:3000/health"  # shorthand, any 2xx response
-/// ready_http = { url = "http://localhost:3000/health", status = [200, 401] }
+/// ready_http = { url = "http://localhost:3000/health", status = [200, 401], timeout = "30s" }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ReadyHttp {
     pub url: String,
     /// Exact status codes that indicate readiness. Empty means any 2xx response.
     pub status: Vec<u16>,
+    /// Optional overall polling timeout. When set, the HTTP readiness check stops
+    /// after this deadline and the daemon fails if no other check succeeds.
+    pub timeout: Option<std::time::Duration>,
 }
 
 impl ReadyHttp {
@@ -191,6 +211,7 @@ impl ReadyHttp {
         Self {
             url: url.into(),
             status: vec![],
+            timeout: None,
         }
     }
 
@@ -211,10 +232,10 @@ impl std::fmt::Display for ReadyHttp {
             let status = self
                 .status
                 .iter()
-                .map(u16::to_string)
+                .map(|s| s.to_string())
                 .collect::<Vec<_>>()
                 .join(", ");
-            write!(f, "{} (status: {status})", self.url)
+            write!(f, "{} (status: {})", self.url, status)
         }
     }
 }
@@ -225,6 +246,8 @@ pub struct ReadyHttpRaw {
     url: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     status: Vec<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout: Option<String>,
 }
 
 impl StringOrStruct for ReadyHttp {
@@ -243,14 +266,16 @@ impl StringOrStruct for ReadyHttp {
                 ));
             }
         }
+        let timeout = parse_timeout(&raw.timeout)?;
         Ok(Self {
             url: raw.url,
             status: raw.status,
+            timeout,
         })
     }
 
     fn is_shorthand(&self) -> bool {
-        self.status.is_empty()
+        self.status.is_empty() && self.timeout.is_none()
     }
 
     fn to_short(&self) -> String {
@@ -261,6 +286,7 @@ impl StringOrStruct for ReadyHttp {
         ReadyHttpRaw {
             url: self.url.clone(),
             status: self.status.clone(),
+            timeout: format_timeout(self.timeout),
         }
     }
 }
@@ -284,7 +310,7 @@ impl JsonSchema for ReadyHttp {
 
     fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
         schemars::json_schema!({
-            "description": "HTTP readiness check: a URL string accepting any 2xx response, or { url, status } object with exact accepted status codes",
+            "description": "HTTP readiness check: a URL string accepting any 2xx response, or { url, status, timeout } object with exact accepted status codes and optional overall polling timeout",
             "oneOf": [
                 { "type": "string", "description": "HTTP URL to poll for readiness; any 2xx response is ready" },
                 {
@@ -295,9 +321,358 @@ impl JsonSchema for ReadyHttp {
                             "type": "array",
                             "description": "Exact HTTP status codes that indicate readiness. Omit to accept any 2xx response.",
                             "items": { "type": "integer", "minimum": 100, "maximum": 599 }
-                        }
+                        },
+                        "timeout": { "type": "string", "description": "Overall readiness polling timeout (e.g. '30s', '5m'). Distinct from per-request http_client_timeout." }
                     },
                     "required": ["url"]
+                }
+            ]
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ReadyCmd
+// ---------------------------------------------------------------------------
+
+/// Command readiness check configuration.
+///
+/// Accepts two TOML forms:
+/// ```toml
+/// ready_cmd = "pg_isready -h localhost"                        # shorthand, no timeout
+/// ready_cmd = { run = "pg_isready -h localhost", timeout = "30s" } # full
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ReadyCmd {
+    /// Shell command to run. Exit code 0 indicates readiness.
+    pub run: String,
+    /// Optional overall polling timeout. When set, the command readiness check stops
+    /// after this deadline and the daemon fails if no other check succeeds.
+    pub timeout: Option<std::time::Duration>,
+}
+
+impl ReadyCmd {
+    pub fn new(run: impl Into<String>) -> Self {
+        Self {
+            run: run.into(),
+            timeout: None,
+        }
+    }
+}
+
+impl std::fmt::Display for ReadyCmd {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.run)
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+#[doc(hidden)]
+pub struct ReadyCmdRaw {
+    run: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout: Option<String>,
+}
+
+impl StringOrStruct for ReadyCmd {
+    type Short = String;
+    type Raw = ReadyCmdRaw;
+
+    fn from_short(run: String) -> Self {
+        Self::new(run)
+    }
+
+    fn from_raw(raw: ReadyCmdRaw) -> std::result::Result<Self, String> {
+        let timeout = parse_timeout(&raw.timeout)?;
+        Ok(Self {
+            run: raw.run,
+            timeout,
+        })
+    }
+
+    fn is_shorthand(&self) -> bool {
+        self.timeout.is_none()
+    }
+
+    fn to_short(&self) -> String {
+        self.run.clone()
+    }
+
+    fn to_raw(&self) -> ReadyCmdRaw {
+        ReadyCmdRaw {
+            run: self.run.clone(),
+            timeout: format_timeout(self.timeout),
+        }
+    }
+}
+
+impl Serialize for ReadyCmd {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.string_or_struct_serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for ReadyCmd {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Self::string_or_struct_deserialize(d)
+    }
+}
+
+impl JsonSchema for ReadyCmd {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("ReadyCmd")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "Command readiness check: a shell command string, or { run, timeout } object with an optional overall polling timeout",
+            "oneOf": [
+                { "type": "string", "description": "Shell command that returns exit code 0 when ready" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "run": { "type": "string", "description": "Shell command that returns exit code 0 when ready" },
+                        "timeout": { "type": "string", "description": "Overall readiness polling timeout (e.g. '30s', '5m')" }
+                    },
+                    "required": ["run"]
+                }
+            ]
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ReadyPort
+// ---------------------------------------------------------------------------
+
+/// TCP port readiness check configuration.
+///
+/// Accepts two TOML forms:
+/// ```toml
+/// ready_port = 3000                                  # shorthand, no timeout
+/// ready_port = { port = 3000, timeout = "30s" }      # full
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ReadyPort {
+    /// TCP port number to check for readiness.
+    pub port: u16,
+    /// Optional overall polling timeout. When set, the port readiness check stops
+    /// after this deadline and the daemon fails if no other check succeeds.
+    pub timeout: Option<std::time::Duration>,
+}
+
+impl ReadyPort {
+    pub fn new(port: u16) -> Self {
+        Self {
+            port,
+            timeout: None,
+        }
+    }
+}
+
+impl std::fmt::Display for ReadyPort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.port)
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+#[doc(hidden)]
+pub struct ReadyPortRaw {
+    port: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout: Option<String>,
+}
+
+impl Serialize for ReadyPort {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        if self.timeout.is_none() {
+            self.port.serialize(s)
+        } else {
+            ReadyPortRaw {
+                port: self.port,
+                timeout: format_timeout(self.timeout),
+            }
+            .serialize(s)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ReadyPort {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = ReadyPort;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str(
+                    "a positive integer port number or an object with 'port' and optional 'timeout'",
+                )
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                if v == 0 || v > 65535 {
+                    return Err(E::custom("port must be between 1 and 65535"));
+                }
+                Ok(ReadyPort::new(v as u16))
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                if v <= 0 {
+                    return Err(E::custom("port must be a positive integer"));
+                }
+                self.visit_u64(v as u64)
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                map: A,
+            ) -> Result<Self::Value, A::Error> {
+                let raw =
+                    ReadyPortRaw::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+                if raw.port == 0 {
+                    return Err(serde::de::Error::custom("port must be between 1 and 65535"));
+                }
+                let timeout = parse_timeout(&raw.timeout).map_err(serde::de::Error::custom)?;
+                Ok(ReadyPort {
+                    port: raw.port,
+                    timeout,
+                })
+            }
+        }
+
+        d.deserialize_any(Visitor)
+    }
+}
+
+impl JsonSchema for ReadyPort {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("ReadyPort")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "TCP port readiness check: a port number, or { port, timeout } object with an optional overall polling timeout",
+            "oneOf": [
+                { "type": "integer", "minimum": 1, "maximum": 65535, "description": "TCP port number to check for readiness" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "TCP port number to check for readiness" },
+                        "timeout": { "type": "string", "description": "Overall readiness polling timeout (e.g. '30s', '5m')" }
+                    },
+                    "required": ["port"]
+                }
+            ]
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ReadyOutput
+// ---------------------------------------------------------------------------
+
+/// Output readiness check configuration.
+///
+/// Accepts two TOML forms:
+/// ```toml
+/// ready_output = "Server listening"                   # shorthand, no timeout
+/// ready_output = { pattern = "Server listening", timeout = "30s" }  # full
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ReadyOutput {
+    /// Regex pattern matched against ANSI-stripped stdout/stderr lines.
+    pub pattern: String,
+    /// Optional overall polling timeout. When set, the output readiness check stops
+    /// after this deadline and the daemon fails if no other check succeeds.
+    pub timeout: Option<std::time::Duration>,
+}
+
+impl ReadyOutput {
+    pub fn new(pattern: impl Into<String>) -> Self {
+        Self {
+            pattern: pattern.into(),
+            timeout: None,
+        }
+    }
+}
+
+impl std::fmt::Display for ReadyOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.pattern)
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+#[doc(hidden)]
+pub struct ReadyOutputRaw {
+    pattern: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout: Option<String>,
+}
+
+impl StringOrStruct for ReadyOutput {
+    type Short = String;
+    type Raw = ReadyOutputRaw;
+
+    fn from_short(pattern: String) -> Self {
+        Self::new(pattern)
+    }
+
+    fn from_raw(raw: ReadyOutputRaw) -> std::result::Result<Self, String> {
+        let timeout = parse_timeout(&raw.timeout)?;
+        Ok(Self {
+            pattern: raw.pattern,
+            timeout,
+        })
+    }
+
+    fn is_shorthand(&self) -> bool {
+        self.timeout.is_none()
+    }
+
+    fn to_short(&self) -> String {
+        self.pattern.clone()
+    }
+
+    fn to_raw(&self) -> ReadyOutputRaw {
+        ReadyOutputRaw {
+            pattern: self.pattern.clone(),
+            timeout: format_timeout(self.timeout),
+        }
+    }
+}
+
+impl Serialize for ReadyOutput {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.string_or_struct_serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for ReadyOutput {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Self::string_or_struct_deserialize(d)
+    }
+}
+
+impl JsonSchema for ReadyOutput {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("ReadyOutput")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "Output readiness check: a regex pattern string, or { pattern, timeout } object with an optional overall polling timeout",
+            "oneOf": [
+                { "type": "string", "description": "Regex pattern matched against ANSI-stripped stdout/stderr lines" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "pattern": { "type": "string", "description": "Regex pattern matched against ANSI-stripped stdout/stderr lines" },
+                        "timeout": { "type": "string", "description": "Overall readiness polling timeout (e.g. '30s', '5m')" }
+                    },
+                    "required": ["pattern"]
                 }
             ]
         })
@@ -436,10 +811,7 @@ impl StringOrStruct for StopConfig {
     }
 
     fn from_raw(raw: StopConfigRaw) -> std::result::Result<Self, String> {
-        let timeout = raw
-            .timeout
-            .map(|s| humantime::parse_duration(&s).map_err(|e| format!("invalid timeout: {e}")))
-            .transpose()?;
+        let timeout = parse_timeout(&raw.timeout)?;
         Ok(Self {
             signal: raw.signal,
             timeout,
@@ -457,9 +829,7 @@ impl StringOrStruct for StopConfig {
     fn to_raw(&self) -> StopConfigRaw {
         StopConfigRaw {
             signal: self.signal,
-            timeout: self
-                .timeout
-                .map(|d| humantime::format_duration(d).to_string()),
+            timeout: format_timeout(self.timeout),
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,7 +1,8 @@
 use crate::daemon_id::DaemonId;
 use crate::daemon_status::DaemonStatus;
 use crate::pitchfork_toml::{
-    CpuLimit, CronRetrigger, Dir, MemoryLimit, PortConfig, ReadyHttp, Retry, StopConfig, WatchMode,
+    CpuLimit, CronRetrigger, Dir, MemoryLimit, PortConfig, ReadyCmd, ReadyHttp, ReadyOutput,
+    ReadyPort, Retry, StopConfig, WatchMode,
 };
 use indexmap::IndexMap;
 use std::fmt::Display;
@@ -64,13 +65,13 @@ pub struct Daemon {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_delay: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub ready_output: Option<String>,
+    pub ready_output: Option<ReadyOutput>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_http: Option<ReadyHttp>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub ready_port: Option<u16>,
+    pub ready_port: Option<ReadyPort>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub ready_cmd: Option<String>,
+    pub ready_cmd: Option<ReadyCmd>,
     /// Port configuration (expected ports and auto-bump settings)
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub port: Option<PortConfig>,
@@ -153,10 +154,10 @@ pub struct RunOptions {
     pub retry: Retry,
     pub retry_count: u32,
     pub ready_delay: Option<u64>,
-    pub ready_output: Option<String>,
+    pub ready_output: Option<ReadyOutput>,
     pub ready_http: Option<ReadyHttp>,
-    pub ready_port: Option<u16>,
-    pub ready_cmd: Option<String>,
+    pub ready_port: Option<ReadyPort>,
+    pub ready_cmd: Option<ReadyCmd>,
     pub port: Option<PortConfig>,
     pub wait_ready: bool,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -245,7 +246,7 @@ impl Daemon {
             ready_delay: self.ready_delay,
             ready_output: self.ready_output.clone(),
             ready_http: self.ready_http.clone(),
-            ready_port: self.ready_port,
+            ready_port: self.ready_port.clone(),
             ready_cmd: self.ready_cmd.clone(),
             port: self.port.clone(),
             wait_ready: false,

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -9,7 +9,8 @@ use crate::daemon_id::DaemonId;
 use crate::deps::{compute_reverse_stop_order, resolve_dependencies};
 use crate::ipc::client::IpcClient;
 use crate::pitchfork_toml::{
-    PitchforkToml, PitchforkTomlDaemon, ReadyHttp, is_dot_config_pitchfork, is_global_config,
+    PitchforkToml, PitchforkTomlDaemon, ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort,
+    is_dot_config_pitchfork, is_global_config,
 };
 use chrono::{DateTime, Local};
 use indexmap::IndexMap;
@@ -117,10 +118,18 @@ pub fn build_run_options(
         run_opts.shell_pid = opts.shell_pid;
         run_opts.force = opts.force;
         run_opts.ready_delay = opts.delay.or(run_opts.ready_delay);
-        run_opts.ready_output = opts.output.clone().or(run_opts.ready_output);
+        run_opts.ready_output =
+            merge_ready_output_override(run_opts.ready_output, opts.output.clone());
         run_opts.ready_http = merge_ready_http_override(run_opts.ready_http, opts.http.clone());
-        run_opts.ready_port = opts.port.or(run_opts.ready_port);
-        run_opts.ready_cmd = opts.cmd.clone().or(run_opts.ready_cmd);
+        run_opts.ready_port = if let Some(port) = opts.port {
+            Some(ReadyPort {
+                port,
+                timeout: run_opts.ready_port.as_ref().and_then(|p| p.timeout),
+            })
+        } else {
+            run_opts.ready_port.clone()
+        };
+        run_opts.ready_cmd = merge_ready_cmd_override(run_opts.ready_cmd, opts.cmd.clone());
         if let Some(ref expected) = opts.expected_port {
             run_opts.port.get_or_insert_with(Default::default).expect = expected.clone();
         }
@@ -146,16 +155,44 @@ fn merge_ready_http_override(
     }
 }
 
+fn merge_ready_cmd_override(
+    configured: Option<ReadyCmd>,
+    override_cmd: Option<String>,
+) -> Option<ReadyCmd> {
+    match (configured, override_cmd) {
+        (Some(mut ready_cmd), Some(cmd)) => {
+            ready_cmd.run = cmd;
+            Some(ready_cmd)
+        }
+        (None, Some(cmd)) => Some(ReadyCmd::new(cmd)),
+        (ready_cmd, None) => ready_cmd,
+    }
+}
+
+fn merge_ready_output_override(
+    configured: Option<ReadyOutput>,
+    override_pattern: Option<String>,
+) -> Option<ReadyOutput> {
+    match (configured, override_pattern) {
+        (Some(mut ready_output), Some(pattern)) => {
+            ready_output.pattern = pattern;
+            Some(ready_output)
+        }
+        (None, Some(pattern)) => Some(ReadyOutput::new(pattern)),
+        (ready_output, None) => ready_output,
+    }
+}
+
 /// Determine the effective ready check type from merged RunOptions.
 fn ready_check_type(opts: &RunOptions) -> ReadyCheckType {
-    if let Some(ref pattern) = opts.ready_output {
-        ReadyCheckType::Output(pattern.clone())
+    if let Some(ref output) = opts.ready_output {
+        ReadyCheckType::Output(output.pattern.clone())
     } else if let Some(ref http) = opts.ready_http {
         ReadyCheckType::Http(http.url.clone())
-    } else if let Some(port) = opts.ready_port {
-        ReadyCheckType::Port(port)
+    } else if let Some(port) = &opts.ready_port {
+        ReadyCheckType::Port(port.port)
     } else if let Some(ref cmd) = opts.ready_cmd {
-        ReadyCheckType::Cmd(cmd.clone())
+        ReadyCheckType::Cmd(cmd.run.clone())
     } else if let Some(secs) = opts.ready_delay {
         ReadyCheckType::Delay(secs)
     } else {
@@ -734,7 +771,7 @@ impl IpcClient {
         let output = opts.output.clone();
         let http = merge_ready_http_override(ready_http, opts.http.clone());
         let port = opts.port;
-        let ready_cmd = opts.cmd.clone();
+        let ready_cmd = opts.cmd.clone().map(ReadyCmd::new);
         let expected_port = opts.expected_port.clone();
         let auto_bump_port = opts.auto_bump_port;
         let retry = opts.retry.unwrap_or_default();
@@ -750,9 +787,9 @@ impl IpcClient {
                 dir: crate::config_types::Dir(dir),
                 retry,
                 ready_delay: delay.or(Some(3)),
-                ready_output: output,
+                ready_output: output.map(ReadyOutput::new),
                 ready_http: http,
-                ready_port: port,
+                ready_port: port.map(ReadyPort::new),
                 ready_cmd,
                 port: crate::config_types::PortConfig::from_parts(
                     expected_port.unwrap_or_default(),
@@ -957,10 +994,10 @@ impl IpcClient {
             dir: crate::config_types::Dir(dir),
             retry: opts.retry.unwrap_or_default(),
             ready_delay: opts.delay.or(Some(3)),
-            ready_output: opts.output,
+            ready_output: opts.output.map(ReadyOutput::new),
             ready_http: merge_ready_http_override(None, opts.http),
-            ready_port: opts.port,
-            ready_cmd: opts.cmd.clone(),
+            ready_port: opts.port.map(ReadyPort::new),
+            ready_cmd: opts.cmd.clone().map(ReadyCmd::new),
             port: crate::config_types::PortConfig::from_parts(
                 opts.expected_port.unwrap_or_default(),
                 opts.auto_bump_port.unwrap_or_default(),
@@ -1010,6 +1047,8 @@ pub fn resolve_daemon_dir(dir: Option<&str>, config_path: Option<&Path>) -> Path
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use crate::env;
 
     use super::*;
@@ -1019,6 +1058,7 @@ mod tests {
         let configured = Some(ReadyHttp {
             url: "http://localhost:3000/original".to_string(),
             status: vec![401],
+            timeout: None,
         });
 
         let ready_http =
@@ -1039,6 +1079,7 @@ mod tests {
             ready_http: Some(ReadyHttp {
                 url: "http://localhost:3000/original".to_string(),
                 status: vec![401],
+                timeout: None,
             }),
             ..PitchforkTomlDaemon::default()
         };
@@ -1052,6 +1093,52 @@ mod tests {
 
         assert_eq!(ready_http.url, "http://localhost:3000/health");
         assert_eq!(ready_http.status, vec![401]);
+    }
+
+    #[test]
+    fn build_run_options_preserves_ready_port_timeout_for_cli_port_override() {
+        let id = DaemonId::try_new("project", "api").unwrap();
+        let daemon_config = PitchforkTomlDaemon {
+            run: "echo ready".to_string(),
+            ready_port: Some(ReadyPort {
+                port: 3000,
+                timeout: Some(Duration::from_secs(45)),
+            }),
+            ..PitchforkTomlDaemon::default()
+        };
+        let opts = StartOptions {
+            port: Some(4000),
+            ..StartOptions::default()
+        };
+
+        let run_opts = build_run_options(&id, &daemon_config, Some(&opts)).unwrap();
+        let ready_port = run_opts.ready_port.unwrap();
+
+        assert_eq!(ready_port.port, 4000);
+        assert_eq!(ready_port.timeout, Some(Duration::from_secs(45)));
+    }
+
+    #[test]
+    fn build_run_options_preserves_ready_output_timeout_for_cli_output_override() {
+        let id = DaemonId::try_new("project", "api").unwrap();
+        let daemon_config = PitchforkTomlDaemon {
+            run: "echo ready".to_string(),
+            ready_output: Some(ReadyOutput {
+                pattern: "READY".to_string(),
+                timeout: Some(Duration::from_secs(45)),
+            }),
+            ..PitchforkTomlDaemon::default()
+        };
+        let opts = StartOptions {
+            output: Some("DONE".to_string()),
+            ..StartOptions::default()
+        };
+
+        let run_opts = build_run_options(&id, &daemon_config, Some(&opts)).unwrap();
+        let ready_output = run_opts.ready_output.unwrap();
+
+        assert_eq!(ready_output.pattern, "DONE");
+        assert_eq!(ready_output.timeout, Some(Duration::from_secs(45)));
     }
 
     #[test]

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -263,8 +263,57 @@ impl IpcClient {
     /// Run a single daemon with the given options (low-level operation)
     pub async fn run(&self, opts: RunOptions) -> Result<RunResult> {
         let start_time = chrono::Local::now();
-        // Use longer timeout for daemon start - ready_delay can be up to 60s+
-        let timeout = Duration::from_secs(opts.ready_delay.unwrap_or(3) + 60);
+        // If any configured readiness check is unbounded (no timeout), the
+        // supervisor may wait indefinitely. Use a generous cap so the client
+        // does not disconnect prematurely — e.g. when a bounded ready_cmd
+        // is paired with an unbounded ready_port. When all checks are bounded,
+        // wait through the longest deadline plus a response buffer.
+        let has_unbounded_check = opts
+            .ready_output
+            .as_ref()
+            .is_some_and(|o| o.timeout.is_none())
+            || opts
+                .ready_port
+                .as_ref()
+                .is_some_and(|p| p.timeout.is_none())
+            || opts
+                .ready_http
+                .as_ref()
+                .is_some_and(|h| h.timeout.is_none())
+            || opts.ready_cmd.as_ref().is_some_and(|c| c.timeout.is_none());
+        let timeout = if has_unbounded_check {
+            Duration::from_secs(3600)
+        } else {
+            let max_deadline = opts
+                .ready_output
+                .as_ref()
+                .and_then(|o| o.timeout)
+                .map(|d| d.as_secs())
+                .unwrap_or(0)
+                .max(
+                    opts.ready_http
+                        .as_ref()
+                        .and_then(|h| h.timeout)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                )
+                .max(
+                    opts.ready_cmd
+                        .as_ref()
+                        .and_then(|c| c.timeout)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                )
+                .max(
+                    opts.ready_port
+                        .as_ref()
+                        .and_then(|p| p.timeout)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                )
+                .max(opts.ready_delay.unwrap_or(3));
+            Duration::from_secs(max_deadline + 60)
+        };
         let rsp = self
             .request_with_timeout(IpcRequest::Run(opts.clone()), timeout)
             .await?;

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -12,7 +12,8 @@ use std::path::{Path, PathBuf};
 // Re-export config value types so existing `use crate::pitchfork_toml::X` paths keep working.
 pub use crate::config_types::{
     CpuLimit, CronRetrigger, Dir, MemoryLimit, OnOutputHook, PitchforkTomlAuto, PitchforkTomlCron,
-    PitchforkTomlHooks, PortBump, PortConfig, ReadyHttp, Retry, StopConfig, StopSignal, WatchMode,
+    PitchforkTomlHooks, PortBump, PortConfig, ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort, Retry,
+    StopConfig, StopSignal, WatchMode,
 };
 
 /// Raw slug entry as read from TOML (uses String for dir path).
@@ -163,13 +164,13 @@ struct PitchforkTomlDaemonRaw {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_delay: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub ready_output: Option<String>,
+    pub ready_output: Option<ReadyOutput>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_http: Option<ReadyHttp>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub ready_port: Option<u16>,
+    pub ready_port: Option<ReadyPort>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub ready_cmd: Option<String>,
+    pub ready_cmd: Option<ReadyCmd>,
     /// New port configuration (preferred)
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub port: Option<PortConfig>,
@@ -1231,7 +1232,7 @@ impl PitchforkToml {
                     ready_delay: daemon.ready_delay,
                     ready_output: daemon.ready_output.clone(),
                     ready_http: daemon.ready_http.clone(),
-                    ready_port: daemon.ready_port,
+                    ready_port: daemon.ready_port.clone(),
                     ready_cmd: daemon.ready_cmd.clone(),
                     port: port.cloned(),
                     // Deprecated fields: written for backward compatibility with older pitchfork versions
@@ -1577,14 +1578,13 @@ pub struct PitchforkTomlDaemon {
     /// Delay in seconds before considering the daemon ready
     pub ready_delay: Option<u64>,
     /// Regex pattern to match in ANSI-stripped stdout/stderr to determine readiness
-    pub ready_output: Option<String>,
+    pub ready_output: Option<ReadyOutput>,
     /// HTTP URL to poll for readiness. Accepts any 2xx response by default, or configured statuses.
     pub ready_http: Option<ReadyHttp>,
     /// TCP port to check for readiness (connection success = ready)
-    #[schemars(range(min = 1, max = 65535))]
-    pub ready_port: Option<u16>,
+    pub ready_port: Option<ReadyPort>,
     /// Shell command to poll for readiness (exit code 0 = ready)
-    pub ready_cmd: Option<String>,
+    pub ready_cmd: Option<ReadyCmd>,
     /// Port configuration: expected ports and auto-bump settings
     pub port: Option<PortConfig>,
     /// Whether to start this daemon automatically on system boot
@@ -1683,7 +1683,7 @@ impl PitchforkTomlDaemon {
             ready_delay: self.ready_delay,
             ready_output: self.ready_output.clone(),
             ready_http: self.ready_http.clone(),
-            ready_port: self.ready_port,
+            ready_port: self.ready_port.clone(),
             ready_cmd: self.ready_cmd.clone(),
             port: self.port.clone(),
             wait_ready: false,

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -11,6 +11,7 @@ use crate::error::PortError;
 use crate::ipc::IpcResponse;
 use crate::log_store::LogStore;
 use crate::log_store::sqlite::LOG_STORE;
+use crate::pitchfork_toml::{ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort};
 use crate::procs::PROCS;
 use crate::settings::settings;
 use crate::shell::Shell;
@@ -60,6 +61,94 @@ pub(crate) fn get_or_compile_regex(pattern: &str) -> Option<Regex> {
             None
         }
     }
+}
+
+/// Handle for an in-flight readiness command probe.
+///
+/// The spawned task owns the `tokio::process::Child` and waits for either the
+/// process to exit or the cancel signal. Dropping the handle without cancelling
+/// leaves the task running, but the child is started with `kill_on_drop(true)`
+/// so it will still be terminated when the task ends.
+struct CmdProbe {
+    cancel_tx: tokio::sync::oneshot::Sender<()>,
+    result_rx: tokio::sync::oneshot::Receiver<std::io::Result<std::process::ExitStatus>>,
+}
+
+/// Spawn a readiness command probe and return a handle that can be used to wait
+/// for the exit status or cancel the probe.
+///
+/// The probe is started with `kill_on_drop(true)` as a cancellation fallback. The
+/// spawned task waits for the process to exit; if cancellation is requested, it
+/// kills the child and waits for it to reap before reporting the result.
+fn spawn_cmd_probe(id: &DaemonId, cmd: &str, dir: &std::path::Path) -> CmdProbe {
+    let mut command = Shell::default_for_platform().command(cmd);
+    command
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true);
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            warn!("daemon {id}: failed to spawn readiness command probe: {e}");
+            // Return a probe whose result channel is already closed. The caller will
+            // treat this the same as a probe that exited non-zero and respawn after
+            // the ready_check_interval, preserving the existing retry behaviour.
+            let (cancel_tx, _) = tokio::sync::oneshot::channel();
+            let (_, result_rx) = tokio::sync::oneshot::channel();
+            return CmdProbe {
+                cancel_tx,
+                result_rx,
+            };
+        }
+    };
+
+    let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel();
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+    tokio::spawn(async move {
+        let status = tokio::select! {
+            status = child.wait() => status,
+            _ = &mut cancel_rx => {
+                let mut child = child;
+                let _ = child.kill().await;
+                child.wait().await
+            }
+        };
+        let _ = result_tx.send(status);
+    });
+
+    CmdProbe {
+        cancel_tx,
+        result_rx,
+    }
+}
+
+/// Cancel an active command probe and clear its handle.
+fn stop_cmd_probe_state(probe: &mut Option<CmdProbe>) {
+    if let Some(p) = probe.take() {
+        let _ = p.cancel_tx.send(());
+    }
+}
+
+/// Returns true if any configured readiness check can still succeed.
+/// A check with no timeout is unbounded; a timed check can still succeed until its
+/// deadline fires. `ready_delay` is only used as a fallback when no other check is
+/// configured, so it is not counted here.
+fn any_ready_check_remaining(
+    ready_output: Option<&ReadyOutput>,
+    output_exhausted: bool,
+    ready_port: Option<&ReadyPort>,
+    port_exhausted: bool,
+    ready_http: Option<&ReadyHttp>,
+    http_exhausted: bool,
+    ready_cmd: Option<&ReadyCmd>,
+    cmd_exhausted: bool,
+) -> bool {
+    ready_output.is_some_and(|o| o.timeout.is_none() || !output_exhausted)
+        || ready_port.is_some_and(|p| p.timeout.is_none() || !port_exhausted)
+        || ready_http.is_some_and(|h| h.timeout.is_none() || !http_exhausted)
+        || ready_cmd.is_some_and(|c| c.timeout.is_none() || !cmd_exhausted)
 }
 
 impl Supervisor {
@@ -172,34 +261,35 @@ impl Supervisor {
             .await
             {
                 Ok(resolved) => {
-                    let ready_port = if let Some(configured_port) = opts.ready_port {
-                        // If ready_port matches one of the expected ports, apply the same bump offset
-                        let bump_offset = resolved
-                            .first()
-                            .unwrap_or(&0)
-                            .saturating_sub(*expected_ports.first().unwrap_or(&0));
-                        if expected_ports.contains(&configured_port) && bump_offset > 0 {
-                            configured_port
-                                .checked_add(bump_offset)
-                                .or(Some(configured_port))
+                    let ready_port =
+                        if let Some(configured_port) = opts.ready_port.as_ref().map(|p| p.port) {
+                            // If ready_port matches one of the expected ports, apply the same bump offset
+                            let bump_offset = resolved
+                                .first()
+                                .unwrap_or(&0)
+                                .saturating_sub(*expected_ports.first().unwrap_or(&0));
+                            if expected_ports.contains(&configured_port) && bump_offset > 0 {
+                                configured_port
+                                    .checked_add(bump_offset)
+                                    .or(Some(configured_port))
+                            } else {
+                                Some(configured_port)
+                            }
+                        } else if opts.ready_output.is_none()
+                            && opts.ready_http.is_none()
+                            && opts.ready_cmd.is_none()
+                            && opts.ready_delay.is_none()
+                        {
+                            // No other ready check configured — use the first expected port as a
+                            // TCP port readiness check so the daemon is considered ready once it
+                            // starts listening.  Skip port 0 (ephemeral port request).
+                            resolved.first().copied().filter(|&p| p != 0)
                         } else {
-                            Some(configured_port)
-                        }
-                    } else if opts.ready_output.is_none()
-                        && opts.ready_http.is_none()
-                        && opts.ready_cmd.is_none()
-                        && opts.ready_delay.is_none()
-                    {
-                        // No other ready check configured — use the first expected port as a
-                        // TCP port readiness check so the daemon is considered ready once it
-                        // starts listening.  Skip port 0 (ephemeral port request).
-                        resolved.first().copied().filter(|&p| p != 0)
-                    } else {
-                        // Another ready check is configured (output/http/cmd/delay).
-                        // Don't add an implicit TCP port check — it could race and fire
-                        // before the daemon has produced any output.
-                        None
-                    };
+                            // Another ready check is configured (output/http/cmd/delay).
+                            // Don't add an implicit TCP port check — it could race and fire
+                            // before the daemon has produced any output.
+                            None
+                        };
                     info!("daemon {id}: ports {expected_ports:?} resolved to {resolved:?}");
                     (resolved, ready_port)
                 }
@@ -237,14 +327,14 @@ impl Supervisor {
             // the TCP readiness probe would immediately succeed and pitchfork
             // would falsely consider the daemon ready — routing proxy traffic to
             // the wrong process.
-            if let Some(port) = opts.ready_port {
+            if let Some(port) = opts.ready_port.as_ref().map(|p| p.port) {
                 if port > 0 {
                     if let Some((pid, process)) = detect_port_conflict(port).await {
                         return Ok(IpcResponse::PortConflict { port, process, pid });
                     }
                 }
             }
-            (Vec::new(), opts.ready_port)
+            (Vec::new(), opts.ready_port.as_ref().map(|p| p.port))
         };
 
         // Parse the configured shell (default "sh -c") into program + args.
@@ -444,7 +534,10 @@ impl Supervisor {
                     .set(|o| {
                         o.pid = Some(pid);
                         o.cmd = Some(original_cmd);
-                        o.ready_port = effective_ready_port;
+                        o.ready_port = effective_ready_port.map(|p| ReadyPort {
+                            port: p,
+                            timeout: opts.ready_port.as_ref().and_then(|rp| rp.timeout),
+                        });
                         o.port = crate::config_types::PortConfig::from_parts(
                             expected_ports,
                             opts.port.as_ref().map(|p| p.bump).unwrap_or_default(),
@@ -460,6 +553,11 @@ impl Supervisor {
         let ready_output = opts.ready_output.clone();
         let ready_http = opts.ready_http.clone();
         let ready_port = effective_ready_port;
+        let implicit_ready_port = ready_port.map(|p| ReadyPort {
+            port: p,
+            timeout: None,
+        });
+        let ready_port_config = opts.ready_port.clone().or(implicit_ready_port);
         let ready_cmd = opts.ready_cmd.clone();
         let daemon_dir = opts.dir.0.clone();
         let hook_retry_count = opts.retry_count;
@@ -589,7 +687,9 @@ impl Supervisor {
             // Setup readiness checking
             let mut ready_notified = false;
             let mut ready_tx = ready_tx;
-            let ready_pattern = ready_output.as_ref().and_then(|p| get_or_compile_regex(p));
+            let ready_pattern = ready_output
+                .as_ref()
+                .and_then(|o| get_or_compile_regex(&o.pattern));
             // Track whether we've already spawned the active_port detection task
             let mut active_port_spawned = false;
 
@@ -622,15 +722,31 @@ impl Supervisor {
             let mut delay_timer =
                 ready_delay.map(|secs| Box::pin(time::sleep(Duration::from_secs(secs))));
 
+            // Track exhaustion of timed checks
+            let mut http_exhausted = false;
+            let mut cmd_exhausted = false;
+            let mut port_exhausted = false;
+            let mut output_exhausted = false;
+
             // Get settings for intervals
             let s = settings();
             let ready_check_interval = s.supervisor_ready_check_interval();
             let http_client_timeout = s.supervisor_http_client_timeout();
 
-            // Setup HTTP readiness check interval
+            // Setup output readiness check deadline
+            let mut output_deadline = ready_output
+                .as_ref()
+                .and_then(|o| o.timeout)
+                .map(|d| Box::pin(time::sleep(d)));
+
+            // Setup HTTP readiness check interval and deadline
             let mut http_check_interval = ready_http
                 .as_ref()
                 .map(|_| tokio::time::interval(ready_check_interval));
+            let mut http_deadline = ready_http
+                .as_ref()
+                .and_then(|h| h.timeout)
+                .map(|d| Box::pin(time::sleep(d)));
             let http_client = ready_http.as_ref().map(|_| {
                 reqwest::Client::builder()
                     .timeout(http_client_timeout)
@@ -638,14 +754,25 @@ impl Supervisor {
                     .unwrap_or_default()
             });
 
-            // Setup TCP port readiness check interval
+            // Setup TCP port readiness check interval and deadline
             let mut port_check_interval =
                 ready_port.map(|_| tokio::time::interval(ready_check_interval));
-
-            // Setup command readiness check interval
-            let mut cmd_check_interval = ready_cmd
+            let mut port_deadline = ready_port_config
                 .as_ref()
-                .map(|_| tokio::time::interval(ready_check_interval));
+                .and_then(|p| p.timeout)
+                .map(|d| Box::pin(time::sleep(d)));
+
+            // Setup command readiness check state. Probes are spawned one at a time;
+            // a non-zero result triggers a respawn delay, and a timeout stops the probe.
+            let mut cmd_probe: Option<CmdProbe> = None;
+            let mut cmd_respawn_delay: Option<_> = None;
+            let mut cmd_deadline = ready_cmd
+                .as_ref()
+                .and_then(|c| c.timeout)
+                .map(|d| Box::pin(time::sleep(d)));
+            if let Some(ref cmd) = ready_cmd {
+                cmd_probe = Some(spawn_cmd_probe(&id, &cmd.run, daemon_dir.as_path()));
+            }
 
             // Use a channel to communicate process exit status
             let (exit_tx, mut exit_rx) =
@@ -733,6 +860,7 @@ impl Supervisor {
 
                         // Check if output matches ready pattern
                         if !ready_notified
+                            && !output_exhausted
                             && let Some(ref pattern) = ready_pattern
                             && pattern.is_match(&line_clean)
                         {
@@ -749,6 +877,11 @@ impl Supervisor {
                                 let _ = tx.send(Ok(()));
                             }
                             fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), vec![]).await;
+                            stop_cmd_probe_state(&mut cmd_probe);
+                            http_deadline = None;
+                            cmd_deadline = None;
+                            port_deadline = None;
+                            output_deadline = None;
                             if !active_port_spawned && has_port_config {
                                 active_port_spawned = true;
                                 detect_and_store_active_port(id.clone(), daemon_pid);
@@ -771,6 +904,9 @@ impl Supervisor {
                                 }
                             }
                         }
+                        // Yield briefly so that the output readiness deadline can be
+                        // evaluated even when output is produced continuously.
+                        tokio::task::yield_now().await;
                     }
                     Some(result) = exit_rx.recv() => {
                         // Process exited - save exit status and notify if not ready yet
@@ -806,7 +942,7 @@ impl Supervisor {
                         } else {
                             std::future::pending::<()>().await;
                         }
-                    }, if !ready_notified && ready_http.is_some() => {
+                    }, if !ready_notified && ready_http.is_some() && !http_exhausted => {
                         if let (Some(http), Some(client)) = (&ready_http, &http_client) {
                             match client.get(&http.url).send().await {
                                 Ok(response) if http.accepts_status(response.status().as_u16()) => {
@@ -817,6 +953,11 @@ impl Supervisor {
                                     }
                                     fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), vec![]).await;
                                     http_check_interval = None;
+                                    http_deadline = None;
+                                    stop_cmd_probe_state(&mut cmd_probe);
+                                    cmd_deadline = None;
+                                    port_deadline = None;
+                                    output_deadline = None;
                                     if !active_port_spawned && has_port_config {
                                         active_port_spawned = true;
                                         detect_and_store_active_port(id.clone(), daemon_pid);
@@ -832,12 +973,75 @@ impl Supervisor {
                         }
                     }
                     _ = async {
+                        if let Some(ref mut deadline) = http_deadline {
+                            deadline.await;
+                        } else {
+                            std::future::pending::<()>().await;
+                        }
+                    }, if !ready_notified && ready_http.is_some() => {
+                        http_exhausted = true;
+                        http_deadline = None;
+                        http_check_interval = None;
+                        warn!("daemon {id}: HTTP readiness check timed out");
+                        let any_remaining = any_ready_check_remaining(
+                            ready_output.as_ref(),
+                            output_exhausted,
+                            ready_port_config.as_ref(),
+                            port_exhausted,
+                            ready_http.as_ref(),
+                            http_exhausted,
+                            ready_cmd.as_ref(),
+                            cmd_exhausted,
+                        );
+                        if !any_remaining {
+                            error!("daemon {id}: all readiness checks exhausted, failing");
+                            stop_cmd_probe_state(&mut cmd_probe);
+                            if let Some(tx) = ready_tx.take() {
+                                let _ = tx.send(Err(Some(124)));
+                            }
+                            let stop_cfg = opts.stop_signal.unwrap_or_default();
+                            let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            break;
+                        }
+                    }
+                    _ = async {
+                        if let Some(ref mut deadline) = output_deadline {
+                            deadline.await;
+                        } else {
+                            std::future::pending::<()>().await;
+                        }
+                    }, if !ready_notified && ready_output.is_some() => {
+                        output_exhausted = true;
+                        output_deadline = None;
+                        warn!("daemon {id}: output readiness check timed out");
+                        let any_remaining = any_ready_check_remaining(
+                            ready_output.as_ref(),
+                            output_exhausted,
+                            ready_port_config.as_ref(),
+                            port_exhausted,
+                            ready_http.as_ref(),
+                            http_exhausted,
+                            ready_cmd.as_ref(),
+                            cmd_exhausted,
+                        );
+                        if !any_remaining {
+                            error!("daemon {id}: all readiness checks exhausted, failing");
+                            stop_cmd_probe_state(&mut cmd_probe);
+                            if let Some(tx) = ready_tx.take() {
+                                let _ = tx.send(Err(Some(124)));
+                            }
+                            let stop_cfg = opts.stop_signal.unwrap_or_default();
+                            let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            break;
+                        }
+                    }
+                    _ = async {
                         if let Some(ref mut interval) = port_check_interval {
                             interval.tick().await;
                         } else {
                             std::future::pending::<()>().await;
                         }
-                    }, if !ready_notified && ready_port.is_some() => {
+                    }, if !ready_notified && ready_port.is_some() && !port_exhausted => {
                         if let Some(port) = ready_port {
                             match tokio::net::TcpStream::connect(("127.0.0.1", port)).await {
                                 Ok(_) => {
@@ -849,6 +1053,11 @@ impl Supervisor {
                                     fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), vec![]).await;
                                     // Stop checking once ready
                                     port_check_interval = None;
+                                    port_deadline = None;
+                                    stop_cmd_probe_state(&mut cmd_probe);
+                                    http_deadline = None;
+                                    cmd_deadline = None;
+                                    output_deadline = None;
                                     if !active_port_spawned && has_port_config {
                                         active_port_spawned = true;
                                         detect_and_store_active_port(id.clone(), daemon_pid);
@@ -861,42 +1070,114 @@ impl Supervisor {
                         }
                     }
                     _ = async {
-                        if let Some(ref mut interval) = cmd_check_interval {
-                            interval.tick().await;
+                        if let Some(ref mut deadline) = port_deadline {
+                            deadline.await;
+                        } else {
+                            std::future::pending::<()>().await;
+                        }
+                    }, if !ready_notified && ready_port.is_some() => {
+                        port_exhausted = true;
+                        port_deadline = None;
+                        port_check_interval = None;
+                        warn!("daemon {id}: TCP port readiness check timed out");
+                        let any_remaining = any_ready_check_remaining(
+                            ready_output.as_ref(),
+                            output_exhausted,
+                            ready_port_config.as_ref(),
+                            port_exhausted,
+                            ready_http.as_ref(),
+                            http_exhausted,
+                            ready_cmd.as_ref(),
+                            cmd_exhausted,
+                        );
+                        if !any_remaining {
+                            error!("daemon {id}: all readiness checks exhausted, failing");
+                            stop_cmd_probe_state(&mut cmd_probe);
+                            if let Some(tx) = ready_tx.take() {
+                                let _ = tx.send(Err(Some(124)));
+                            }
+                            let stop_cfg = opts.stop_signal.unwrap_or_default();
+                            let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            break;
+                        }
+                    }
+                    _ = async {
+                        if let Some(ref mut delay) = cmd_respawn_delay {
+                            delay.await;
+                        } else {
+                            std::future::pending::<()>().await;
+                        }
+                    }, if !ready_notified && ready_cmd.is_some() && !cmd_exhausted && cmd_probe.is_none() => {
+                        if let Some(ref cmd) = ready_cmd {
+                            cmd_probe = Some(spawn_cmd_probe(&id, &cmd.run, daemon_dir.as_path()));
+                        }
+                        cmd_respawn_delay = None;
+                    }
+                    result = async {
+                        if let Some(probe) = cmd_probe.as_mut() {
+                            std::pin::Pin::new(&mut probe.result_rx).await
+                        } else {
+                            std::future::pending::<Result<Result<std::process::ExitStatus, std::io::Error>, tokio::sync::oneshot::error::RecvError>>().await
+                        }
+                    }, if !ready_notified && ready_cmd.is_some() && !cmd_exhausted => {
+                        // The probe task has finished; remove the handle so it is not
+                        // cancelled or reused. This must happen only after this branch
+                        // actually wins the select, not while constructing the future.
+                        let _ = cmd_probe.take();
+                        match result {
+                            Ok(Ok(status)) if status.success() => {
+                                info!("daemon {id} ready: readiness command succeeded");
+                                ready_notified = true;
+                                if let Some(tx) = ready_tx.take() {
+                                    let _ = tx.send(Ok(()));
+                                }
+                                fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), vec![]).await;
+                                cmd_respawn_delay = None;
+                                cmd_deadline = None;
+                                http_deadline = None;
+                                port_deadline = None;
+                                output_deadline = None;
+                                if !active_port_spawned && has_port_config {
+                                    active_port_spawned = true;
+                                    detect_and_store_active_port(id.clone(), daemon_pid);
+                                }
+                            }
+                            Ok(Ok(_)) | Ok(Err(_)) | Err(_) => {
+                                trace!("daemon {id} cmd check: command not ready, will respawn");
+                                cmd_respawn_delay = Some(Box::pin(time::sleep(ready_check_interval)));
+                            }
+                        }
+                    }
+                    _ = async {
+                        if let Some(ref mut deadline) = cmd_deadline {
+                            deadline.await;
                         } else {
                             std::future::pending::<()>().await;
                         }
                     }, if !ready_notified && ready_cmd.is_some() => {
-                        if let Some(ref cmd) = ready_cmd {
-                            // Run the readiness check command using the shell abstraction
-                            let mut command = Shell::default_for_platform().command(cmd);
-                            command
-                                .current_dir(&daemon_dir)
-                                .stdout(std::process::Stdio::null())
-                                .stderr(std::process::Stdio::null());
-                            let result: std::io::Result<std::process::ExitStatus> = command.status().await;
-                            match result {
-                                Ok(status) if status.success() => {
-                                    info!("daemon {id} ready: readiness command succeeded");
-                                    ready_notified = true;
-                                    if let Some(tx) = ready_tx.take() {
-                                        let _ = tx.send(Ok(()));
-                                    }
-                                    fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), vec![]).await;
-                                    // Stop checking once ready
-                                    cmd_check_interval = None;
-                                    if !active_port_spawned && has_port_config {
-                                        active_port_spawned = true;
-                                        detect_and_store_active_port(id.clone(), daemon_pid);
-                                    }
-                                }
-                                Ok(_) => {
-                                    trace!("daemon {id} cmd check: command returned non-zero (not ready)");
-                                }
-                                Err(e) => {
-                                    trace!("daemon {id} cmd check failed: {e}");
-                                }
+                        cmd_exhausted = true;
+                        cmd_deadline = None;
+                        stop_cmd_probe_state(&mut cmd_probe);
+                        cmd_respawn_delay = None;
+                        warn!("daemon {id}: command readiness check timed out");
+                        let any_remaining = any_ready_check_remaining(
+                            ready_output.as_ref(),
+                            output_exhausted,
+                            ready_port_config.as_ref(),
+                            port_exhausted,
+                            ready_http.as_ref(),
+                            http_exhausted,
+                            ready_cmd.as_ref(),
+                            cmd_exhausted,
+                        );
+                        if !any_remaining {
+                            error!("daemon {id}: all readiness checks exhausted, failing");
+                            if let Some(tx) = ready_tx.take() {
+                                let _ = tx.send(Err(Some(124)));
                             }
+                            let stop_cfg = opts.stop_signal.unwrap_or_default();
+                            let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            break;
                         }
                     }
                     _ = async {
@@ -913,6 +1194,13 @@ impl Supervisor {
                                 let _ = tx.send(Ok(()));
                             }
                             fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), vec![]).await;
+                            // Clear all deadlines — no other checks are configured
+                            // when delay fires as readiness, but clear defensively.
+                            output_deadline = None;
+                            http_deadline = None;
+                            cmd_deadline = None;
+                            port_deadline = None;
+                            stop_cmd_probe_state(&mut cmd_probe);
                         }
                         // Disable timer after it fires
                         delay_timer = None;
@@ -1823,4 +2111,102 @@ fn build_pitchfork_url(slug: &Option<String>, s: &crate::settings::Settings) -> 
     let lan_enabled = s.proxy.lan || !s.proxy.lan_ip.is_empty();
     let tld = if lan_enabled { "local" } else { &s.proxy.tld };
     Some(format!("{scheme}://{slug}.{tld}{port_suffix}",))
+}
+
+#[cfg(test)]
+mod ready_check_tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn any_ready_check_remaining_prefers_unbounded_checks() {
+        let http = ReadyHttp::new("http://localhost/health");
+        let cmd = ReadyCmd::new("true");
+
+        assert!(any_ready_check_remaining(
+            None,
+            false,
+            None,
+            false,
+            Some(&http),
+            false,
+            None,
+            false
+        ));
+        assert!(any_ready_check_remaining(
+            None,
+            false,
+            None,
+            false,
+            None,
+            false,
+            Some(&cmd),
+            false
+        ));
+        assert!(any_ready_check_remaining(
+            None,
+            false,
+            Some(&ReadyPort::new(8080)),
+            false,
+            Some(&http),
+            true,
+            Some(&cmd),
+            true
+        ));
+    }
+
+    #[test]
+    fn any_ready_check_remaining_exhausted_timed_checks() {
+        let http = ReadyHttp {
+            url: "http://localhost/health".to_string(),
+            status: vec![],
+            timeout: Some(Duration::from_secs(5)),
+        };
+        let cmd = ReadyCmd {
+            run: "true".to_string(),
+            timeout: Some(Duration::from_secs(5)),
+        };
+
+        assert!(any_ready_check_remaining(
+            None,
+            false,
+            None,
+            false,
+            Some(&http),
+            false,
+            Some(&cmd),
+            false
+        ));
+        assert!(!any_ready_check_remaining(
+            None,
+            false,
+            None,
+            false,
+            Some(&http),
+            true,
+            Some(&cmd),
+            true
+        ));
+    }
+
+    #[tokio::test]
+    async fn spawn_cmd_probe_reports_success() {
+        let id = DaemonId::new("global", "probe-test");
+        let probe = spawn_cmd_probe(&id, "true", &std::env::temp_dir());
+        let status = probe.result_rx.await.unwrap().unwrap();
+        assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn spawn_cmd_probe_stops_on_request() {
+        let id = DaemonId::new("global", "probe-test");
+        let probe = spawn_cmd_probe(&id, "sleep 30", &std::env::temp_dir());
+        let CmdProbe {
+            cancel_tx,
+            result_rx,
+        } = probe;
+        let _ = cancel_tx.send(());
+        let status = result_rx.await.unwrap().unwrap();
+        assert!(!status.success());
+    }
 }

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -13,7 +13,10 @@ use crate::pitchfork_toml::CronRetrigger;
 use crate::pitchfork_toml::MemoryLimit;
 use crate::pitchfork_toml::PitchforkToml;
 use crate::pitchfork_toml::PortConfig;
+use crate::pitchfork_toml::ReadyCmd;
 use crate::pitchfork_toml::ReadyHttp;
+use crate::pitchfork_toml::ReadyOutput;
+use crate::pitchfork_toml::ReadyPort;
 use crate::pitchfork_toml::Retry;
 use crate::pitchfork_toml::StopConfig;
 use crate::pitchfork_toml::WatchMode;
@@ -42,10 +45,10 @@ pub(crate) struct UpsertDaemonOpts {
     pub retry: Option<Retry>,
     pub retry_count: Option<u32>,
     pub ready_delay: Option<u64>,
-    pub ready_output: Option<String>,
+    pub ready_output: Option<ReadyOutput>,
     pub ready_http: Option<ReadyHttp>,
-    pub ready_port: Option<u16>,
-    pub ready_cmd: Option<String>,
+    pub ready_port: Option<ReadyPort>,
+    pub ready_cmd: Option<ReadyCmd>,
     /// Port configuration
     pub port: Option<PortConfig>,
     /// Resolved ports actually used after auto-bump (may differ from expected)
@@ -129,7 +132,7 @@ impl UpsertDaemonOpts {
             o.ready_delay = opts.ready_delay;
             o.ready_output = opts.ready_output.clone();
             o.ready_http = opts.ready_http.clone();
-            o.ready_port = opts.ready_port;
+            o.ready_port = opts.ready_port.clone();
             o.ready_cmd = opts.ready_cmd.clone();
             o.port = opts.port.clone();
             o.depends = Some(opts.depends.clone());
@@ -209,7 +212,9 @@ impl Supervisor {
             ready_http: opts
                 .ready_http
                 .or(existing.and_then(|d| d.ready_http.clone())),
-            ready_port: opts.ready_port.or(existing.and_then(|d| d.ready_port)),
+            ready_port: opts
+                .ready_port
+                .or(existing.and_then(|d| d.ready_port.clone())),
             ready_cmd: opts
                 .ready_cmd
                 .or(existing.and_then(|d| d.ready_cmd.clone())),

--- a/src/template.rs
+++ b/src/template.rs
@@ -260,7 +260,10 @@ pub fn render_daemon_templates(
     }
 
     if let Some(ref cmd) = config.ready_cmd {
-        config.ready_cmd = Some(renderer.render(cmd)?);
+        config.ready_cmd = Some(crate::pitchfork_toml::ReadyCmd {
+            run: renderer.render(&cmd.run)?,
+            timeout: cmd.timeout,
+        });
     }
 
     Ok(())

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7,7 +7,7 @@ use crate::log_store::LogStore;
 use crate::log_store::sqlite::LOG_STORE;
 use crate::pitchfork_toml::{
     CronRetrigger, PitchforkToml, PitchforkTomlAuto, PitchforkTomlCron, PitchforkTomlDaemon,
-    ReadyHttp, Retry, namespace_from_path,
+    ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort, Retry, namespace_from_path,
 };
 use crate::procs::{PROCS, ProcessStats};
 use crate::settings::settings;
@@ -330,9 +330,15 @@ pub struct EditorState {
     #[allow(dead_code)]
     pub scroll_offset: usize,
     /// Preserved config field for ready_cmd (no form UI yet)
-    preserved_ready_cmd: Option<String>,
+    preserved_ready_cmd: Option<ReadyCmd>,
     /// Preserved ready_http statuses (no form UI yet)
     preserved_ready_http_status: Option<Vec<u16>>,
+    /// Preserved ready_http timeout (no form UI yet)
+    preserved_ready_http_timeout: Option<std::time::Duration>,
+    /// Preserved ready_output timeout (no form UI yet)
+    preserved_ready_output_timeout: Option<std::time::Duration>,
+    /// Preserved ready_port timeout (no form UI yet)
+    preserved_ready_port_timeout: Option<std::time::Duration>,
 }
 
 impl EditorState {
@@ -350,6 +356,9 @@ impl EditorState {
             scroll_offset: 0,
             preserved_ready_cmd: None,
             preserved_ready_http_status: None,
+            preserved_ready_http_timeout: None,
+            preserved_ready_output_timeout: None,
+            preserved_ready_port_timeout: None,
         }
     }
 
@@ -372,6 +381,9 @@ impl EditorState {
                 .ready_http
                 .as_ref()
                 .and_then(|h| (!h.status.is_empty()).then(|| h.status.clone())),
+            preserved_ready_http_timeout: config.ready_http.as_ref().and_then(|h| h.timeout),
+            preserved_ready_output_timeout: config.ready_output.as_ref().and_then(|o| o.timeout),
+            preserved_ready_port_timeout: config.ready_port.as_ref().and_then(|p| p.timeout),
         }
     }
 
@@ -477,14 +489,19 @@ impl EditorState {
                 "retry" => field.value = FormFieldValue::Number(config.retry.count()),
                 "ready_delay" => field.value = FormFieldValue::OptionalNumber(config.ready_delay),
                 "ready_output" => {
-                    field.value = FormFieldValue::OptionalText(config.ready_output.clone())
+                    field.value = FormFieldValue::OptionalText(
+                        config.ready_output.as_ref().map(|o| o.pattern.clone()),
+                    )
                 }
                 "ready_http" => {
                     field.value = FormFieldValue::OptionalText(
                         config.ready_http.as_ref().map(|h| h.url.clone()),
                     )
                 }
-                "ready_port" => field.value = FormFieldValue::OptionalPort(config.ready_port),
+                "ready_port" => {
+                    field.value =
+                        FormFieldValue::OptionalPort(config.ready_port.as_ref().map(|p| p.port))
+                }
                 "boot_start" => field.value = FormFieldValue::OptionalBoolean(config.boot_start),
                 "depends" => {
                     field.value = FormFieldValue::StringList(
@@ -553,15 +570,24 @@ impl EditorState {
                 ("retry", FormFieldValue::Number(n)) => config.retry = Retry(*n),
                 ("ready_delay", FormFieldValue::OptionalNumber(n)) => config.ready_delay = *n,
                 ("ready_output", FormFieldValue::OptionalText(s)) => {
-                    config.ready_output = s.clone()
+                    config.ready_output = s.clone().map(|pattern| ReadyOutput {
+                        pattern,
+                        timeout: self.preserved_ready_output_timeout,
+                    })
                 }
                 ("ready_http", FormFieldValue::OptionalText(s)) => {
                     config.ready_http = s.clone().map(|url| ReadyHttp {
                         url,
                         status: self.preserved_ready_http_status.clone().unwrap_or_default(),
+                        timeout: self.preserved_ready_http_timeout,
                     })
                 }
-                ("ready_port", FormFieldValue::OptionalPort(p)) => config.ready_port = *p,
+                ("ready_port", FormFieldValue::OptionalPort(p)) => {
+                    config.ready_port = p.map(|port| ReadyPort {
+                        port,
+                        timeout: self.preserved_ready_port_timeout,
+                    })
+                }
                 ("boot_start", FormFieldValue::OptionalBoolean(b)) => config.boot_start = *b,
                 ("depends", FormFieldValue::StringList(v)) => {
                     config.depends = v.iter().filter_map(|s| DaemonId::parse(s).ok()).collect()

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1639,7 +1639,7 @@ fn draw_details_overlay(f: &mut Frame, app: &App) {
         if let Some(output) = &cfg.ready_output {
             lines.push(Line::from(vec![
                 Span::styled("Ready output: ", Style::default().fg(GRAY)),
-                Span::styled(output.clone(), Style::default().fg(Color::White)),
+                Span::styled(output.pattern.clone(), Style::default().fg(Color::White)),
             ]));
         }
 

--- a/src/web/routes/api/daemons.rs
+++ b/src/web/routes/api/daemons.rs
@@ -161,10 +161,10 @@ fn entry_to_api(
             None
         },
         ready_delay: d.ready_delay,
-        ready_output: d.ready_output.clone(),
+        ready_output: d.ready_output.as_ref().map(|o| o.pattern.clone()),
         ready_http_url: d.ready_http.as_ref().map(|r| r.url.clone()),
-        ready_port: d.ready_port,
-        ready_cmd: d.ready_cmd.clone(),
+        ready_port: d.ready_port.as_ref().map(|p| p.port),
+        ready_cmd: d.ready_cmd.as_ref().map(|r| r.run.clone()),
         port_config: d.port.as_ref().map(|p| {
             if p.bump.0 == 0 {
                 p.expect

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -471,6 +471,48 @@ EOF
   pitchfork stop port_test
 }
 
+@test "ready port timeout fails daemon" {
+  kill_port 18083
+
+  create_pitchfork_toml <<EOF
+[daemons.port_timeout_test]
+run = "sleep 30"
+ready_port = { port = 18083, timeout = "3s" }
+retry = 0
+EOF
+
+  local start_time elapsed
+  start_time=$(date +%s)
+  run pitchfork start port_timeout_test
+  elapsed=$(($(date +%s) - start_time))
+
+  assert_failure
+  [[ $elapsed -ge 2 ]]
+  [[ $elapsed -lt 10 ]]
+
+  wait_for_status port_timeout_test errored
+}
+
+@test "ready output timeout fails daemon" {
+  create_pitchfork_toml <<EOF
+[daemons.output_timeout_test]
+run = "while true; do echo 'still starting'; sleep 1; done"
+ready_output = { pattern = "READY", timeout = "3s" }
+retry = 0
+EOF
+
+  local start_time elapsed
+  start_time=$(date +%s)
+  run pitchfork start output_timeout_test
+  elapsed=$(($(date +%s) - start_time))
+
+  assert_failure
+  [[ $elapsed -ge 2 ]]
+  [[ $elapsed -lt 10 ]]
+
+  wait_for_status output_timeout_test errored
+}
+
 @test "ready cmd check waits for command to succeed" {
   local marker
   marker="$TEST_TEMP_DIR/ready_marker"
@@ -498,6 +540,61 @@ EOF
   assert_output --partial "Ready"
 
   pitchfork stop cmd_test
+}
+
+@test "ready cmd timeout fails daemon and blocks dependent" {
+  create_pitchfork_toml <<EOF
+[daemons.never_ready]
+run = "sleep 30"
+ready_cmd = { run = "false", timeout = "3s" }
+retry = 0
+
+[daemons.dependent]
+run = "sleep 30"
+depends = ["never_ready"]
+ready_delay = 1
+retry = 0
+EOF
+
+  local start_time elapsed
+  start_time=$(date +%s)
+  run pitchfork start never_ready
+  elapsed=$(($(date +%s) - start_time))
+
+  assert_failure
+  [[ $elapsed -ge 2 ]]
+  [[ $elapsed -lt 10 ]]
+
+  wait_for_status never_ready errored
+
+  start_time=$(date +%s)
+  run pitchfork start dependent
+  elapsed=$(($(date +%s) - start_time))
+
+  assert_failure
+  [[ $elapsed -lt 10 ]]
+
+  run pitchfork status dependent
+  refute_output --partial "running"
+}
+
+@test "ready cmd probe survives concurrent output lines" {
+  create_pitchfork_toml <<EOF
+[daemons.cmd_output_race]
+run = "while true; do echo tick; sleep 0.05; done"
+ready_cmd = "sleep 1; true"
+EOF
+
+  local start_time elapsed
+  start_time=$(date +%s)
+  run pitchfork start cmd_output_race
+  elapsed=$(($(date +%s) - start_time))
+
+  assert_success
+  [[ $elapsed -ge 1 ]]
+  [[ $elapsed -lt 15 ]]
+
+  pitchfork stop cmd_output_race
 }
 
 # ============================================================================

--- a/tests/test_pitchfork_toml.rs
+++ b/tests/test_pitchfork_toml.rs
@@ -2,6 +2,7 @@ use pitchfork_cli::daemon_id::DaemonId;
 use pitchfork_cli::*;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tempfile::TempDir;
 
 /// Helper function to get a daemon by name from a PitchforkToml
@@ -210,14 +211,21 @@ ready_cmd = "test -f /tmp/ready"
     let daemon = get_daemon_by_name(&pt, "ready_daemon").unwrap();
 
     assert_eq!(daemon.ready_delay, Some(5000));
-    assert_eq!(daemon.ready_output, Some("Server is ready".to_string()));
+    assert_eq!(
+        daemon.ready_output,
+        Some(pitchfork_toml::ReadyOutput::new("Server is ready"))
+    );
     assert_eq!(
         daemon.ready_http.as_ref().unwrap().url,
         "http://localhost:8080/health"
     );
     assert!(daemon.ready_http.as_ref().unwrap().status.is_empty());
-    assert_eq!(daemon.ready_port, Some(8080));
-    assert_eq!(daemon.ready_cmd, Some("test -f /tmp/ready".to_string()));
+    assert_eq!(
+        daemon.ready_port,
+        Some(pitchfork_toml::ReadyPort::new(8080))
+    );
+    assert_eq!(daemon.ready_cmd.as_ref().unwrap().run, "test -f /tmp/ready");
+    assert!(daemon.ready_cmd.as_ref().unwrap().timeout.is_none());
 
     Ok(())
 }
@@ -268,6 +276,179 @@ ready_http = { url = "http://localhost:8080/health", status = [99] }
         err.contains("ready_http status must be between 100 and 599"),
         "unexpected error: {err}"
     );
+}
+
+/// Test daemon with structured command ready check including a timeout
+#[test]
+fn test_daemon_with_ready_cmd_object() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.ready_daemon]
+run = "echo 'server starting'"
+ready_cmd = { run = "test -f /tmp/ready", timeout = "5s" }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "ready_daemon").unwrap();
+    let ready_cmd = daemon.ready_cmd.as_ref().unwrap();
+
+    assert_eq!(ready_cmd.run, "test -f /tmp/ready");
+    assert_eq!(ready_cmd.timeout, Some(Duration::from_secs(5)));
+
+    Ok(())
+}
+
+/// Test daemon with structured HTTP ready check including a timeout
+#[test]
+fn test_daemon_with_ready_http_timeout() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.ready_daemon]
+run = "echo 'server starting'"
+ready_http = { url = "http://localhost:8080/health", timeout = "30s" }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "ready_daemon").unwrap();
+    let ready_http = daemon.ready_http.as_ref().unwrap();
+
+    assert_eq!(ready_http.url, "http://localhost:8080/health");
+    assert!(ready_http.status.is_empty());
+    assert_eq!(ready_http.timeout, Some(Duration::from_secs(30)));
+
+    Ok(())
+}
+
+/// Test invalid command ready check timeout is rejected
+#[test]
+fn test_daemon_with_invalid_ready_cmd_timeout() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.ready_daemon]
+run = "echo 'server starting'"
+ready_cmd = { run = "test -f /tmp/ready", timeout = "not-a-duration" }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
+    let err = format!("{err:?}");
+    assert!(err.contains("invalid timeout"), "unexpected error: {err}");
+}
+
+/// Test invalid HTTP ready check timeout is rejected
+#[test]
+fn test_daemon_with_invalid_ready_http_timeout() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.ready_daemon]
+run = "echo 'server starting'"
+ready_http = { url = "http://localhost:8080/health", timeout = "not-a-duration" }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
+    let err = format!("{err:?}");
+    assert!(err.contains("invalid timeout"), "unexpected error: {err}");
+}
+
+/// Test daemon with structured port ready check including a timeout
+#[test]
+fn test_daemon_with_ready_port_timeout() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.ready_daemon]
+run = "echo 'server starting'"
+ready_port = { port = 8080, timeout = "30s" }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "ready_daemon").unwrap();
+    let ready_port = daemon.ready_port.as_ref().unwrap();
+
+    assert_eq!(ready_port.port, 8080);
+    assert_eq!(ready_port.timeout, Some(Duration::from_secs(30)));
+
+    Ok(())
+}
+
+/// Test invalid port ready check timeout is rejected
+#[test]
+fn test_daemon_with_invalid_ready_port_timeout() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.ready_daemon]
+run = "echo 'server starting'"
+ready_port = { port = 8080, timeout = "not-a-duration" }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
+    let err = format!("{err:?}");
+    assert!(err.contains("invalid timeout"), "unexpected error: {err}");
+}
+
+/// Test output ready check with timeout
+#[test]
+fn test_daemon_with_ready_output_timeout() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.ready_daemon]
+run = "echo 'server starting'"
+ready_output = { pattern = "Server is ready", timeout = "30s" }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "ready_daemon").unwrap();
+
+    let ready_output = daemon.ready_output.as_ref().unwrap();
+    assert_eq!(ready_output.pattern, "Server is ready");
+    assert_eq!(ready_output.timeout, Some(Duration::from_secs(30)));
+
+    Ok(())
+}
+
+/// Test invalid output ready check timeout is rejected
+#[test]
+fn test_daemon_with_invalid_ready_output_timeout() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.ready_daemon]
+run = "echo 'server starting'"
+ready_output = { pattern = "Server is ready", timeout = "not-a-duration" }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
+    let err = format!("{err:?}");
+    assert!(err.contains("invalid timeout"), "unexpected error: {err}");
 }
 
 /// Test multiple daemons in one file
@@ -508,7 +689,9 @@ ready_output = "ready to accept connections"
     assert_eq!(db.ready_delay, Some(3000));
     assert_eq!(
         db.ready_output,
-        Some("ready to accept connections".to_string())
+        Some(pitchfork_toml::ReadyOutput::new(
+            "ready to accept connections"
+        ))
     );
 
     Ok(())
@@ -1034,7 +1217,7 @@ run = "npm run debug"
     // api should be overridden by local
     let api = pt.daemons.get(&api_key).unwrap();
     assert_eq!(api.run, "npm run dev");
-    assert_eq!(api.ready_port, Some(3001));
+    assert_eq!(api.ready_port, Some(pitchfork_toml::ReadyPort::new(3001)));
 
     // worker should remain from base
     let worker = pt.daemons.get(&worker_key).unwrap();


### PR DESCRIPTION
Closes #545.

## Summary

Implements the opt-in, overall readiness polling timeout discussed in #545. Per the maintainer's comment, the timeout lives inside readiness configuration objects rather than a top-level field, and the default remains unlimited polling for backwards compatibility. All four readiness check types now support an optional `timeout`.

## Supported check types

| Check | Shorthand | Object form |
|-------|-----------|-------------|
| `ready_cmd` | `"pg_isready -h localhost"` | `{ run = "...", timeout = "30s" }` |
| `ready_http` | `"http://localhost:3000/health"` | `{ url = "...", status = [200], timeout = "1m" }` |
| `ready_port` | `8080` | `{ port = 8080, timeout = "30s" }` |
| `ready_output` | `"Server listening"` | `{ pattern = "...", timeout = "30s" }` |

All use `humantime` duration strings (`"30s"`, `"5m"`, etc.). Omitting `timeout` preserves the current unbounded behavior.

## Lifecycle behavior

- Each timed readiness check stops polling when its own deadline fires. Because readiness checks are ORed (first success wins), startup fails only after **every** configured check has exhausted its deadline. Any unbounded check (a check without `timeout`, or `ready_delay` as fallback) keeps startup open.
- When all checks are exhausted, the daemon is killed via its process group and the existing failure path returns exit code `124`, so retry, hooks, and `depends` propagate normally.
- Command probes are reworked into a non-blocking spawned task that owns the `Child`. It `select!`s between `child.wait()` and a cancel signal, calls `child.kill().await` on cancellation, and uses `kill_on_drop(true)` as a fallback.
- The IPC client detects unbounded checks and uses a generous cap (1 hour) to avoid premature disconnection. When all checks are bounded, it waits through the longest deadline plus a 60s buffer.

## Examples

```toml
[daemons.api]
run = "node server.js"
ready_cmd = { run = "curl -sf http://localhost:3000/health", timeout = "30s" }

[daemons.webserver]
run = "python -m uvicorn main:app"
ready_http = { url = "http://localhost:8000/health", status = [200], timeout = "1m" }

[daemons.database]
run = "postgres -D /var/lib/pgsql/data"
ready_output = { pattern = "database system is ready to accept connections", timeout = "2m" }

[daemons.cache]
run = "redis-server"
ready_port = { port = 6379, timeout = "10s" }
```

## Testing

- `cargo nextest run`: 468/468 passed
- `bats test/basic.bats`: all readiness scenarios pass, including new timeout tests for each check type:
  - `ready cmd timeout fails daemon and blocks dependent` (exit code 124, errored state, dependency blocking)
  - `ready port timeout fails daemon`
  - `ready output timeout fails daemon`
  - `ready cmd probe survives concurrent output lines` (regression test for a select-cancellation race)
- `mise run lint` passed
- `mise run render` regenerated `docs/public/schema.json`

*This PR was prepared with Claude Code.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional overall `timeout` for HTTP, command, port, and output readiness checks via structured `{ ... , timeout }` forms.
  * Readiness checks now use consistent structured representations and preserve timeouts through config/edit/merge and IPC start paths.
  * Timed readiness checks stop at their deadlines; startup fails after all configured timed checks exhaust, with exit code **124** (unbounded checks can keep startup open).

* **Documentation**
  * Updated the readiness guide and public schema with the new timeout behavior and examples.

* **Bug Fixes**
  * Improved command readiness reliability during interleaved output.
  * Correctly display and serialize readiness details (command/run, output/pattern, port).

* **Tests**
  * Added coverage for readiness timeouts and structured timeout parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->