### PR TITLE
fix: deterministic IPC response attribution and whole-group stop wait

### DIFF
--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -564,13 +564,7 @@ impl IpcClient {
                         }
 
                         let is_explicit = explicitly_requested.contains(&id);
-                        let task = Self::spawn_start_task(
-                            self.clone(),
-                            id,
-                            &rendered_config,
-                            is_explicit,
-                            &opts,
-                        );
+                        let task = Self::spawn_start_task(id, &rendered_config, is_explicit, &opts);
                         tasks.push(task);
                     }
                 }
@@ -653,7 +647,6 @@ impl IpcClient {
                     if let Some(ref cmd) = adhoc_daemon.cmd {
                         let is_explicit = explicitly_requested.contains(&id);
                         let task = Self::spawn_adhoc_start_task(
-                            self.clone(),
                             id,
                             cmd.clone(),
                             adhoc_daemon.dir.clone().unwrap_or_default(),
@@ -719,6 +712,19 @@ impl IpcClient {
         })
     }
 
+    /// Open a dedicated IPC connection for a parallel task.
+    ///
+    /// The wire protocol has no request IDs, so a connection can only carry one
+    /// in-flight request at a time. Tasks that run concurrently (parallel
+    /// start/stop within a dependency level) must therefore each use their own
+    /// connection — sharing one would mis-attribute responses between daemons
+    /// (e.g. a ready daemon reported as failed with another daemon's exit code).
+    async fn connect_dedicated() -> Result<Self> {
+        // The caller already connected once, so the supervisor is running —
+        // no autostart needed.
+        Self::connect(false).await
+    }
+
     /// Spawn a task to start a single daemon
     ///
     /// This encapsulates the start logic for one daemon, allowing parallel execution
@@ -726,8 +732,10 @@ impl IpcClient {
     /// - Command parsing
     /// - Config merging (CLI options override config file)
     /// - IPC communication with supervisor
+    ///
+    /// Each task uses its own dedicated IPC connection so concurrent responses
+    /// are attributed deterministically (see [`Self::connect_dedicated`]).
     fn spawn_start_task(
-        ipc: Arc<Self>,
         id: DaemonId,
         daemon_config: &PitchforkTomlDaemon,
         is_explicitly_requested: bool,
@@ -769,7 +777,10 @@ impl IpcClient {
                 (None, None)
             };
 
-            let result = ipc.run(run_opts).await;
+            let result = match Self::connect_dedicated().await {
+                Ok(ipc) => ipc.run(run_opts).await,
+                Err(e) => Err(e),
+            };
 
             // Stop log streaming and wait for the task to fully exit
             if let Some(tx) = &log_stop_tx {
@@ -791,9 +802,11 @@ impl IpcClient {
     ///
     /// This handles restarting ad-hoc daemons that were originally started
     /// via `pitchfork run` command.
+    ///
+    /// Each task uses its own dedicated IPC connection so concurrent responses
+    /// are attributed deterministically (see [`Self::connect_dedicated`]).
     #[allow(clippy::too_many_arguments)]
     fn spawn_adhoc_start_task(
-        ipc: Arc<Self>,
         id: DaemonId,
         cmd: Vec<String>,
         dir: PathBuf,
@@ -858,7 +871,10 @@ impl IpcClient {
                 (None, None)
             };
 
-            let result = ipc.run(run_opts).await;
+            let result = match Self::connect_dedicated().await {
+                Ok(ipc) => ipc.run(run_opts).await,
+                Err(e) => Err(e),
+            };
 
             // Stop log streaming and wait for the task to fully exit
             if let Some(tx) = &log_stop_tx {
@@ -879,13 +895,14 @@ impl IpcClient {
     /// Spawn a task to stop a single daemon
     ///
     /// Similar to spawn_start_task, this allows parallel stopping of daemons
-    /// within the same dependency level.
-    fn spawn_stop_task(
-        ipc: Arc<Self>,
-        id: DaemonId,
-    ) -> tokio::task::JoinHandle<(DaemonId, Result<()>)> {
+    /// within the same dependency level, on a dedicated IPC connection
+    /// (see [`Self::connect_dedicated`]).
+    fn spawn_stop_task(id: DaemonId) -> tokio::task::JoinHandle<(DaemonId, Result<()>)> {
         tokio::spawn(async move {
-            let result = ipc.stop(id.clone()).await.map(|_| ());
+            let result = match Self::connect_dedicated().await {
+                Ok(ipc) => ipc.stop(id.clone()).await.map(|_| ()),
+                Err(e) => Err(e),
+            };
             (id, result)
         })
     }
@@ -992,7 +1009,7 @@ impl IpcClient {
             // Stop all daemons in this level concurrently
             let mut tasks = Vec::new();
             for id in to_stop {
-                let task = Self::spawn_stop_task(self.clone(), id);
+                let task = Self::spawn_stop_task(id);
                 tasks.push(task);
             }
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -15,10 +15,25 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
+/// Returns whether the version-mismatch warning was already emitted by this
+/// process, marking it as emitted. Parallel batch tasks each open their own
+/// connection, so without this a mismatched supervisor would warn once per
+/// daemon instead of once.
+fn version_mismatch_already_warned() -> bool {
+    static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    WARNED.swap(true, std::sync::atomic::Ordering::Relaxed)
+}
+
 pub struct IpcClient {
     _id: String,
     recv: Mutex<BufReader<RecvHalf>>,
     send: Mutex<SendHalf>,
+    /// Held across a full request/response exchange. The wire protocol has no
+    /// request IDs, so responses are attributed purely by read order — if two
+    /// tasks interleave request/read on the same connection, each can consume
+    /// the other's response. Callers that need parallel requests must use
+    /// dedicated connections (one in-flight request per connection).
+    exchange: Mutex<()>,
 }
 
 impl IpcClient {
@@ -43,7 +58,7 @@ impl IpcClient {
             IpcResponse::ConnectOk {
                 version: supervisor_version,
             } => {
-                if supervisor_version != client_version {
+                if supervisor_version != client_version && !version_mismatch_already_warned() {
                     warn!(
                         "CLI version {client_version} differs from supervisor version {supervisor_version}. \
                          Restart the supervisor with: pitchfork supervisor start --force"
@@ -61,10 +76,12 @@ impl IpcClient {
                     }
                     .into());
                 }
-                warn!(
-                    "Supervisor is running an older version. \
-                     Restart the supervisor with: pitchfork supervisor start --force"
-                );
+                if !version_mismatch_already_warned() {
+                    warn!(
+                        "Supervisor is running an older version. \
+                         Restart the supervisor with: pitchfork supervisor start --force"
+                    );
+                }
             }
             _ => {
                 return Err(IpcError::UnexpectedResponse {
@@ -121,6 +138,7 @@ impl IpcClient {
                             _id: id.to_string(),
                             recv: Mutex::new(recv),
                             send: Mutex::new(send),
+                            exchange: Mutex::new(()),
                         });
                     }
                     Err(err) => {
@@ -218,6 +236,7 @@ impl IpcClient {
         msg: IpcRequest,
         timeout: Duration,
     ) -> Result<IpcResponse> {
+        let _exchange = self.exchange.lock().await;
         self.send(msg).await?;
         self.read(timeout).await
     }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -15,13 +15,21 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-/// Returns whether the version-mismatch warning was already emitted by this
-/// process, marking it as emitted. Parallel batch tasks each open their own
-/// connection, so without this a mismatched supervisor would warn once per
-/// daemon instead of once.
-fn version_mismatch_already_warned() -> bool {
-    static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-    WARNED.swap(true, std::sync::atomic::Ordering::Relaxed)
+/// Returns whether the version-mismatch warning was already emitted for this
+/// supervisor version, marking it as emitted. Parallel batch tasks each open
+/// their own connection, so without this a mismatched supervisor would warn
+/// once per daemon instead of once. Keyed by the supervisor version so a
+/// long-lived process (TUI, web, MCP) warns again if a *different* mismatched
+/// supervisor appears later.
+fn version_mismatch_already_warned(supervisor_version: &str) -> bool {
+    static WARNED: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+    let mut warned = WARNED.lock().unwrap_or_else(|e| e.into_inner());
+    if warned.as_deref() == Some(supervisor_version) {
+        true
+    } else {
+        *warned = Some(supervisor_version.to_string());
+        false
+    }
 }
 
 pub struct IpcClient {
@@ -34,6 +42,11 @@ pub struct IpcClient {
     /// the other's response. Callers that need parallel requests must use
     /// dedicated connections (one in-flight request per connection).
     exchange: Mutex<()>,
+    /// Set when an exchange fails mid-stream (timeout or I/O error). The
+    /// abandoned response may still arrive on the connection later, so reading
+    /// again would attribute it to the next request (permanent off-by-one
+    /// desync). The next exchange reconnects instead of reading stale data.
+    desynced: std::sync::atomic::AtomicBool,
 }
 
 impl IpcClient {
@@ -58,7 +71,9 @@ impl IpcClient {
             IpcResponse::ConnectOk {
                 version: supervisor_version,
             } => {
-                if supervisor_version != client_version && !version_mismatch_already_warned() {
+                if supervisor_version != client_version
+                    && !version_mismatch_already_warned(&supervisor_version)
+                {
                     warn!(
                         "CLI version {client_version} differs from supervisor version {supervisor_version}. \
                          Restart the supervisor with: pitchfork supervisor start --force"
@@ -76,7 +91,7 @@ impl IpcClient {
                     }
                     .into());
                 }
-                if !version_mismatch_already_warned() {
+                if !version_mismatch_already_warned("legacy") {
                     warn!(
                         "Supervisor is running an older version. \
                          Restart the supervisor with: pitchfork supervisor start --force"
@@ -96,6 +111,20 @@ impl IpcClient {
     }
 
     async fn connect_(id: &str, name: &str) -> Result<Self> {
+        let (recv, send) = Self::open_stream(name).await?;
+        Ok(Self {
+            _id: id.to_string(),
+            recv: Mutex::new(recv),
+            send: Mutex::new(send),
+            exchange: Mutex::new(()),
+            desynced: std::sync::atomic::AtomicBool::new(false),
+        })
+    }
+
+    /// Open a raw socket stream to the supervisor with connect retry/backoff.
+    /// Used both for the initial connection and to re-establish a connection
+    /// whose framing was lost after a failed exchange (see `desynced`).
+    async fn open_stream(name: &str) -> Result<(BufReader<RecvHalf>, SendHalf)> {
         let s = settings();
         let connect_attempts = u32::try_from(s.ipc.connect_attempts).unwrap_or_else(|_| {
             warn!(
@@ -132,14 +161,7 @@ impl IpcClient {
                 match interprocess::local_socket::tokio::Stream::connect(fs_name(name)?).await {
                     Ok(conn) => {
                         let (recv, send) = conn.split();
-                        let recv = BufReader::new(recv);
-
-                        return Ok(Self {
-                            _id: id.to_string(),
-                            recv: Mutex::new(recv),
-                            send: Mutex::new(send),
-                            exchange: Mutex::new(()),
-                        });
+                        return Ok((BufReader::new(recv), send));
                     }
                     Err(err) => {
                         if let Some(duration) = duration {
@@ -236,9 +258,26 @@ impl IpcClient {
         msg: IpcRequest,
         timeout: Duration,
     ) -> Result<IpcResponse> {
+        use std::sync::atomic::Ordering;
         let _exchange = self.exchange.lock().await;
-        self.send(msg).await?;
-        self.read(timeout).await
+        // A previous exchange failed mid-stream, so its response may still be
+        // queued (or half-read) on the socket. Reconnect to restore framing —
+        // reading would attribute the stale response to this request.
+        if self.desynced.load(Ordering::Acquire) {
+            let (recv, send) = Self::open_stream("main").await?;
+            *self.recv.lock().await = recv;
+            *self.send.lock().await = send;
+            self.desynced.store(false, Ordering::Release);
+        }
+        let result = async {
+            self.send(msg).await?;
+            self.read(timeout).await
+        }
+        .await;
+        if result.is_err() {
+            self.desynced.store(true, Ordering::Release);
+        }
+        result
     }
 
     // =========================================================================
@@ -578,7 +617,23 @@ impl IpcClient {
     /// Stop a single daemon (low-level operation)
     pub async fn stop(&self, id: DaemonId) -> Result<bool> {
         let id_str = id.qualified();
-        let rsp = self.request(IpcRequest::Stop { id: id.clone() }).await?;
+        // The supervisor's Stop handler blocks until the daemon's ENTIRE
+        // process group has exited (stop signal -> stop budget -> SIGKILL ->
+        // bounded verification), which can far exceed the flat IPC request
+        // timeout — a correct, in-progress stop would otherwise be reported
+        // as a failure. Budget the request from the daemon's own stop
+        // configuration: its graceful window, plus the supervisor's ~2s
+        // post-SIGKILL verification, plus the normal request timeout as slack.
+        let stop_budget = crate::state_file::StateFile::get()
+            .daemons
+            .get(&id)
+            .and_then(|d| d.stop_signal.as_ref())
+            .and_then(|s| s.timeout)
+            .unwrap_or_else(|| settings().supervisor_stop_timeout());
+        let timeout = stop_budget + Duration::from_secs(2) + settings().ipc_request_timeout();
+        let rsp = self
+            .request_with_timeout(IpcRequest::Stop { id: id.clone() }, timeout)
+            .await?;
         match rsp {
             IpcResponse::Ok => {
                 info!("Stopped daemon {id_str}");

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -258,6 +258,13 @@ impl Procs {
 
         // Wait for graceful shutdown: fast initial check then slower polling.
         // Per-daemon timeout overrides the global setting.
+        //
+        // The wait must cover the ENTIRE group, not just the leader. The leader
+        // is often a thin shell (`sh -c ...`) that dies within milliseconds of
+        // the signal while its children are still shutting down gracefully
+        // (e.g. `docker compose up` waiting for its container to stop).
+        // Returning as soon as the leader dies lets a force-restart spawn a
+        // replacement that collides with the still-terminating old instance.
         let stop_timeout = stop_timeout.unwrap_or_else(|| settings().supervisor_stop_timeout());
         let fast_ms = 10u64;
         let slow_ms = 50u64;
@@ -275,9 +282,8 @@ impl Procs {
 
         for sleep_duration in fast_checks.chain(slow_checks) {
             std::thread::sleep(sleep_duration);
-            self.refresh_pids(&[pid]);
             elapsed_ms += sleep_duration.as_millis() as u64;
-            if self.is_terminated_or_zombie(sysinfo::Pid::from_u32(pid)) {
+            if process_group_terminated(pgid) {
                 debug!("process group {pgid} terminated after {signal_name} ({elapsed_ms} ms)",);
                 return Ok(true);
             }
@@ -296,8 +302,16 @@ impl Procs {
             }
         }
 
-        // Brief wait for SIGKILL to take effect
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        // Wait for SIGKILL to take effect on the whole group (bounded: SIGKILL
+        // cannot be caught, so members disappear as soon as the kernel reaps
+        // them — anything left after this is stuck in uninterruptible sleep).
+        for _ in 0..40 {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            if process_group_terminated(pgid) {
+                return Ok(true);
+            }
+        }
+        warn!("process group {pgid} still has members after SIGKILL");
         Ok(true)
     }
 
@@ -1061,6 +1075,22 @@ fn format_duration(secs: u64) -> String {
 
 fn format_bytes_per_sec(bytes: u64) -> String {
     format!("{}/s", humanbyte::to_string(bytes, humanbyte::Format::IEC))
+}
+
+/// Check whether a process group has no remaining members.
+///
+/// `killpg(pgid, 0)` probes for any member without delivering a signal:
+/// ESRCH means the group is empty. Unreaped zombies still count as members,
+/// but they are reaped promptly (the leader by the supervisor's monitoring
+/// task via `child.wait()`, orphans by init or the container-mode reaper),
+/// so the group empties as soon as every member has actually exited.
+#[cfg(unix)]
+fn process_group_terminated(pgid: i32) -> bool {
+    let ret = unsafe { libc::killpg(pgid, 0) };
+    if ret == 0 {
+        return false;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
 }
 
 #[cfg(unix)]

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -201,13 +201,21 @@ impl Procs {
     }
 
     /// Kill an entire process group with graceful shutdown strategy:
-    /// 1. Send the configured stop signal to the process group (-pgid) and wait up to ~3s
-    /// 2. If any processes remain, send SIGKILL to the group
+    /// 1. Send the configured stop signal to the process group (-pgid) and
+    ///    wait up to the stop timeout for the WHOLE group to exit
+    /// 2. If any processes remain, send SIGKILL to the group and verify
     ///
     /// Since daemons are spawned with setsid(), the daemon PID == PGID,
     /// so this atomically signals all descendant processes.
     ///
-    /// Returns `Err` if the signal could not be sent (e.g. permission denied).
+    /// The stop timeout is the graceful-shutdown budget for the entire group
+    /// (like systemd's TimeoutStopSec for a cgroup): members that are still
+    /// alive when it expires are SIGKILLed. Daemons whose teardown legitimately
+    /// takes longer (e.g. draining connections, stopping containers) should
+    /// raise `stop_signal.timeout` rather than rely on outliving the budget.
+    ///
+    /// Returns `Err` if the signal could not be sent (e.g. permission denied)
+    /// or if group members survived even SIGKILL (uninterruptible sleep).
     #[cfg(unix)]
     fn kill_process_group(
         &self,
@@ -311,8 +319,25 @@ impl Procs {
                 return Ok(true);
             }
         }
-        warn!("process group {pgid} still has members after SIGKILL");
-        Ok(true)
+        // Report failure so callers do not mark the daemon Stopped (and start
+        // a replacement) while a member is still alive.
+        Err(miette::miette!(
+            "process group {pgid} still has members after SIGKILL \
+             (possibly stuck in uninterruptible sleep)"
+        ))
+    }
+
+    /// Whether any signalable member of the daemon's process group is still
+    /// alive. The daemon PID == PGID because daemons are spawned with setsid().
+    pub fn process_group_alive(&self, pid: u32) -> bool {
+        #[cfg(unix)]
+        {
+            !process_group_terminated(pid as i32)
+        }
+        #[cfg(not(unix))]
+        {
+            self.is_running(pid)
+        }
     }
 
     #[cfg(target_os = "linux")]
@@ -1077,20 +1102,24 @@ fn format_bytes_per_sec(bytes: u64) -> String {
     format!("{}/s", humanbyte::to_string(bytes, humanbyte::Format::IEC))
 }
 
-/// Check whether a process group has no remaining members.
+/// Check whether a process group has no remaining members that we could
+/// still be waiting on.
 ///
-/// `killpg(pgid, 0)` probes for any member without delivering a signal:
-/// ESRCH means the group is empty. Unreaped zombies still count as members,
-/// but they are reaped promptly (the leader by the supervisor's monitoring
-/// task via `child.wait()`, orphans by init or the container-mode reaper),
-/// so the group empties as soon as every member has actually exited.
+/// `killpg(pgid, 0)` probes for members without delivering a signal:
+/// - success: at least one member remains that we may signal — keep waiting.
+/// - ESRCH: the group is empty.
+/// - EPERM: members remain, but none that we may signal (e.g. a root-owned
+///   helper spawned inside the group). Our stop signal and SIGKILL never
+///   reached them, so waiting longer cannot make progress — treat the group
+///   as terminated, matching the previous leader-only behavior.
+///
+/// Unreaped zombies still count as members, but they are reaped promptly
+/// (the leader by the supervisor's monitoring task via `child.wait()`,
+/// orphans by init or the supervisor's PID-1 reaper), so the group empties
+/// as soon as every member has actually exited.
 #[cfg(unix)]
 fn process_group_terminated(pgid: i32) -> bool {
-    let ret = unsafe { libc::killpg(pgid, 0) };
-    if ret == 0 {
-        return false;
-    }
-    std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+    unsafe { libc::killpg(pgid, 0) != 0 }
 }
 
 #[cfg(unix)]

--- a/src/supervisor/autostop.rs
+++ b/src/supervisor/autostop.rs
@@ -3,7 +3,7 @@
 //! Handles automatic stopping of daemons when shells leave directories,
 //! and starting daemons configured with `boot_start = true`.
 
-use super::Supervisor;
+use super::{SUPERVISOR, Supervisor};
 use crate::Result;
 use crate::daemon_id::DaemonId;
 use crate::ipc::IpcResponse;
@@ -64,11 +64,24 @@ impl Supervisor {
                 );
                 if starts && !still_active {
                     if autostop_delay.is_zero() {
-                        // No delay configured, stop immediately
+                        // No delay configured, stop immediately. Spawned: a stop
+                        // now waits for the daemon's whole process group to exit
+                        // (up to its stop budget), and this path runs inside the
+                        // UpdateShellDir handler — blocking here would stall the
+                        // user's `cd` shell hook until the stop completes.
                         info!("autostopping {daemon}");
-                        self.stop(&daemon.id).await?;
-                        self.add_notification(Info, format!("autostopped {daemon}"))
-                            .await;
+                        let label = daemon.to_string();
+                        let daemon_id = daemon.id.clone();
+                        tokio::spawn(async move {
+                            match SUPERVISOR.stop(&daemon_id).await {
+                                Ok(_) => {
+                                    SUPERVISOR
+                                        .add_notification(Info, format!("autostopped {label}"))
+                                        .await;
+                                }
+                                Err(e) => error!("failed to autostop {daemon_id}: {e}"),
+                            }
+                        });
                     } else {
                         // Schedule autostop with delay
                         let stop_at = time::Instant::now() + autostop_delay;
@@ -152,10 +165,22 @@ impl Supervisor {
                         );
                         continue;
                     }
+                    // Spawned: a stop now waits for the daemon's whole process
+                    // group to exit (up to its stop budget). This path runs from
+                    // the interval watcher and the UpdateShellDir handler —
+                    // blocking here would stall the `cd` shell hook and delay
+                    // other watcher duties (e.g. retries) behind each stop.
                     info!("autostopping {daemon_id} (after delay)");
-                    self.stop(&daemon_id).await?;
-                    self.add_notification(Info, format!("autostopped {daemon_id}"))
-                        .await;
+                    tokio::spawn(async move {
+                        match SUPERVISOR.stop(&daemon_id).await {
+                            Ok(_) => {
+                                SUPERVISOR
+                                    .add_notification(Info, format!("autostopped {daemon_id}"))
+                                    .await;
+                            }
+                            Err(e) => error!("failed to autostop {daemon_id}: {e}"),
+                        }
+                    });
                 }
             }
         }

--- a/src/supervisor/autostop.rs
+++ b/src/supervisor/autostop.rs
@@ -11,6 +11,8 @@ use crate::pitchfork_toml::PitchforkToml;
 use crate::settings::settings;
 use log::LevelFilter::Info;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::time;
 
 /// Whether `path` is equal to or nested inside `base`.
@@ -70,18 +72,8 @@ impl Supervisor {
                         // UpdateShellDir handler — blocking here would stall the
                         // user's `cd` shell hook until the stop completes.
                         info!("autostopping {daemon}");
-                        let label = daemon.to_string();
-                        let daemon_id = daemon.id.clone();
-                        tokio::spawn(async move {
-                            match SUPERVISOR.stop(&daemon_id).await {
-                                Ok(_) => {
-                                    SUPERVISOR
-                                        .add_notification(Info, format!("autostopped {label}"))
-                                        .await;
-                                }
-                                Err(e) => error!("failed to autostop {daemon_id}: {e}"),
-                            }
-                        });
+                        self.spawn_autostop(daemon.id.clone(), daemon.to_string())
+                            .await;
                     } else {
                         // Schedule autostop with delay
                         let stop_at = time::Instant::now() + autostop_delay;
@@ -125,6 +117,83 @@ impl Supervisor {
             if pending.remove(&daemon_id).is_some() {
                 info!("cancelled pending autostop for {daemon_id}");
             }
+            // Also call off any stop task already spawned but not yet stopping.
+            // The entry is removed so a later leave can schedule a fresh
+            // autostop; the task keeps its own clone of the flag.
+            if let Some(flag) = self.in_flight_autostops.lock().await.remove(&daemon_id) {
+                flag.store(true, Ordering::SeqCst);
+                info!("cancelled in-flight autostop for {daemon_id}");
+            }
+        }
+    }
+
+    /// Spawn a detached stop task for an autostopped daemon.
+    ///
+    /// The task is registered in `in_flight_autostops` so that
+    /// `cancel_pending_autostops_for_dir` can call it off if a shell
+    /// re-enters the directory before the stop begins, and it revalidates
+    /// directory activity right before stopping since the scheduling check
+    /// ran before the task was spawned.
+    async fn spawn_autostop(&self, daemon_id: DaemonId, label: String) {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        {
+            let mut in_flight = self.in_flight_autostops.lock().await;
+            if in_flight.contains_key(&daemon_id) {
+                debug!("autostop already in flight for {daemon_id}");
+                return;
+            }
+            in_flight.insert(daemon_id.clone(), cancelled.clone());
+        }
+        tokio::spawn(async move {
+            SUPERVISOR
+                .run_autostop(&daemon_id, &label, &cancelled)
+                .await;
+            // Only remove our own registration: a cancelled entry may have
+            // been replaced by a newer in-flight autostop for the same daemon.
+            let mut in_flight = SUPERVISOR.in_flight_autostops.lock().await;
+            if in_flight
+                .get(&daemon_id)
+                .is_some_and(|f| Arc::ptr_eq(f, &cancelled))
+            {
+                in_flight.remove(&daemon_id);
+            }
+        });
+    }
+
+    /// Body of a detached autostop task: revalidate, then stop.
+    async fn run_autostop(&self, daemon_id: &DaemonId, label: &str, cancelled: &AtomicBool) {
+        if cancelled.load(Ordering::SeqCst) {
+            debug!("autostop of {daemon_id} cancelled before stopping");
+            return;
+        }
+        // Revalidate that the daemon's directory is still inactive: a shell
+        // may have entered it between the scheduling check and this task
+        // running.
+        if let Some(daemon) = self.get_daemon(daemon_id).await
+            && daemon.autostop
+            && daemon.status.is_running()
+        {
+            if let Some(daemon_dir) = daemon.dir.as_ref() {
+                let active_dirs = self.get_active_directories().await;
+                if active_dirs.iter().any(|d| is_within(daemon_dir, d)) {
+                    debug!("autostop of {daemon_id} skipped: directory active again");
+                    return;
+                }
+            }
+        } else {
+            debug!("autostop of {daemon_id} skipped: no longer running");
+            return;
+        }
+        if cancelled.load(Ordering::SeqCst) {
+            debug!("autostop of {daemon_id} cancelled before stopping");
+            return;
+        }
+        match self.stop(daemon_id).await {
+            Ok(_) => {
+                self.add_notification(Info, format!("autostopped {label}"))
+                    .await;
+            }
+            Err(e) => error!("failed to autostop {daemon_id}: {e}"),
         }
     }
 
@@ -171,16 +240,8 @@ impl Supervisor {
                     // blocking here would stall the `cd` shell hook and delay
                     // other watcher duties (e.g. retries) behind each stop.
                     info!("autostopping {daemon_id} (after delay)");
-                    tokio::spawn(async move {
-                        match SUPERVISOR.stop(&daemon_id).await {
-                            Ok(_) => {
-                                SUPERVISOR
-                                    .add_notification(Info, format!("autostopped {daemon_id}"))
-                                    .await;
-                            }
-                            Err(e) => error!("failed to autostop {daemon_id}: {e}"),
-                        }
-                    });
+                    let label = daemon_id.to_string();
+                    self.spawn_autostop(daemon_id, label).await;
                 }
             }
         }

--- a/src/supervisor/ipc_handlers.rs
+++ b/src/supervisor/ipc_handlers.rs
@@ -10,6 +10,21 @@ use miette::IntoDiagnostic;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Dedupe the supervisor-side version-mismatch warning. Parallel batch clients
+/// open one dedicated connection per daemon, each performing its own handshake,
+/// which would otherwise log the warning once per connection. Keyed by client
+/// version so a different mismatched client still gets logged.
+fn version_mismatch_should_warn(client_version: &str) -> bool {
+    static WARNED: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+    let mut warned = WARNED.lock().unwrap_or_else(|e| e.into_inner());
+    if warned.as_deref() == Some(client_version) {
+        false
+    } else {
+        *warned = Some(client_version.to_string());
+        true
+    }
+}
+
 impl Supervisor {
     /// Main IPC connection watch loop - reads and dispatches requests
     pub(crate) async fn conn_watch(&self, mut ipc: IpcServer) -> ! {
@@ -49,7 +64,7 @@ impl Supervisor {
                 version: client_version,
             } => {
                 debug!("received connect message (client version: {client_version})");
-                if client_version != VERSION {
+                if client_version != VERSION && version_mismatch_should_warn(&client_version) {
                     warn!(
                         "Client version {client_version} differs from supervisor version {VERSION}. \
                             Restart the supervisor with: pitchfork supervisor start --force"

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -1750,9 +1750,12 @@ impl Supervisor {
                     }
 
                     // Process successfully stopped
-                    // Note: kill_async uses SIGTERM -> wait ~3s -> SIGKILL strategy,
-                    // and also detects zombie processes, so by the time it returns,
-                    // the process should be fully terminated.
+                    // Note: kill_process_group_async waits for the ENTIRE process
+                    // group to exit (stop signal -> stop_timeout -> SIGKILL, then a
+                    // bounded verification), so a replacement daemon can be started
+                    // without colliding with a still-terminating instance. The only
+                    // exception is a member stuck in uninterruptible sleep, which is
+                    // logged with a warning.
                     self.upsert_daemon(
                         UpsertDaemonOpts::builder(id.clone())
                             .set(|o| {

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -187,20 +187,30 @@ impl Supervisor {
             }
         }
 
-        let daemon = self.get_daemon(id).await;
-        if let Some(daemon) = daemon {
-            // Stopping state is treated as "not running" - the monitoring task will clean it up
-            // Only check for Running state with a valid PID
-            if !daemon.status.is_stopping()
-                && !daemon.status.is_stopped()
-                && let Some(pid) = daemon.pid
-            {
-                if opts.force {
-                    self.stop(id).await?;
-                    info!("run: stop completed for daemon {id}");
-                } else {
-                    warn!("daemon {id} already running with pid {pid}");
-                    return Ok(IpcResponse::DaemonAlreadyRunning);
+        {
+            // Serialize against any in-flight stop of this daemon: a stop now
+            // waits for the whole process group to exit, so the Stopping window
+            // can last seconds instead of milliseconds. Starting through that
+            // window would collide with the dying instance (duplicate processes,
+            // port conflicts). Acquiring the stop lock waits the stop out; the
+            // state is re-read afterwards.
+            let stop_lock = self.stop_lock(id).await;
+            let _stop_guard = stop_lock.lock().await;
+            let daemon = self.get_daemon(id).await;
+            if let Some(daemon) = daemon {
+                // Stopping state is treated as "not running" - the monitoring task will clean it up
+                // Only check for Running state with a valid PID
+                if !daemon.status.is_stopping()
+                    && !daemon.status.is_stopped()
+                    && let Some(pid) = daemon.pid
+                {
+                    if opts.force {
+                        self.stop_locked(id).await?;
+                        info!("run: stop completed for daemon {id}");
+                    } else {
+                        warn!("daemon {id} already running with pid {pid}");
+                        return Ok(IpcResponse::DaemonAlreadyRunning);
+                    }
                 }
             }
         }
@@ -1009,6 +1019,14 @@ impl Supervisor {
                 detect_and_store_active_port(id.clone(), daemon_pid);
             }
 
+            // Set when readiness checks exhaust. The group kill runs as a
+            // separate task so this loop can exit and the post-loop drain
+            // keeps consuming output — children logging during SIGTERM
+            // cleanup would otherwise block on a full pipe and never exit.
+            // The ready failure is only sent once the kill task completes,
+            // so the retry loop cannot respawn into the dying group.
+            let mut ready_fail_kill: Option<tokio::task::JoinHandle<()>> = None;
+
             loop {
                 // biased: evaluate in exit → output → delay order so that
                 // process exit pre-empts both buffered output and the delay
@@ -1144,11 +1162,10 @@ impl Supervisor {
                         if !any_remaining {
                             error!("daemon {id}: all readiness checks exhausted, failing");
                             stop_cmd_probe_state(&mut cmd_probe);
-                            if let Some(tx) = ready_tx.take() {
-                                let _ = tx.send(Err(Some(124)));
-                            }
                             let stop_cfg = opts.stop_signal.unwrap_or_default();
-                            let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            ready_fail_kill = Some(tokio::spawn(async move {
+                                let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            }));
                             break;
                         }
                     }
@@ -1175,11 +1192,10 @@ impl Supervisor {
                         if !any_remaining {
                             error!("daemon {id}: all readiness checks exhausted, failing");
                             stop_cmd_probe_state(&mut cmd_probe);
-                            if let Some(tx) = ready_tx.take() {
-                                let _ = tx.send(Err(Some(124)));
-                            }
                             let stop_cfg = opts.stop_signal.unwrap_or_default();
-                            let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            ready_fail_kill = Some(tokio::spawn(async move {
+                                let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            }));
                             break;
                         }
                     }
@@ -1243,11 +1259,10 @@ impl Supervisor {
                         if !any_remaining {
                             error!("daemon {id}: all readiness checks exhausted, failing");
                             stop_cmd_probe_state(&mut cmd_probe);
-                            if let Some(tx) = ready_tx.take() {
-                                let _ = tx.send(Err(Some(124)));
-                            }
                             let stop_cfg = opts.stop_signal.unwrap_or_default();
-                            let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            ready_fail_kill = Some(tokio::spawn(async move {
+                                let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            }));
                             break;
                         }
                     }
@@ -1378,11 +1393,10 @@ impl Supervisor {
                         );
                         if !any_remaining {
                             error!("daemon {id}: all readiness checks exhausted, failing");
-                            if let Some(tx) = ready_tx.take() {
-                                let _ = tx.send(Err(Some(124)));
-                            }
                             let stop_cfg = opts.stop_signal.unwrap_or_default();
-                            let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            ready_fail_kill = Some(tokio::spawn(async move {
+                                let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
+                            }));
                             break;
                         }
                     }
@@ -1508,6 +1522,18 @@ impl Supervisor {
                     }
                 }
             };
+
+            // If the loop exited via readiness exhaustion, wait for the group
+            // kill to finish before reporting the failure so the retry loop
+            // (or a waiting client) cannot start a replacement while the old
+            // process group is still terminating.
+            if let Some(kill) = ready_fail_kill {
+                let _ = kill.await;
+                if let Some(tx) = ready_tx.take() {
+                    let _ = tx.send(Err(Some(124)));
+                }
+            }
+
             let current_daemon = SUPERVISOR.get_daemon(&id).await;
 
             // Signal that this monitoring task is processing its exit path.
@@ -1672,6 +1698,16 @@ impl Supervisor {
 
     /// Stop a running daemon
     pub async fn stop(&self, id: &DaemonId) -> Result<IpcResponse> {
+        // Hold the daemon's stop lock for the whole stop (including the
+        // whole-group termination wait) so starts and concurrent stops of the
+        // same daemon serialize against it instead of racing the Stopping window.
+        let lock = self.stop_lock(id).await;
+        let _guard = lock.lock().await;
+        self.stop_locked(id).await
+    }
+
+    /// Stop implementation. Caller must hold the daemon's stop lock.
+    async fn stop_locked(&self, id: &DaemonId) -> Result<IpcResponse> {
         let pitchfork_id = DaemonId::pitchfork();
         if *id == pitchfork_id {
             return Ok(IpcResponse::Error(
@@ -1728,10 +1764,16 @@ impl Supervisor {
                         .await
                     {
                         debug!("failed to kill pid {pid}: {e}");
-                        // Check if the process is actually stopped despite the error
-                        if PROCS.is_running(pid) {
-                            // Process still running after kill attempt - set back to Running
-                            debug!("failed to stop pid {pid}: process still running after kill");
+                        // Check if the process group is actually gone despite the
+                        // error. Checking only the leader here would mark the daemon
+                        // Stopped while surviving group members (e.g. one stuck in
+                        // uninterruptible sleep) are still alive — letting a restart
+                        // collide with them.
+                        if PROCS.process_group_alive(pid) {
+                            // Group still has live members - set back to Running
+                            debug!(
+                                "failed to stop pid {pid}: process group still alive after kill"
+                            );
                             self.upsert_daemon(
                                 UpsertDaemonOpts::builder(id.clone())
                                     .set(|o| {
@@ -1743,7 +1785,7 @@ impl Supervisor {
                             .await?;
                             return Ok(IpcResponse::DaemonStopFailed {
                                 error: format!(
-                                    "process {pid} still running after kill attempt: {e}"
+                                    "process group of {pid} still alive after kill attempt: {e}"
                                 ),
                             });
                         }

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -146,6 +146,25 @@ fn stop_cmd_probe_state(probe: &mut Option<CmdProbe>) {
     }
 }
 
+/// Spawn a detached task that kills a daemon's process group after its
+/// readiness checks are exhausted, logging a failed kill instead of
+/// discarding it. The returned handle is awaited before the readiness
+/// failure is reported so the process group is down by then.
+fn spawn_ready_fail_kill(
+    id: DaemonId,
+    pid: u32,
+    stop_cfg: crate::config_types::StopConfig,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(e) = PROCS
+            .kill_process_group_async(pid, stop_cfg.signal.into(), stop_cfg.timeout)
+            .await
+        {
+            error!("daemon {id}: failed to kill pid {pid} after readiness failure: {e}");
+        }
+    })
+}
+
 /// Returns true if any configured readiness check can still succeed.
 /// A check with no timeout is unbounded; a timed check can still succeed until its
 /// deadline fires. `ready_delay` is only used as a fallback when no other check is
@@ -187,30 +206,31 @@ impl Supervisor {
             }
         }
 
-        {
-            // Serialize against any in-flight stop of this daemon: a stop now
-            // waits for the whole process group to exit, so the Stopping window
-            // can last seconds instead of milliseconds. Starting through that
-            // window would collide with the dying instance (duplicate processes,
-            // port conflicts). Acquiring the stop lock waits the stop out; the
-            // state is re-read afterwards.
-            let stop_lock = self.stop_lock(id).await;
-            let _stop_guard = stop_lock.lock().await;
-            let daemon = self.get_daemon(id).await;
-            if let Some(daemon) = daemon {
-                // Stopping state is treated as "not running" - the monitoring task will clean it up
-                // Only check for Running state with a valid PID
-                if !daemon.status.is_stopping()
-                    && !daemon.status.is_stopped()
-                    && let Some(pid) = daemon.pid
-                {
-                    if opts.force {
-                        self.stop_locked(id).await?;
-                        info!("run: stop completed for daemon {id}");
-                    } else {
-                        warn!("daemon {id} already running with pid {pid}");
-                        return Ok(IpcResponse::DaemonAlreadyRunning);
-                    }
+        // Serialize against any in-flight stop of this daemon: a stop now
+        // waits for the whole process group to exit, so the Stopping window
+        // can last seconds instead of milliseconds. Starting through that
+        // window would collide with the dying instance (duplicate processes,
+        // port conflicts). Acquiring the stop lock waits the stop out; the
+        // state is re-read afterwards. The guard is owned and handed to
+        // run_once, which holds it until the new daemon's Running state and
+        // PID are persisted — releasing it before that point would let a
+        // concurrent run pass this same check (duplicate processes) or let a
+        // concurrent stop see no PID and return without stopping anything.
+        let mut stop_guard = Some(self.stop_lock(id).await.lock_owned().await);
+        let daemon = self.get_daemon(id).await;
+        if let Some(daemon) = daemon {
+            // Stopping state is treated as "not running" - the monitoring task will clean it up
+            // Only check for Running state with a valid PID
+            if !daemon.status.is_stopping()
+                && !daemon.status.is_stopped()
+                && let Some(pid) = daemon.pid
+            {
+                if opts.force {
+                    self.stop_locked(id).await?;
+                    info!("run: stop completed for daemon {id}");
+                } else {
+                    warn!("daemon {id} already running with pid {pid}");
+                    return Ok(IpcResponse::DaemonAlreadyRunning);
                 }
             }
         }
@@ -224,7 +244,14 @@ impl Supervisor {
                 retry_opts.retry_count = attempt;
                 retry_opts.cmd = cmd.clone();
 
-                let result = self.run_once(retry_opts).await?;
+                // The first attempt starts under the guard held since the
+                // running check above; later attempts re-acquire it so stops
+                // are not locked out during the backoff sleeps.
+                let guard = match stop_guard.take() {
+                    Some(guard) => guard,
+                    None => self.stop_lock(id).await.lock_owned().await,
+                };
+                let result = self.run_once(retry_opts, guard).await?;
 
                 match result {
                     IpcResponse::DaemonReady { daemon } => {
@@ -261,11 +288,24 @@ impl Supervisor {
         }
 
         // No retry or wait_ready is false
-        self.run_once(opts).await
+        let guard = match stop_guard.take() {
+            Some(guard) => guard,
+            None => self.stop_lock(id).await.lock_owned().await,
+        };
+        self.run_once(opts, guard).await
     }
 
-    /// Run a daemon once (single attempt)
-    pub(crate) async fn run_once(&self, opts: RunOptions) -> Result<IpcResponse> {
+    /// Run a daemon once (single attempt).
+    ///
+    /// `stop_guard` is this daemon's stop lock, acquired by `run` before the
+    /// already-running check. It is held through spawning until the Running
+    /// state and PID are persisted (or an early failure returns), then dropped
+    /// before the potentially unbounded readiness wait.
+    pub(crate) async fn run_once(
+        &self,
+        opts: RunOptions,
+        stop_guard: tokio::sync::OwnedMutexGuard<()>,
+    ) -> Result<IpcResponse> {
         let id = &opts.id;
         let original_cmd = opts.cmd.clone(); // Save original command for persistence
 
@@ -681,6 +721,12 @@ impl Supervisor {
                     .build(),
             )
             .await?;
+
+        // Running state and PID are now persisted: concurrent run/stop calls
+        // observe a running daemon and behave correctly, so release the stop
+        // lock rather than holding it through the readiness wait below, which
+        // can take arbitrarily long.
+        drop(stop_guard);
 
         let id_clone = id.clone();
         let ready_delay = opts.ready_delay;
@@ -1162,10 +1208,11 @@ impl Supervisor {
                         if !any_remaining {
                             error!("daemon {id}: all readiness checks exhausted, failing");
                             stop_cmd_probe_state(&mut cmd_probe);
-                            let stop_cfg = opts.stop_signal.unwrap_or_default();
-                            ready_fail_kill = Some(tokio::spawn(async move {
-                                let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
-                            }));
+                            ready_fail_kill = Some(spawn_ready_fail_kill(
+                                id.clone(),
+                                daemon_pid,
+                                opts.stop_signal.unwrap_or_default(),
+                            ));
                             break;
                         }
                     }
@@ -1192,10 +1239,11 @@ impl Supervisor {
                         if !any_remaining {
                             error!("daemon {id}: all readiness checks exhausted, failing");
                             stop_cmd_probe_state(&mut cmd_probe);
-                            let stop_cfg = opts.stop_signal.unwrap_or_default();
-                            ready_fail_kill = Some(tokio::spawn(async move {
-                                let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
-                            }));
+                            ready_fail_kill = Some(spawn_ready_fail_kill(
+                                id.clone(),
+                                daemon_pid,
+                                opts.stop_signal.unwrap_or_default(),
+                            ));
                             break;
                         }
                     }
@@ -1259,10 +1307,11 @@ impl Supervisor {
                         if !any_remaining {
                             error!("daemon {id}: all readiness checks exhausted, failing");
                             stop_cmd_probe_state(&mut cmd_probe);
-                            let stop_cfg = opts.stop_signal.unwrap_or_default();
-                            ready_fail_kill = Some(tokio::spawn(async move {
-                                let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
-                            }));
+                            ready_fail_kill = Some(spawn_ready_fail_kill(
+                                id.clone(),
+                                daemon_pid,
+                                opts.stop_signal.unwrap_or_default(),
+                            ));
                             break;
                         }
                     }
@@ -1393,10 +1442,11 @@ impl Supervisor {
                         );
                         if !any_remaining {
                             error!("daemon {id}: all readiness checks exhausted, failing");
-                            let stop_cfg = opts.stop_signal.unwrap_or_default();
-                            ready_fail_kill = Some(tokio::spawn(async move {
-                                let _ = PROCS.kill_process_group_async(daemon_pid, stop_cfg.signal.into(), stop_cfg.timeout).await;
-                            }));
+                            ready_fail_kill = Some(spawn_ready_fail_kill(
+                                id.clone(),
+                                daemon_pid,
+                                opts.stop_signal.unwrap_or_default(),
+                            ));
                             break;
                         }
                     }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -110,6 +110,11 @@ pub struct Supervisor {
     /// before the sink starts and unregisters when it ends, so a line arriving
     /// from a sink that outlived its daemon has nowhere to go and is dropped.
     pub(crate) sink_output: std::sync::Mutex<HashMap<DaemonId, log_sink::Relay>>,
+    /// Per-daemon stop locks. A stop holds the daemon's lock for its whole
+    /// duration (which now includes waiting for the entire process group to
+    /// exit), and starts/orphan-cleanup acquire it first — serializing them
+    /// against in-flight stops instead of racing the Stopping window.
+    pub(crate) stop_locks: Mutex<HashMap<DaemonId, std::sync::Arc<tokio::sync::Mutex<()>>>>,
 }
 
 /// A line of daemon output on its way to the monitoring task.
@@ -304,7 +309,18 @@ impl Supervisor {
             flush_cancel: std::sync::Mutex::new(None),
             monitored: std::sync::Mutex::new(HashMap::new()),
             sink_output: std::sync::Mutex::new(HashMap::new()),
+            stop_locks: Mutex::new(HashMap::new()),
         })
+    }
+
+    /// Get (or create) the per-daemon stop lock for `id`.
+    pub(crate) async fn stop_lock(&self, id: &DaemonId) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+        self.stop_locks
+            .lock()
+            .await
+            .entry(id.clone())
+            .or_default()
+            .clone()
     }
 
     pub async fn start(
@@ -324,19 +340,25 @@ impl Supervisor {
         let pid = std::process::id();
         // Ensure PROCS has data for the supervisor PID before upsert_daemon reads title()
         PROCS.refresh_pids(&[pid]);
-        // Determine container mode: CLI flag takes priority, then settings
-        let container_mode = container || settings().supervisor.container;
+        // Determine container mode: CLI flag takes priority, then settings.
+        // Running as PID 1 always enables it: orphaned descendants of daemons
+        // re-parent to us, and without the zombie reaper they would accumulate
+        // as unreaped zombies — which also keep their process group alive,
+        // stalling whole-group stop waits indefinitely.
+        let container_mode =
+            container || settings().supervisor.container || std::process::id() == 1;
         if container_mode {
             info!("Starting supervisor in container/PID1 mode with pid {pid}");
         } else {
             info!("Starting supervisor with pid {pid}");
         }
 
-        // If the previous supervisor died uncleanly, its daemon child processes
-        // may still be alive (orphaned, re-parented to init).  Terminate them
-        // before we take over so we don't end up with duplicate processes
-        // holding the same ports.
-        cleanup_orphaned_daemons(self).await;
+        // Whether the previous supervisor exited uncleanly must be read before
+        // we record ourselves in the state file just below (see
+        // `supervisor_exited_uncleanly`); the background cleanup task runs
+        // after that record exists, so it receives the answer instead of
+        // reading it too late.
+        let unclean = supervisor_exited_uncleanly(self).await;
 
         self.upsert_daemon(
             UpsertDaemonOpts::builder(DaemonId::pitchfork())
@@ -350,11 +372,28 @@ impl Supervisor {
         #[cfg(unix)]
         fix_state_dir_permissions();
 
-        // If this is a boot start, automatically start boot_start daemons
-        if is_boot {
-            info!("Boot start mode enabled, starting boot_start daemons");
-            self.start_boot_daemons().await?;
-        }
+        // If the previous supervisor died uncleanly, its daemon child processes
+        // may still be alive (orphaned, re-parented to init).  Terminate them
+        // before starting replacements so we don't end up with duplicate
+        // processes holding the same ports.
+        //
+        // This runs in the background: each orphan kill now waits for its
+        // whole process group to exit (seconds per orphan), and doing that
+        // inline would delay IPC socket creation past the CLI's short connect
+        // budget on autostart. Per-daemon stop locks serialize the cleanup
+        // against any Run/Stop requests that arrive for the same daemon in the
+        // meantime, and boot daemons start after cleanup completes so they
+        // cannot observe an orphan as "already running".
+        let boot_after_cleanup = is_boot;
+        tokio::spawn(async move {
+            cleanup_orphaned_daemons(&SUPERVISOR, unclean).await;
+            if boot_after_cleanup {
+                info!("Boot start mode enabled, starting boot_start daemons");
+                if let Err(e) = SUPERVISOR.start_boot_daemons().await {
+                    error!("failed to start boot daemons: {e}");
+                }
+            }
+        });
 
         self.interval_watch()?;
 
@@ -1032,6 +1071,12 @@ impl Supervisor {
         // If dependency resolution fails (e.g. config changed), fall back to
         // stopping in arbitrary order so we still shut down cleanly.
         // Daemons within the same level are stopped concurrently.
+        //
+        // Each stop waits for the daemon's whole process group (bounded by its
+        // stop budget) and levels are sequential, so total shutdown time is the
+        // sum of the slowest stop per level. If an external manager (docker,
+        // systemd) kills us before this completes, cleanup_orphaned_daemons()
+        // recovers the leftover processes and stale state on the next start.
         let stop_levels = compute_reverse_stop_order(&active_ids);
         for level in &stop_levels {
             let mut tasks = Vec::new();
@@ -1301,7 +1346,13 @@ fn chmod_safe_subtrees(state_dir: &std::path::Path) {
 /// PID/PGID cannot be pinned between identity validation and signaling.
 ///
 /// This is gated by the `supervisor.cleanup_orphans` setting (default: true).
-async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
+///
+/// `unclean` is whether the previous supervisor exited uncleanly (see
+/// [`supervisor_exited_uncleanly`]). It is read in `start()` before the
+/// starting supervisor records itself in the state file — this function runs
+/// in the background after that record exists, so reading it here would
+/// always report unclean.
+async fn cleanup_orphaned_daemons(supervisor: &Supervisor, unclean: bool) {
     if !settings().supervisor.cleanup_orphans {
         return;
     }
@@ -1327,118 +1378,157 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
 
     let policy = orphan_policy();
     let boot_time = PROCS.boot_time();
-    let unclean = supervisor_exited_uncleanly(supervisor).await;
 
-    for daemon in candidates {
-        let Some(pid) = daemon.pid else { continue };
+    // Reconcile orphans in parallel — a kill waits for the daemon's whole
+    // process group to exit, bounded by that daemon's stop budget, so
+    // sequential processing would make total cleanup time the sum of the
+    // budgets.
+    let tasks: Vec<_> = candidates
+        .into_iter()
+        .map(|daemon| {
+            let policy = policy.clone();
+            tokio::spawn(cleanup_orphaned_daemon(daemon, policy, boot_time, unclean))
+        })
+        .collect();
+    for task in tasks {
+        let _ = task.await;
+    }
+}
 
-        // Refresh each candidate immediately before checking it. Processing an
-        // earlier orphan can await its stop timeout, during which this PID may
-        // exit and be recycled.
-        PROCS.refresh_pids(&[pid]);
+/// Reconcile a single orphan candidate: adopt it, kill it, or reset its state,
+/// per the policy and identity checks described on [`cleanup_orphaned_daemons`].
+///
+/// Holds the daemon's stop lock so a concurrent Run/Stop request for the same
+/// daemon (cleanup runs in the background) serializes with the orphan kill,
+/// and re-checks the recorded PID under the lock: if it changed, another path
+/// already replaced or cleaned up this record and the snapshot is stale.
+async fn cleanup_orphaned_daemon(
+    daemon: crate::daemon::Daemon,
+    policy: String,
+    boot_time: u64,
+    unclean: bool,
+) {
+    let supervisor: &Supervisor = &SUPERVISOR;
+    let Some(pid) = daemon.pid else { return };
 
-        if !PROCS.is_running(pid) {
-            // PID already dead — the daemon exited while unsupervised, so
-            // record a terminal status that reflects whether it died under a
-            // crashed supervisor (retryable) or with the machine.
-            let status =
-                unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time, unclean);
-            reset_daemon_state(supervisor, &daemon.id, status, ExitObservation::Unobserved).await;
-            continue;
-        }
+    let lock = supervisor.stop_lock(&daemon.id).await;
+    let _guard = lock.lock().await;
+    let current_pid = {
+        let state = supervisor.state_file.lock().await;
+        state.daemons.get(&daemon.id).and_then(|d| d.pid)
+    };
+    if current_pid != Some(pid) {
+        debug!(
+            "orphan cleanup: daemon {} pid changed (recorded {pid}, now {current_pid:?}), skipping",
+            daemon.id
+        );
+        return;
+    }
 
-        // Safety check: verify the live process really is the daemon we
-        // recorded, not an unrelated process that received a recycled PID.
-        // The kernel start time is a stable identity for the lifetime of a
-        // process, and is the only thing accepted as one.
-        let current_start_time = PROCS.start_time(pid);
-        let matches = process_identity_matches(daemon.start_time, current_start_time);
+    // Refresh the candidate immediately before checking it: waiting for the
+    // stop lock can await another path's stop timeout, during which this PID
+    // may exit and be recycled.
+    PROCS.refresh_pids(&[pid]);
 
-        if !matches {
-            // Either side missing means the identity cannot be checked at all,
-            // which is different from checking it and finding a stranger: retain
-            // the running state rather than resetting a record whose process may
-            // well still be the daemon.
-            if daemon.start_time.is_none() || current_start_time.is_none() {
-                warn!(
-                    "could not verify the identity of live pid {pid} recorded for daemon {}; retaining running state",
-                    daemon.id,
-                );
-                continue;
-            }
+    if !PROCS.is_running(pid) {
+        // PID already dead — the daemon exited while unsupervised, so
+        // record a terminal status that reflects whether it died under a
+        // crashed supervisor (retryable) or with the machine.
+        let status = unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time, unclean);
+        reset_daemon_state(supervisor, &daemon.id, status, ExitObservation::Unobserved).await;
+        return;
+    }
+
+    // Safety check: verify the live process really is the daemon we
+    // recorded, not an unrelated process that received a recycled PID.
+    // The kernel start time is a stable identity for the lifetime of a
+    // process, and is the only thing accepted as one.
+    let current_start_time = PROCS.start_time(pid);
+    let matches = process_identity_matches(daemon.start_time, current_start_time);
+
+    if !matches {
+        // Either side missing means the identity cannot be checked at all,
+        // which is different from checking it and finding a stranger: retain
+        // the running state rather than resetting a record whose process may
+        // well still be the daemon.
+        if daemon.start_time.is_none() || current_start_time.is_none() {
             warn!(
-                "pid {pid} recorded for daemon {} belongs to a different process now (PID recycled); resetting state without killing",
+                "could not verify the identity of live pid {pid} recorded for daemon {}; retaining running state",
                 daemon.id,
             );
-            // The daemon died at some unknown point and the OS handed its PID
-            // to something else — same unobserved exit as a dead PID.
-            let status =
-                unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time, unclean);
-            reset_daemon_state(supervisor, &daemon.id, status, ExitObservation::Unobserved).await;
-            continue;
+            return;
         }
+        warn!(
+            "pid {pid} recorded for daemon {} belongs to a different process now (PID recycled); resetting state without killing",
+            daemon.id,
+        );
+        // The daemon died at some unknown point and the OS handed its PID
+        // to something else — same unobserved exit as a dead PID.
+        let status = unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time, unclean);
+        reset_daemon_state(supervisor, &daemon.id, status, ExitObservation::Unobserved).await;
+        return;
+    }
 
-        // Both policies need a verified start time: killing revalidates it
-        // while pinned to the process, and adoption anchors its poll monitor
-        // to it so a later PID recycle is never mistaken for the daemon.
-        let Some(expected_start_time) = current_start_time else {
-            warn!(
-                "could not read start time for live pid {pid} recorded for daemon {}; retaining running state",
-                daemon.id,
-            );
-            continue;
-        };
+    // Both policies need a verified start time: killing revalidates it
+    // while pinned to the process, and adoption anchors its poll monitor
+    // to it so a later PID recycle is never mistaken for the daemon.
+    let Some(expected_start_time) = current_start_time else {
+        warn!(
+            "could not read start time for live pid {pid} recorded for daemon {}; retaining running state",
+            daemon.id,
+        );
+        return;
+    };
 
-        // Identity verified — the process really is our orphaned daemon.
-        // The policy decides whether supervision resumes or the slate is
-        // wiped clean.
-        if policy == "adopt" {
-            supervisor
-                .adopt_daemon(&daemon, pid, expected_start_time)
-                .await;
-            continue;
-        }
-
-        info!("terminating orphaned daemon {} (pid {pid})", daemon.id);
-
-        let stop_cfg = daemon.stop_signal.unwrap_or_default();
-        let termination_result = PROCS
-            .kill_process_group_if_start_time_matches_async(
-                pid,
-                expected_start_time,
-                stop_cfg.signal.into(),
-                stop_cfg.timeout,
-            )
+    // Identity verified — the process really is our orphaned daemon.
+    // The policy decides whether supervision resumes or the slate is
+    // wiped clean.
+    if policy == "adopt" {
+        supervisor
+            .adopt_daemon(&daemon, pid, expected_start_time)
             .await;
+        return;
+    }
 
-        match termination_result {
-            Ok(true) => {}
-            Ok(false) => {
-                warn!(
-                    "could not securely terminate orphaned daemon {} (pid {pid}); retaining running state",
-                    daemon.id
-                );
-                continue;
-            }
-            Err(err) => {
-                warn!(
-                    "failed to terminate orphaned daemon {} (pid {pid}): {err}; retaining running state",
-                    daemon.id
-                );
-                continue;
-            }
-        }
+    info!("terminating orphaned daemon {} (pid {pid})", daemon.id);
 
-        // We terminated the orphan ourselves, so this is an observed,
-        // intentional stop rather than an unobserved exit.
-        reset_daemon_state(
-            supervisor,
-            &daemon.id,
-            DaemonStatus::Stopped,
-            ExitObservation::Terminated,
+    let stop_cfg = daemon.stop_signal.unwrap_or_default();
+    let termination_result = PROCS
+        .kill_process_group_if_start_time_matches_async(
+            pid,
+            expected_start_time,
+            stop_cfg.signal.into(),
+            stop_cfg.timeout,
         )
         .await;
+
+    match termination_result {
+        Ok(true) => {}
+        Ok(false) => {
+            warn!(
+                "could not securely terminate orphaned daemon {} (pid {pid}); retaining running state",
+                daemon.id
+            );
+            return;
+        }
+        Err(err) => {
+            warn!(
+                "failed to terminate orphaned daemon {} (pid {pid}): {err}; retaining running state",
+                daemon.id
+            );
+            return;
+        }
     }
+
+    // We terminated the orphan ourselves, so this is an observed,
+    // intentional stop rather than an unobserved exit.
+    reset_daemon_state(
+        supervisor,
+        &daemon.id,
+        DaemonStatus::Stopped,
+        ExitObservation::Terminated,
+    )
+    .await;
 }
 
 /// Effective `supervisor.orphan_policy`, warning on an unrecognized value

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -47,7 +47,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32};
 use std::time::Duration;
 #[cfg(unix)]
 use tokio::signal::unix::SignalKind;
-use tokio::sync::{Mutex, Notify, mpsc};
+use tokio::sync::{Mutex, Notify};
 use tokio::task::JoinHandle;
 use tokio::{signal, time};
 

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -72,6 +72,12 @@ pub struct Supervisor {
     pub(crate) last_refreshed_at: Mutex<time::Instant>,
     /// Map of daemon ID to scheduled autostop time
     pub(crate) pending_autostops: Mutex<HashMap<DaemonId, time::Instant>>,
+    /// Autostop stops that have been spawned as detached tasks but have not
+    /// yet begun stopping. `cancel_pending_autostops_for_dir` flips the flag
+    /// to call off the stop when a shell re-enters the directory while the
+    /// stop task is still in flight.
+    pub(crate) in_flight_autostops:
+        Mutex<HashMap<DaemonId, std::sync::Arc<std::sync::atomic::AtomicBool>>>,
     /// Handle for graceful IPC server shutdown
     pub(crate) ipc_shutdown: Mutex<Option<IpcServerHandle>>,
     /// Tracks in-flight hook tasks so shutdown can wait for them to complete
@@ -298,6 +304,7 @@ impl Supervisor {
             last_refreshed_at: Mutex::new(time::Instant::now()),
             pending_notifications: Mutex::new(vec![]),
             pending_autostops: Mutex::new(HashMap::new()),
+            in_flight_autostops: Mutex::new(HashMap::new()),
             ipc_shutdown: Mutex::new(None),
             hook_tasks: Mutex::new(Vec::new()),
             active_monitors: AtomicU32::new(0),

--- a/test/cron.bats
+++ b/test/cron.bats
@@ -319,7 +319,10 @@ EOF
   assert_success
 
   # immediate=true should trigger the cron watcher on its first check because a
-  # scheduled time falls within the 10-second look-back window.
+  # scheduled time falls within the 10-second look-back window. The manual
+  # start logs the first line; poll until the cron-triggered second line
+  # arrives — asserting a count immediately races the cron tick and the log
+  # flush on loaded CI runners.
   wait_for_logs cron_immediate "immediate_fired" 5
 
   local count

--- a/test/group_stop.bats
+++ b/test/group_stop.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+
+# E2E tests for whole-process-group stops and the paths that depend on their
+# timing: stop() waiting for every group member to exit (escalating to SIGKILL
+# for members that ignore the stop signal), starts serializing behind an
+# in-flight slow stop instead of racing the widened Stopping window, and
+# parallel multi-daemon start/stop attributing IPC responses to the right
+# daemon task.
+
+setup() {
+  load test_helper/common_setup
+  bats_require_minimum_version 1.5.0
+  _common_setup
+}
+
+teardown() {
+  _common_teardown
+}
+
+@test "stop returns only after TERM-ignoring child processes are gone" {
+  skip_on_windows "POSIX signals and process groups are not supported on Windows"
+
+  local child_pid_file="$TEST_TEMP_DIR/child.pid"
+  local child_script="$TEST_TEMP_DIR/stubborn_child.sh"
+  local daemon_script="$TEST_TEMP_DIR/parent.sh"
+  cat > "$child_script" <<EOF
+#!/bin/sh
+trap '' TERM
+echo \$\$ > "$child_pid_file"
+sleep 60
+EOF
+  cat > "$daemon_script" <<EOF
+#!/bin/sh
+sh "$child_script" &
+wait
+EOF
+
+  create_pitchfork_toml <<EOF
+[daemons.group_stop_test]
+run = "sh $daemon_script"
+stop_signal = { signal = "SIGTERM", timeout = "2s" }
+ready_delay = 1
+EOF
+
+  run pitchfork start group_stop_test
+  assert_success
+  wait_for_status group_stop_test running
+  wait_for_file "$child_pid_file"
+  local child_pid
+  child_pid="$(cat "$child_pid_file")"
+  pid_alive "$child_pid"
+
+  # The child ignores SIGTERM, so stop must escalate to SIGKILL after the 2s
+  # stop timeout and wait for the entire process group — by the time stop
+  # returns, the child may only linger as an unreaped zombie, never as a
+  # running process.
+  run pitchfork stop group_stop_test
+  assert_success
+
+  local gone=1
+  for _ in $(seq 1 10); do
+    if ! pid_alive "$child_pid"; then
+      gone=0
+      break
+    fi
+    # ps state Z means the process is dead and merely awaiting reaping by init
+    if [[ "$(ps -o stat= -p "$child_pid" 2>/dev/null)" == Z* ]]; then
+      gone=0
+      break
+    fi
+    sleep 0.1
+  done
+  [[ "$gone" -eq 0 ]]
+
+  wait_for_status group_stop_test stopped
+}
+
+@test "start during an in-flight slow stop waits it out instead of racing it" {
+  skip_on_windows "POSIX signals are not supported on Windows"
+
+  local marker_file="$TEST_TEMP_DIR/instances.log"
+  local daemon_script="$TEST_TEMP_DIR/slow_stop.sh"
+  cat > "$daemon_script" <<EOF
+#!/bin/sh
+echo "started:\$\$" >> "$marker_file"
+trap 'sleep 2; exit 0' TERM
+while true; do sleep 0.1; done
+EOF
+
+  create_pitchfork_toml <<EOF
+[daemons.slow_stop_test]
+run = "sh $daemon_script"
+ready_delay = 1
+EOF
+
+  run pitchfork start slow_stop_test
+  assert_success
+  wait_for_status slow_stop_test running
+  local old_pid
+  old_pid="$(get_daemon_pid slow_stop_test)"
+
+  # Kick off a stop that takes ~2s (the daemon delays its TERM exit), then
+  # immediately request a start. The start must serialize behind the
+  # in-flight stop — waiting out the Stopping window rather than observing it
+  # as "not running" and spawning a duplicate instance.
+  pitchfork stop slow_stop_test &
+  local stop_job=$!
+  sleep 0.3
+  run pitchfork start slow_stop_test
+  assert_success
+  wait "$stop_job"
+
+  wait_for_status slow_stop_test running
+  local new_pid
+  new_pid="$(get_daemon_pid slow_stop_test)"
+  [[ -n "$new_pid" ]]
+  [[ "$new_pid" != "$old_pid" ]]
+  ! pid_alive "$old_pid"
+
+  # Exactly two instances ever ran: the original and the one started after
+  # the stop completed. A third line would mean the start raced the stop.
+  local count
+  count="$(grep -c '^started:' "$marker_file")"
+  [[ "$count" -eq 2 ]]
+}
+
+@test "parallel multi-daemon start attributes readiness to the right daemon" {
+  # Staggered readiness makes the per-daemon IPC responses arrive interleaved,
+  # which is exactly the case that requires each parallel start task to read
+  # from its own connection rather than picking up a sibling's response.
+  create_pitchfork_toml <<EOF
+[daemons.par_a]
+run = "sleep 2 && echo a_ready && sleep 60"
+ready_output = "a_ready"
+
+[daemons.par_b]
+run = "sleep 1 && echo b_ready && sleep 60"
+ready_output = "b_ready"
+
+[daemons.par_c]
+run = "echo c_ready && sleep 60"
+ready_output = "c_ready"
+EOF
+
+  run pitchfork start par_a par_b par_c
+  assert_success
+
+  wait_for_status par_a running
+  wait_for_status par_b running
+  wait_for_status par_c running
+
+  run pitchfork stop par_a par_b par_c
+  assert_success
+
+  wait_for_status par_a stopped
+  wait_for_status par_b stopped
+  wait_for_status par_c stopped
+}

--- a/test/group_stop.bats
+++ b/test/group_stop.bats
@@ -115,7 +115,9 @@ EOF
   new_pid="$(get_daemon_pid slow_stop_test)"
   [[ -n "$new_pid" ]]
   [[ "$new_pid" != "$old_pid" ]]
-  ! pid_alive "$old_pid"
+  # `run !` rather than a bare `! pid_alive`: negated commands are excluded
+  # from errexit, so a bare form could never fail the test.
+  run ! pid_alive "$old_pid"
 
   # Exactly two instances ever ran: the original and the one started after
   # the stop completed. A third line would mean the start raced the stop.


### PR DESCRIPTION
## Summary

Fixes two race conditions observed in production with pitchfork 2.16.0, plus a hardening pass for the system-wide implications of the second fix.

### 1. Phantom start failure (`fix(ipc)`)

Cold-starting many daemons at once (e.g. 9 in one `pitchfork start`) occasionally reported a daemon as failed even though the supervisor had marked it ready, aborting its dependents.

**Root cause:** the IPC wire protocol has no request IDs — responses are attributed purely by read order on a connection. The supervisor handles each request in its own spawned task (`conn_watch`) and writes responses back in *completion* order, while all parallel start tasks shared a single `Arc<IpcClient>` connection and raced on the recv lock. Two concurrent `Run` requests could each consume the other's response: daemon A's task reads daemon B's `DaemonFailedWithCode` (which carries no daemon ID) while B's task reads A's `DaemonReady`. The swap could also silently misroute `resolved_ports` into dependent daemons' templates.

**Fix:** each parallel start/adhoc-start/stop task now opens its own dedicated IPC connection, so there is exactly one in-flight request per connection and response attribution is structural rather than timing-dependent — deterministic, with no wire-format change and parallelism within dependency levels preserved. As defense in depth, `IpcClient` holds a mutex across each send/read pair so shared clients (TUI, web routes) serialize exchanges, and a client whose exchange fails mid-stream (timeout/IO error) marks itself desynced and transparently reconnects on the next request instead of reading the abandoned response. Version-mismatch warnings are deduped on both sides (keyed by peer version, so a *different* mismatched peer still warns).

### 2. Restart race: stop returns while the group is still dying (`fix(supervisor)`)

`kill_process_group` signalled the whole group but only waited for the **leader** PID to die. Daemons run as `sh -c "..."`, so the leader exits within ~30ms of SIGTERM while children in the group are still shutting down gracefully — e.g. `docker compose up` waiting for its container to stop. `stop()` returned early, marked the daemon Stopped, and a force-restart spawned a replacement `up` that attached to the dying container and exited with it (reproduced killing ClickHouse after every rebuild-restart).

**Fix:** the wait predicate is now whole-group emptiness (`killpg(pgid, 0)`) instead of leader death, keeping the existing stop signal → `stop_timeout` → SIGKILL escalation, with group emptiness verified after SIGKILL (bounded). Members that survive even SIGKILL (uninterruptible sleep) are reported as `DaemonStopFailed` instead of being silently marked Stopped. `killpg` EPERM is treated as terminated — only members we may not signal remain (e.g. root-owned helpers), which our signals never reached, so waiting cannot make progress.

### 3. Hardening: the rest of the system assumed millisecond stops

Making stops wait for the whole group (seconds, bounded by the stop budget) exposed several paths that assumed stops return in milliseconds. These are addressed in the follow-up commits:

- **Per-daemon stop locks**: `stop()` holds the daemon's lock for the entire stop, and `run()` acquires it before its already-running check — a start deterministically waits out an in-flight stop instead of racing the (now wider) `Stopping` window into duplicate instances/port conflicts.
- **Client stop timeout tracks the server-side budget**: `IpcClient::stop` budgets its request from the daemon's own `stop_signal.timeout` (or `supervisor.stop_timeout`) instead of the flat IPC request timeout, so a correct in-progress stop is no longer reported as a timeout failure.
- **Orphan cleanup off the startup path**: it now runs in the background (parallel per orphan, guarded by the stop locks with a PID re-check), so supervisor autostart no longer delays IPC socket creation past the CLI's connect budget; boot daemons start after cleanup completes.
- **Autostop stops are spawned**, keeping the `cd` shell hook (`UpdateShellDir`) and the 10s interval watcher responsive during group waits.
- **Ready-check-exhausted path**: the group kill runs as a separate task (the monitor loop keeps draining output, so children logging during SIGTERM cleanup can't deadlock on a full pipe) and the failure notification is deferred until the kill completes, so the retry loop cannot respawn into the dying group.
- **Zombie reaper installs whenever the supervisor is PID 1** (not only with `--container`), so orphaned zombies can't keep a process group alive indefinitely.

Note for slow graceful shutdowns: the stop timeout is now the graceful budget for the *entire group* (like systemd's `TimeoutStopSec` for a cgroup) — daemons whose teardown legitimately takes longer (draining connections, stopping containers) should raise `stop_signal.timeout` rather than rely on outliving the budget.

## Testing

- `mise run ci-dev` passes on every commit (fmt, clippy `-D warnings`, full e2e suite 279/279, render — no generated-doc changes)
- Bug 1 fix reasoned end-to-end: one in-flight request per connection makes mis-attribution impossible by construction; supervisor-side handling is unchanged
- Bug 2 fix verified against all `kill_process_group_async` call paths (IPC stop, force-restart, readiness-timeout kills, orphan cleanup, supervisor shutdown); the hardening pass came out of an adversarial multi-agent review of the diff (15 verified findings, all addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting and stopping multiple daemons concurrently.
  * Prevented stale or misattributed IPC responses by isolating IPC exchanges per operation.
  * Reduced repeated version-mismatch warnings from both client and supervisor.
  * Shutdown now waits for the entire process group to exit before reporting success.
  * Stronger coordination between run/stop, readiness failures, autostop, and orphan cleanup (including container/PID 1 handling).
* **Tests**
  * Added E2E coverage for whole process-group stop/start serialization and multi-daemon readiness attribution.
  * Clarified cron startup timing behavior in test documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->