### PR TITLE
feat(config): support tera templates in ready check fields

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -366,8 +366,8 @@
               {
                 "name": "ready-port",
                 "usage": "--ready-port <READY_PORT>",
-                "help": "TCP port to check for readiness",
-                "help_first_line": "TCP port to check for readiness",
+                "help": "TCP port to check for readiness (a number or Tera template)",
+                "help_first_line": "TCP port to check for readiness (a number or Tera template)",
                 "short": [],
                 "long": [
                   "ready-port"

--- a/docs/cli/daemons/add.md
+++ b/docs/cli/daemons/add.md
@@ -76,7 +76,7 @@ HTTP endpoint URL to poll for readiness
 
 ### `--ready-port <READY_PORT>`
 
-TCP port to check for readiness
+TCP port to check for readiness (a number or Tera template)
 
 ### `--ready-cmd <READY_CMD>`
 

--- a/docs/guides/configuration-templates.md
+++ b/docs/guides/configuration-templates.md
@@ -46,6 +46,9 @@ Templates work in these configuration fields:
 | `env` values | <code v-pre>env = { DB_URL = "postgres://localhost:{{ daemons.db.port }}" }</code> |
 | `hooks.*` commands | <code v-pre>on_ready = "curl http://localhost:{{ daemons.api.port }}/health"</code> |
 | `ready_cmd` | <code v-pre>ready_cmd = "curl http://localhost:{{ daemons.api.port }}/health"</code> |
+| `ready_http` | <code v-pre>ready_http = "http://localhost:{{ daemons.api.port }}/health"</code> |
+| `ready_port` | <code v-pre>ready_port = "{{ daemons.api.port }}"</code> (must render to a port number) |
+| `ready_output` | <code v-pre>ready_output = "listening on port {{ daemons.api.port }}"</code> |
 
 ## Template Variables
 

--- a/docs/guides/ready-checks.md
+++ b/docs/guides/ready-checks.md
@@ -136,6 +136,27 @@ ready_cmd = "pg_isready -h localhost"
 The command check polls every 500ms. Use this when you need more complex readiness checks than the built-in options provide.
 :::
 
+## Templates
+
+All ready check fields (`ready_output`, `ready_http`, `ready_port`, `ready_cmd`) accept
+[Tera templates](/guides/configuration-templates) to reference resolved values from
+daemons started earlier in the dependency order:
+
+```toml
+[daemons.redis]
+run = "redis-server"
+port = { expect = [6379], bump = 10 }
+
+[daemons.worker]
+run = "worker --redis-port {{ daemons.redis.port }}"
+# Ready once the worker can reach redis, even if its port was auto-bumped
+ready_cmd = "redis-cli -p {{ daemons.redis.port }} ping"
+depends = ["redis"]
+```
+
+`ready_port` templates must render to a port number (1-65535); otherwise the daemon
+fails to start with an error.
+
 ## Behaviors
 
 | Check Type | Ready When |

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -317,14 +317,15 @@
           ]
         },
         "ready_port": {
-          "description": "TCP port to check for readiness (connection success = ready)",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint16",
-          "maximum": 65535,
-          "minimum": 1
+          "description": "TCP port to check for readiness (connection success = ready).\nAccepts a port number or a Tera template string that renders to one.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReadyPort"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "retry": {
           "description": "Number of times to retry if the daemon fails.\nCan be a number (e.g., `3`) or `true` for infinite retries.",
@@ -541,6 +542,20 @@
           "required": [
             "url"
           ]
+        }
+      ]
+    },
+    "ReadyPort": {
+      "description": "TCP readiness port: a port number, or a template string rendering to one (e.g. \"{{ daemons.redis.port }}\")",
+      "oneOf": [
+        {
+          "type": "integer",
+          "maximum": 65535,
+          "minimum": 1
+        },
+        {
+          "description": "Tera template that renders to a port number",
+          "type": "string"
         }
       ]
     },

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -224,7 +224,8 @@ ready_delay = 5
 
 ### `ready_output`
 
-Regex pattern to match in output for readiness.
+Regex pattern to match in output for readiness. Supports
+[templates](/guides/configuration-templates).
 
 ```toml
 [daemons.postgres]
@@ -236,7 +237,8 @@ ready_output = "ready to accept connections"
 
 HTTP endpoint URL to poll for readiness. By default, any 2xx response is ready.
 Use the object form when specific non-2xx statuses also mean the service is up
-(for example an authenticated endpoint returning 401).
+(for example an authenticated endpoint returning 401). The URL supports
+[templates](/guides/configuration-templates).
 
 ```toml
 [daemons.api]
