### PR TITLE
fix(schema): do not require daemons field

### DIFF
--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -27,9 +27,6 @@
       "default": {}
     }
   },
-  "required": [
-    "daemons"
-  ],
   "$defs": {
     "CpuLimit": {
       "description": "CPU usage limit as a percentage (e.g. 80 for 80% of one core, 200 for 2 cores)",

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -239,6 +239,7 @@ struct PitchforkTomlDaemonRaw {
 #[schemars(title = "Pitchfork Configuration")]
 pub struct PitchforkToml {
     /// Map of daemon IDs to their configurations
+    #[serde(default)]
     pub daemons: IndexMap<DaemonId, PitchforkTomlDaemon>,
     /// Optional explicit namespace declared in this file.
     ///


### PR DESCRIPTION
This is relevant mostly for global configuration files, which may contain only settings without any daemons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated schema validation so the `daemons` field is no longer required when validating input.
  * Improved TOML handling so when the `daemons` section is omitted, it now correctly defaults to an empty set instead of failing deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->