### PR TITLE
fix(web): resolve spa assets from app root on nested routes

### DIFF
--- a/src/web/static_files.rs
+++ b/src/web/static_files.rs
@@ -45,7 +45,7 @@ fn inject_into_index_html(data: &[u8]) -> Body {
     // works both at the root and under a sub-path (`web_path`). A <base> tag
     // anchors those URLs to the app root; without it, reloading a nested SPA
     // route like /daemon/:id resolves them against the route path instead.
-    let replaced = replaced.replace("<head>", &format!("<head>\n  <base href=\"{base}/\">"));
+    let replaced = replaced.replacen("<head>", &format!("<head>\n  <base href=\"{base}/\">"), 1);
     Body::from(replaced.into_bytes())
 }
 

--- a/src/web/static_files.rs
+++ b/src/web/static_files.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::Body,
-    http::{StatusCode, Uri, header},
+    http::{HeaderMap, StatusCode, Uri, header},
     response::{IntoResponse, Response},
 };
 use rust_embed::Embed;
@@ -39,10 +39,13 @@ fn inject_into_index_html(data: &[u8]) -> Body {
         .filter(|t| !t.is_empty())
         .map(|token| html.replace(TOKEN_PLACEHOLDER, token))
         .unwrap_or_else(|| html.into_owned());
-    let replaced = STATIC_BASE
-        .get()
-        .map(|base| replaced.replace(BASE_PLACEHOLDER, base))
-        .unwrap_or(replaced);
+    let base = STATIC_BASE.get().map(String::as_str).unwrap_or("");
+    let replaced = replaced.replace(BASE_PLACEHOLDER, base);
+    // The bundle references assets with relative URLs (vite `base: ''`) so it
+    // works both at the root and under a sub-path (`web_path`). A <base> tag
+    // anchors those URLs to the app root; without it, reloading a nested SPA
+    // route like /daemon/:id resolves them against the route path instead.
+    let replaced = replaced.replace("<head>", &format!("<head>\n  <base href=\"{base}/\">"));
     Body::from(replaced.into_bytes())
 }
 
@@ -51,7 +54,7 @@ fn inject_into_index_html(data: &[u8]) -> Body {
 /// Any request path is first tried as a static file. If not found,
 /// falls back to `index.html` so the SPA router can handle client-side routes.
 /// When serving `index.html`, replaces placeholders with the actual token and base path.
-pub async fn static_handler(uri: Uri) -> impl IntoResponse {
+pub async fn static_handler(uri: Uri, headers: HeaderMap) -> impl IntoResponse {
     let mut path = uri.path().trim_start_matches('/');
     if path.is_empty() {
         path = "index.html";
@@ -79,7 +82,20 @@ pub async fn static_handler(uri: Uri) -> impl IntoResponse {
             builder.body(body).unwrap()
         }
         None => {
-            // SPA fallback: return index.html for unknown paths (client-side routing)
+            // SPA fallback: return index.html for unknown paths (client-side routing).
+            // Only do this for navigation requests (Accept: text/html); scripts,
+            // stylesheets, and other subresources request with a different Accept
+            // and must get a 404 rather than index.html with the wrong MIME type.
+            let accepts_html = headers
+                .get(header::ACCEPT)
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|v| v.contains("text/html"));
+            if !accepts_html {
+                return Response::builder()
+                    .status(StatusCode::NOT_FOUND)
+                    .body(Body::from("404 Not Found"))
+                    .unwrap();
+            }
             match Assets::get("index.html") {
                 Some(content) => {
                     let data = content.data.to_vec();


### PR DESCRIPTION
## Problem

Reloading the browser on a nested web UI route like `/daemon/:name` or `/logs/:name` renders a blank/black page with console errors like:

> Loading module from "http://localhost:3130/daemon/assets/index-BXkI6laM.js" was blocked because of a disallowed MIME type ("text/html").

The built SPA references its assets with relative URLs (`vite base: ''`, deliberate so the same embedded bundle works when mounted under a sub-path via `web_path` / `web.base_path`). On a full page load of a nested route, the browser resolves `./assets/index-*.js` against the route path (`/daemon/assets/...`), which doesn't exist — and the SPA fallback returned `index.html` for it, hence the `text/html` MIME errors and blank page.

## Fix

- Inject a `<base href>` tag into `index.html` at serve time (alongside the existing token/base placeholder injection), so relative asset URLs always resolve against the app root regardless of route depth. This keeps sub-path mounting working with a single embedded bundle: at the root it injects `<base href="/">`, under `web_path=/pf` it injects `<base href="/pf/">`.
- Make the SPA fallback return 404 for non-navigation requests (`Accept` without `text/html`). Scripts and stylesheets never accept `text/html`, so a missing asset (e.g. a stale tab requesting an old hashed bundle after an upgrade) now fails with a clear 404 instead of a confusing MIME error.

## Verification

Tested against the running server:
- `GET /daemon/foo` with `Accept: text/html` → `index.html` with `<base href="/">` injected
- `GET /assets/index-*.js` → 200 `text/javascript`
- `GET /daemon/assets/<missing>.js` with `Accept: */*` → 404
- `mise run ci-dev` passes (lint, build, docs, full test suite incl. bats)

*This PR was generated by Claude Code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved single-page application routing by serving the app shell only for requests that accept HTML.
  * Unknown non-HTML asset paths now return a correct 404 response instead of the app shell.
  * Updated the embedded web app injection to include the configured base path so relative assets resolve correctly when hosted under a sub-path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->