@@ -251,16 +253,24 @@ ready_http = { url = "http://localhost:3000/health", status = [200, 401] }
 ### `ready_port`
 
 TCP port to check for readiness. Daemon is ready when port is listening.
+Accepts a port number or a [template](/guides/configuration-templates) string
+that renders to one.
 
 ```toml
 [daemons.api]
 run = "npm run server"
 ready_port = 3000
+
+[daemons.worker]
+run = "npm run worker"
+ready_port = "{{ daemons.api.port }}"
+depends = ["api"]
 ```
 
 ### `ready_cmd`
 
 Shell command to poll for readiness. Daemon is ready when command exits with code 0.
+Supports [templates](/guides/configuration-templates).
 
 ```toml
 [daemons.postgres]

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -59,7 +59,7 @@ cmd daemons help="List configured daemons from all merged config files." {
         flag --ready-http help="HTTP endpoint URL to poll for readiness" {
             arg <READY_HTTP>
         }
-        flag --ready-port help="TCP port to check for readiness" {
+        flag --ready-port help="TCP port to check for readiness (a number or Tera template)" {
             arg <READY_PORT>
         }
         flag --ready-cmd help="Shell command to poll for readiness" {

--- a/src/cli/daemons/add.rs
+++ b/src/cli/daemons/add.rs
@@ -3,7 +3,7 @@ use crate::cli::daemons::resolve_project_config_path;
 use crate::daemon_id::DaemonId;
 use crate::pitchfork_toml::{
     CronRetrigger, PitchforkToml, PitchforkTomlAuto, PitchforkTomlCron, PitchforkTomlDaemon,
-    PitchforkTomlHooks, PortBump, PortConfig, ReadyHttp, Retry, namespace_from_path,
+    PitchforkTomlHooks, PortBump, PortConfig, ReadyHttp, ReadyPort, Retry, namespace_from_path,
 };
 use crate::settings::settings;
 use indexmap::IndexMap;
@@ -72,9 +72,9 @@ pub struct Add {
     /// HTTP endpoint URL to poll for readiness
     #[clap(long)]
     ready_http: Option<String>,
-    /// TCP port to check for readiness
+    /// TCP port to check for readiness (a number or Tera template)
     #[clap(long)]
-    ready_port: Option<u16>,
+    ready_port: Option<ReadyPort>,
     /// Shell command to poll for readiness
     #[clap(long)]
     ready_cmd: Option<String>,
@@ -246,7 +246,7 @@ impl Add {
                 ready_delay: self.ready_delay,
                 ready_output: self.ready_output.clone(),
                 ready_http: self.ready_http.clone().map(ReadyHttp::new),
-                ready_port: self.ready_port.map(Into::into),
+                ready_port: self.ready_port.clone(),
                 ready_cmd: self.ready_cmd.clone(),
                 port: {
                     let expect = self.expected_port.clone();

--- a/src/cli/daemons/add.rs
+++ b/src/cli/daemons/add.rs
@@ -246,7 +246,7 @@ impl Add {
                 ready_delay: self.ready_delay,
                 ready_output: self.ready_output.clone(),
                 ready_http: self.ready_http.clone().map(ReadyHttp::new),
-                ready_port: self.ready_port,
+                ready_port: self.ready_port.map(Into::into),
                 ready_cmd: self.ready_cmd.clone(),
                 port: {
                     let expect = self.expected_port.clone();

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -347,7 +347,7 @@ impl std::str::FromStr for ReadyPort {
         let s = s.trim();
         if s.is_empty() {
             Err("ready_port cannot be empty".to_string())
-        } else if let Ok(n) = s.parse::<u64>() {
+        } else if let Ok(n) = s.parse::<i64>() {
             u16::try_from(n)
                 .ok()
                 .filter(|&p| p > 0)

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -305,6 +305,133 @@ impl JsonSchema for ReadyHttp {
 }
 
 // ---------------------------------------------------------------------------
+// ReadyPort
+// ---------------------------------------------------------------------------
+
+/// TCP readiness port: a literal port number or a Tera template string that
+/// renders to one.
+///
+/// Accepts two TOML forms:
+/// ```toml
+/// ready_port = 3000                          # literal
+/// ready_port = "{{ daemons.redis.port }}"    # template
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadyPort {
+    Port(u16),
+    Template(String),
+}
+
+impl ReadyPort {
+    /// The resolved port number. `None` if this is an unrendered template.
+    pub fn as_port(&self) -> Option<u16> {
+        match self {
+            Self::Port(port) => Some(*port),
+            Self::Template(_) => None,
+        }
+    }
+}
+
+impl From<u16> for ReadyPort {
+    fn from(port: u16) -> Self {
+        Self::Port(port)
+    }
+}
+
+impl std::str::FromStr for ReadyPort {
+    type Err = String;
+
+    /// Numeric strings must be a valid port (1-65535); anything else
+    /// (non-empty) is treated as a Tera template.
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.is_empty() {
+            Err("ready_port cannot be empty".to_string())
+        } else if let Ok(n) = s.parse::<u64>() {
+            u16::try_from(n)
+                .ok()
+                .filter(|&p| p > 0)
+                .map(Self::Port)
+                .ok_or_else(|| format!("ready_port out of range (1-65535): {n}"))
+        } else {
+            Ok(Self::Template(s.to_string()))
+        }
+    }
+}
+
+impl std::fmt::Display for ReadyPort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Port(port) => write!(f, "{port}"),
+            Self::Template(template) => f.write_str(template),
+        }
+    }
+}
+
+impl Serialize for ReadyPort {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Port(port) => s.serialize_u16(*port),
+            Self::Template(template) => s.serialize_str(template),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ReadyPort {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+
+        impl serde::de::Visitor<'_> for V {
+            type Value = ReadyPort;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a port number (1-65535) or a template string")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<ReadyPort, E> {
+                u16::try_from(v)
+                    .ok()
+                    .filter(|&p| p > 0)
+                    .map(ReadyPort::Port)
+                    .ok_or_else(|| E::custom(format!("ready_port out of range (1-65535): {v}")))
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<ReadyPort, E> {
+                if v < 0 {
+                    Err(E::custom("ready_port cannot be negative"))
+                } else {
+                    self.visit_u64(v as u64)
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<ReadyPort, E> {
+                // Numeric strings resolve immediately; anything else is a
+                // Tera template rendered at daemon start time.
+                v.parse().map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_any(V)
+    }
+}
+
+impl JsonSchema for ReadyPort {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("ReadyPort")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "TCP readiness port: a port number, or a template string rendering to one (e.g. \"{{ daemons.redis.port }}\")",
+            "oneOf": [
+                { "type": "integer", "minimum": 1, "maximum": 65535 },
+                { "type": "string", "description": "Tera template that renders to a port number" }
+            ]
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // StopSignal
 // ---------------------------------------------------------------------------
 

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -12,7 +12,8 @@ use std::path::{Path, PathBuf};
 // Re-export config value types so existing `use crate::pitchfork_toml::X` paths keep working.
 pub use crate::config_types::{
     CpuLimit, CronRetrigger, Dir, MemoryLimit, OnOutputHook, PitchforkTomlAuto, PitchforkTomlCron,
-    PitchforkTomlHooks, PortBump, PortConfig, ReadyHttp, Retry, StopConfig, StopSignal, WatchMode,
+    PitchforkTomlHooks, PortBump, PortConfig, ReadyHttp, ReadyPort, Retry, StopConfig, StopSignal,
+    WatchMode,
 };
 
 /// Raw slug entry as read from TOML (uses String for dir path).
@@ -167,7 +168,7 @@ struct PitchforkTomlDaemonRaw {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_http: Option<ReadyHttp>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub ready_port: Option<u16>,
+    pub ready_port: Option<ReadyPort>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_cmd: Option<String>,
     /// New port configuration (preferred)
@@ -1231,7 +1232,7 @@ impl PitchforkToml {
                     ready_delay: daemon.ready_delay,
                     ready_output: daemon.ready_output.clone(),
                     ready_http: daemon.ready_http.clone(),
-                    ready_port: daemon.ready_port,
+                    ready_port: daemon.ready_port.clone(),
                     ready_cmd: daemon.ready_cmd.clone(),
                     port: port.cloned(),
                     // Deprecated fields: written for backward compatibility with older pitchfork versions
@@ -1580,9 +1581,9 @@ pub struct PitchforkTomlDaemon {
     pub ready_output: Option<String>,
     /// HTTP URL to poll for readiness. Accepts any 2xx response by default, or configured statuses.
     pub ready_http: Option<ReadyHttp>,
-    /// TCP port to check for readiness (connection success = ready)
-    #[schemars(range(min = 1, max = 65535))]
-    pub ready_port: Option<u16>,
+    /// TCP port to check for readiness (connection success = ready).
+    /// Accepts a port number or a Tera template string that renders to one.
+    pub ready_port: Option<ReadyPort>,
     /// Shell command to poll for readiness (exit code 0 = ready)
     pub ready_cmd: Option<String>,
     /// Port configuration: expected ports and auto-bump settings
@@ -1683,7 +1684,17 @@ impl PitchforkTomlDaemon {
             ready_delay: self.ready_delay,
             ready_output: self.ready_output.clone(),
             ready_http: self.ready_http.clone(),
-            ready_port: self.ready_port,
+            // Templates are resolved to a literal port by render_daemon_templates
+            // on the start path; an unrendered template has no usable port.
+            ready_port: self.ready_port.as_ref().and_then(|rp| {
+                let port = rp.as_port();
+                if port.is_none() {
+                    warn!(
+                        "daemon {id}: ready_port template {rp:?} was not rendered on this start path; skipping port readiness check"
+                    );
+                }
+                port
+            }),
             ready_cmd: self.ready_cmd.clone(),
             port: self.port.clone(),
             wait_ready: false,

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,7 +1,8 @@
 //! Tera template rendering for pitchfork.toml configuration fields.
 //!
-//! Allows `run`, `env` values, `hooks.*`, and `ready_cmd` to use Tera templates
-//! like `{{ daemons.redis.ports[0] }}` to reference computed values from other daemons.
+//! Allows `run`, `env` values, `hooks.*`, and the readiness fields (`ready_cmd`,
+//! `ready_http`, `ready_port`, `ready_output`) to use Tera templates like
+//! `{{ daemons.redis.ports[0] }}` to reference computed values from other daemons.
 //!
 //! Templates are resolved level-by-level along the dependency order: each level
 //! can reference daemons from previous levels (which have already started and
@@ -203,7 +204,7 @@ pub fn render_template(template: &str, context: &TemplateContext) -> Result<Stri
 /// Render all template-enabled fields of a daemon config.
 ///
 /// Modifies the config in place. Returns the first error encountered from
-/// non-hook fields (`run`, `env`, `ready_cmd`). Hook template errors are
+/// non-hook fields (`run`, `env`, `ready_*`). Hook template errors are
 /// logged as warnings and the hook is set to `None` — hooks are re-rendered
 /// at fire time via `fire_hook`, so pre-rendered hook strings are unused.
 pub fn render_daemon_templates(
@@ -261,6 +262,30 @@ pub fn render_daemon_templates(
 
     if let Some(ref cmd) = config.ready_cmd {
         config.ready_cmd = Some(renderer.render(cmd)?);
+    }
+
+    if let Some(ref output) = config.ready_output {
+        config.ready_output = Some(renderer.render(output)?);
+    }
+
+    if let Some(ref http) = config.ready_http {
+        let mut http = http.clone();
+        http.url = renderer.render(&http.url)?;
+        config.ready_http = Some(http);
+    }
+
+    if let Some(crate::config_types::ReadyPort::Template(ref template)) = config.ready_port {
+        let rendered = renderer.render(template)?;
+        let port = rendered
+            .trim()
+            .parse::<u16>()
+            .ok()
+            .filter(|&p| p > 0)
+            .ok_or_else(|| RenderError::InvalidPort {
+                template: template.clone(),
+                rendered: rendered.clone(),
+            })?;
+        config.ready_port = Some(crate::config_types::ReadyPort::Port(port));
     }
 
     Ok(())
@@ -341,6 +366,10 @@ pub enum RenderError {
         template: String,
         source: tera::Error,
     },
+    #[error(
+        "ready_port template {template:?} rendered to {rendered:?}, expected a port number (1-65535)"
+    )]
+    InvalidPort { template: String, rendered: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -545,6 +574,63 @@ mod tests {
         let on_output = hooks.on_output.unwrap();
         assert_eq!(on_output.run, "curl http://localhost:6379");
         assert_eq!(on_output.filter.as_deref(), Some("ready"));
+    }
+
+    #[test]
+    fn test_render_daemon_templates_ready_fields() {
+        use crate::config_types::{ReadyHttp, ReadyPort};
+
+        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut config = PitchforkTomlDaemon {
+            run: "echo".to_string(),
+            ready_cmd: Some("redis-cli -p {{ daemons.redis.port }} ping".to_string()),
+            ready_output: Some("listening on {{ daemons.redis.port }}".to_string()),
+            ready_http: Some(ReadyHttp {
+                url: "http://localhost:{{ daemons.redis.port }}/health".to_string(),
+                status: vec![200, 401],
+            }),
+            ready_port: Some(ReadyPort::Template("{{ daemons.redis.port }}".to_string())),
+            ..Default::default()
+        };
+
+        render_daemon_templates(&mut config, &ctx).unwrap();
+
+        assert_eq!(config.ready_cmd.as_deref(), Some("redis-cli -p 6379 ping"));
+        assert_eq!(config.ready_output.as_deref(), Some("listening on 6379"));
+        let http = config.ready_http.unwrap();
+        assert_eq!(http.url, "http://localhost:6379/health");
+        assert_eq!(http.status, vec![200, 401]);
+        assert_eq!(config.ready_port, Some(ReadyPort::Port(6379)));
+    }
+
+    #[test]
+    fn test_render_daemon_templates_ready_port_invalid() {
+        use crate::config_types::ReadyPort;
+
+        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut config = PitchforkTomlDaemon {
+            run: "echo".to_string(),
+            ready_port: Some(ReadyPort::Template("{{ name }}".to_string())),
+            ..Default::default()
+        };
+
+        let err = render_daemon_templates(&mut config, &ctx).unwrap_err();
+        assert!(matches!(err, RenderError::InvalidPort { .. }));
+    }
+
+    #[test]
+    fn test_render_daemon_templates_ready_port_literal_untouched() {
+        use crate::config_types::ReadyPort;
+
+        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut config = PitchforkTomlDaemon {
+            run: "echo".to_string(),
+            ready_port: Some(ReadyPort::Port(8080)),
+            ..Default::default()
+        };
+
+        render_daemon_templates(&mut config, &ctx).unwrap();
+        assert_eq!(config.ready_port, Some(ReadyPort::Port(8080)));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7,7 +7,7 @@ use crate::log_store::LogStore;
 use crate::log_store::sqlite::LOG_STORE;
 use crate::pitchfork_toml::{
     CronRetrigger, PitchforkToml, PitchforkTomlAuto, PitchforkTomlCron, PitchforkTomlDaemon,
-    ReadyHttp, Retry, namespace_from_path,
+    ReadyHttp, ReadyPort, Retry, namespace_from_path,
 };
 use crate::procs::{PROCS, ProcessStats};
 use crate::settings::settings;
@@ -105,7 +105,7 @@ pub enum FormFieldValue {
     OptionalText(Option<String>),
     Number(u32),
     OptionalNumber(Option<u64>),
-    OptionalPort(Option<u16>),
+    OptionalPort(Option<ReadyPort>),
     #[allow(dead_code)]
     Boolean(bool),
     OptionalBoolean(Option<bool>),
@@ -289,7 +289,22 @@ impl FormField {
                 *opt = text.parse().ok();
             }
             FormFieldValue::OptionalPort(opt) => {
-                *opt = text.parse().ok();
+                let trimmed = text.trim();
+                if trimmed.is_empty() {
+                    *opt = None;
+                    self.error = None;
+                } else {
+                    match trimmed.parse() {
+                        Ok(value) => {
+                            *opt = Some(value);
+                            self.error = None;
+                        }
+                        Err(e) => {
+                            *opt = None;
+                            self.error = Some(e);
+                        }
+                    }
+                }
             }
             FormFieldValue::StringList(v) => {
                 *v = text
@@ -484,7 +499,9 @@ impl EditorState {
                         config.ready_http.as_ref().map(|h| h.url.clone()),
                     )
                 }
-                "ready_port" => field.value = FormFieldValue::OptionalPort(config.ready_port),
+                "ready_port" => {
+                    field.value = FormFieldValue::OptionalPort(config.ready_port.clone())
+                }
                 "boot_start" => field.value = FormFieldValue::OptionalBoolean(config.boot_start),
                 "depends" => {
                     field.value = FormFieldValue::StringList(
@@ -561,7 +578,7 @@ impl EditorState {
                         status: self.preserved_ready_http_status.clone().unwrap_or_default(),
                     })
                 }
-                ("ready_port", FormFieldValue::OptionalPort(p)) => config.ready_port = *p,
+                ("ready_port", FormFieldValue::OptionalPort(p)) => config.ready_port = p.clone(),
                 ("boot_start", FormFieldValue::OptionalBoolean(b)) => config.boot_start = *b,
                 ("depends", FormFieldValue::StringList(v)) => {
                     config.depends = v.iter().filter_map(|s| DaemonId::parse(s).ok()).collect()
@@ -717,6 +734,12 @@ impl EditorState {
             && field.cursor > 0
         {
             let mut text = field.get_text();
+            // Value-backed fields (OptionalNumber/OptionalPort) drop invalid
+            // input in set_text, so the cursor can be past the derived text.
+            field.cursor = field.cursor.min(text.chars().count());
+            if field.cursor == 0 {
+                return;
+            }
             field.cursor -= 1;
             let byte_idx = char_to_byte_index(&text, field.cursor);
             text.remove(byte_idx);
@@ -755,10 +778,6 @@ impl EditorState {
             match (field.name, &field.value) {
                 ("run", FormFieldValue::Text(s)) if s.is_empty() => {
                     field.error = Some("Required".to_string());
-                    valid = false;
-                }
-                ("ready_port", FormFieldValue::OptionalPort(Some(p))) if *p == 0 => {
-                    field.error = Some("Port must be 1-65535".to_string());
                     valid = false;
                 }
                 ("ready_http", FormFieldValue::OptionalText(Some(url)))

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -262,6 +262,9 @@ impl FormField {
     }
 
     pub fn set_text(&mut self, text: String) {
+        // Any edit invalidates a previous validation error; arms below
+        // re-set it for input that fails to parse.
+        self.error = None;
         match &mut self.value {
             FormFieldValue::Text(s) => *s = text,
             FormFieldValue::OptionalText(opt) => {
@@ -773,7 +776,13 @@ impl EditorState {
 
         // Validate fields
         for field in &mut self.fields {
-            field.error = None;
+            // Keep parse errors from set_text (e.g. out-of-range ready_port):
+            // the typed value was already dropped, so saving now would
+            // silently lose the field.
+            if field.error.is_some() {
+                valid = false;
+                continue;
+            }
 
             match (field.name, &field.value) {
                 ("run", FormFieldValue::Text(s)) if s.is_empty() => {

--- a/tests/test_pitchfork_toml.rs
+++ b/tests/test_pitchfork_toml.rs
@@ -216,8 +216,38 @@ ready_cmd = "test -f /tmp/ready"
         "http://localhost:8080/health"
     );
     assert!(daemon.ready_http.as_ref().unwrap().status.is_empty());
-    assert_eq!(daemon.ready_port, Some(8080));
+    assert_eq!(
+        daemon.ready_port,
+        Some(pitchfork_toml::ReadyPort::Port(8080))
+    );
     assert_eq!(daemon.ready_cmd, Some("test -f /tmp/ready".to_string()));
+
+    Ok(())
+}
+
+/// Test daemon with a templated ready_port
+#[test]
+fn test_daemon_with_templated_ready_port() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.ready_daemon]
+run = "echo 'server starting'"
+ready_port = "{{ daemons.redis.port }}"
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "ready_daemon").unwrap();
+
+    assert_eq!(
+        daemon.ready_port,
+        Some(pitchfork_toml::ReadyPort::Template(
+            "{{ daemons.redis.port }}".to_string()
+        ))
+    );
 
     Ok(())
 }
@@ -1034,7 +1064,7 @@ run = "npm run debug"
     // api should be overridden by local
     let api = pt.daemons.get(&api_key).unwrap();
     assert_eq!(api.run, "npm run dev");
-    assert_eq!(api.ready_port, Some(3001));
+    assert_eq!(api.ready_port, Some(pitchfork_toml::ReadyPort::Port(3001)));
 
     // worker should remain from base
     let worker = pt.daemons.get(&worker_key).unwrap();

--- a/tests/test_pitchfork_toml.rs
+++ b/tests/test_pitchfork_toml.rs
@@ -252,6 +252,32 @@ ready_port = "{{ daemons.redis.port }}"
     Ok(())
 }
 
+/// Numeric-looking ready_port strings are validated at parse time, not
+/// treated as templates
+#[test]
+fn test_daemon_with_out_of_range_ready_port_string() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    for bad in ["\"-1\"", "\"0\"", "\"70000\"", "0", "70000"] {
+        let toml_content = format!(
+            r#"
+[daemons.ready_daemon]
+run = "echo hi"
+ready_port = {bad}
+"#
+        );
+        fs::write(&toml_path, toml_content).unwrap();
+        let err = pitchfork_toml::PitchforkToml::read(&toml_path)
+            .expect_err(&format!("ready_port = {bad} should fail to parse"));
+        let chain = format!("{err:?}");
+        assert!(
+            chain.contains("ready_port"),
+            "error for {bad} should mention ready_port: {chain}"
+        );
+    }
+}
+
 /// Test daemon with structured HTTP ready check
 #[test]
 fn test_daemon_with_ready_http_status() -> Result<()> {


### PR DESCRIPTION
## Summary

Extends Tera template support (previously available in `run`, `env`, `hooks.*`, and `ready_cmd`) to the remaining readiness fields: `ready_http`, `ready_port`, and `ready_output`.

```toml
[daemons.redis]
run = "redis-server"
port = { expect = [6379], bump = 10 }

[daemons.worker]
run = "worker --redis-port {{ daemons.redis.port }}"
ready_cmd = "redis-cli -p {{ daemons.redis.port }} ping"
ready_http = "http://localhost:{{ daemons.redis.port }}/health"
ready_port = "{{ daemons.redis.port }}"
ready_output = "listening on {{ daemons.redis.port }}"
depends = ["redis"]
```

## Changes

- **`ready_output`** and **`ready_http.url`** render through the existing `render_daemon_templates` pipeline on the start path (the `ready_http` `status` list is untouched).
- **`ready_port`** was a bare `u16`, so templates need a string form: new `ReadyPort` config type (`src/config_types.rs`) accepting a TOML integer or string. Numeric strings resolve immediately, out-of-range values are rejected at parse time, and anything else is kept as a template. A template that doesn't render to a valid port (1-65535) fails the daemon start with a new `RenderError::InvalidPort`.
- `RunOptions`, persisted state, and IPC keep the resolved `u16` — no compatibility impact. Retry, file-watch restart, and cron retrigger rebuild options from persisted state where the port was already resolved.
- On start paths that don't render templates (boot_start, cron registration), an unrendered `ready_port` template is dropped with a `warn!` instead of silently skipping the check — same class of limitation `run`/`env`/`ready_cmd` templates already have there.
- TUI config editor: the Ready Port field now round-trips templates instead of coercing through `u16`, with inline validation; also fixes a pre-existing backspace panic when invalid input emptied a value-backed field while the cursor pointed past the derived text.
- Docs: templates guide field table, ready-checks guide (new Templates section), configuration reference, and regenerated `docs/public/schema.json` so editors autocomplete both forms.

## Behavior changes

- `ready_port = 0` now fails config parsing at load. Previously the parser accepted it (the 1-65535 constraint existed only in the JSON schema) and produced a TCP check against port 0.
- `ready_port = "8080"` (numeric string) is now accepted and normalized to the integer form; previously a TOML type error.

## Testing

- Unit tests in `src/template.rs` for all rendered fields, the invalid-port error, and literal passthrough.
- Integration tests in `tests/test_pitchfork_toml.rs` for parsing templated `ready_port`.
- `mise run ci-dev` passes: fmt, clippy `-D warnings`, 455 unit/integration tests, 275 bats e2e tests, docs/schema regeneration.

## Contributor note

This PR was completely generated by a coding agent. I don't have deep experience with Rust but I also accept if this PR doesn't clear the quality bar and gets closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019S4Y8UWbpZapkPXdeCAKLy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Readiness checks now support Tera templates for `ready_output`, `ready_http.url`, `ready_cmd`, and `ready_port`.
  * `ready_port` can be provided as a literal port number or a template that resolves to a valid TCP port.
* **Bug Fixes**
  * Invalid `ready_port` template renders are rejected with a clear error instead of being accepted.
* **Documentation**
  * Updated readiness-check, configuration templates, reference docs, schema, and CLI help to describe template support and validation.
* **Tests**
  * Extended coverage for templated and invalid `ready_port` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->