### PR TITLE
chore: release v2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.18.0](https://github.com/jdx/pitchfork/compare/v2.17.0...v2.18.0) - 2026-07-25
+
+### Added
+
+- *(supervisor)* re-adopt orphaned daemons by default after a crash ([#633](https://github.com/jdx/pitchfork/pull/633))
+- *(project)* add project enter/leave/list for IDE session management ([#619](https://github.com/jdx/pitchfork/pull/619))
+- *(config)* add top-level env with tera template injection ([#618](https://github.com/jdx/pitchfork/pull/618))
+- *(daemons)* add --global flag to daemons add ([#621](https://github.com/jdx/pitchfork/pull/621))
+- full Windows support with CI ([#602](https://github.com/jdx/pitchfork/pull/602))
+
+### Fixed
+
+- *(logs)* tolerate concurrent opens of the log store ([#660](https://github.com/jdx/pitchfork/pull/660))
+- *(supervisor)* make child-monitor exit finalization atomic ([#659](https://github.com/jdx/pitchfork/pull/659))
+- *(supervisor)* make unobserved daemon deaths retryable after a crash ([#657](https://github.com/jdx/pitchfork/pull/657))
+- *(deps)* update rust crate clx to v3 ([#656](https://github.com/jdx/pitchfork/pull/656))
+- *(supervisor)* verify process identity before killing orphaned daemons ([#632](https://github.com/jdx/pitchfork/pull/632))
+- *(web)* resolve spa assets from app root on nested routes ([#603](https://github.com/jdx/pitchfork/pull/603))
+- *(tui)* hoist shared namespace into the daemons panel title ([#622](https://github.com/jdx/pitchfork/pull/622))
+
+### Other
+
+- *(procs)* use div_ceil for the process-exit poll count ([#658](https://github.com/jdx/pitchfork/pull/658))
+- *(deps)* update rust crate tokio to v1.53.0 ([#653](https://github.com/jdx/pitchfork/pull/653))
+- *(deps)* update rust crate uuid to v1.24.0 ([#651](https://github.com/jdx/pitchfork/pull/651))
+- *(deps)* update rust crate http-body-util to v0.1.4 ([#643](https://github.com/jdx/pitchfork/pull/643))
+- *(deps)* update rust crate rustls to v0.23.42 ([#646](https://github.com/jdx/pitchfork/pull/646))
+- *(deps)* update rust crate syn to v2.0.119 ([#647](https://github.com/jdx/pitchfork/pull/647))
+- *(deps)* update rust crate tokio to v1.52.4 ([#648](https://github.com/jdx/pitchfork/pull/648))
+- *(deps)* update rust crate mdns-sd to v0.20.2 ([#644](https://github.com/jdx/pitchfork/pull/644))
+- *(deps)* update rust crate regex to v1.13.1 ([#645](https://github.com/jdx/pitchfork/pull/645))
+- *(deps)* update rust crate globset to v0.4.19 ([#642](https://github.com/jdx/pitchfork/pull/642))
+- *(deps)* update rust crate clx to v2.1.1 ([#641](https://github.com/jdx/pitchfork/pull/641))
+- *(deps)* update rust crate clap to v4.6.2 ([#640](https://github.com/jdx/pitchfork/pull/640))
+- *(deps)* update rust crate xx to v2.6.1 ([#611](https://github.com/jdx/pitchfork/pull/611))
+- *(deps)* update rust crate ratatui to v0.30.2 ([#609](https://github.com/jdx/pitchfork/pull/609))
+- *(deps)* update rust crate rcgen to v0.14.8 ([#610](https://github.com/jdx/pitchfork/pull/610))
+- raise MSRV to Rust 1.88 ([#624](https://github.com/jdx/pitchfork/pull/624))
+
 ## [2.17.0](https://github.com/jdx/pitchfork/compare/v2.16.0...v2.17.0) - 2026-07-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3029,7 +3029,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.17.0"
+version = "2.18.0"
 edition = "2024"
 rust-version = "1.88"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2974,7 +2974,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.17.0",
+  "version": "2.18.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.17.0
+**Version**: 2.18.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.17.0"
+version "2.18.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.17.0 -> 2.18.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.18.0](https://github.com/jdx/pitchfork/compare/v2.17.0...v2.18.0) - 2026-07-25

### Added

- *(supervisor)* re-adopt orphaned daemons by default after a crash ([#633](https://github.com/jdx/pitchfork/pull/633))
- *(project)* add project enter/leave/list for IDE session management ([#619](https://github.com/jdx/pitchfork/pull/619))
- *(config)* add top-level env with tera template injection ([#618](https://github.com/jdx/pitchfork/pull/618))
- *(daemons)* add --global flag to daemons add ([#621](https://github.com/jdx/pitchfork/pull/621))
- full Windows support with CI ([#602](https://github.com/jdx/pitchfork/pull/602))

### Fixed

- *(logs)* tolerate concurrent opens of the log store ([#660](https://github.com/jdx/pitchfork/pull/660))
- *(supervisor)* make child-monitor exit finalization atomic ([#659](https://github.com/jdx/pitchfork/pull/659))
- *(supervisor)* make unobserved daemon deaths retryable after a crash ([#657](https://github.com/jdx/pitchfork/pull/657))
- *(deps)* update rust crate clx to v3 ([#656](https://github.com/jdx/pitchfork/pull/656))
- *(supervisor)* verify process identity before killing orphaned daemons ([#632](https://github.com/jdx/pitchfork/pull/632))
- *(web)* resolve spa assets from app root on nested routes ([#603](https://github.com/jdx/pitchfork/pull/603))
- *(tui)* hoist shared namespace into the daemons panel title ([#622](https://github.com/jdx/pitchfork/pull/622))

### Other

- *(procs)* use div_ceil for the process-exit poll count ([#658](https://github.com/jdx/pitchfork/pull/658))
- *(deps)* update rust crate tokio to v1.53.0 ([#653](https://github.com/jdx/pitchfork/pull/653))
- *(deps)* update rust crate uuid to v1.24.0 ([#651](https://github.com/jdx/pitchfork/pull/651))
- *(deps)* update rust crate http-body-util to v0.1.4 ([#643](https://github.com/jdx/pitchfork/pull/643))
- *(deps)* update rust crate rustls to v0.23.42 ([#646](https://github.com/jdx/pitchfork/pull/646))
- *(deps)* update rust crate syn to v2.0.119 ([#647](https://github.com/jdx/pitchfork/pull/647))
- *(deps)* update rust crate tokio to v1.52.4 ([#648](https://github.com/jdx/pitchfork/pull/648))
- *(deps)* update rust crate mdns-sd to v0.20.2 ([#644](https://github.com/jdx/pitchfork/pull/644))
- *(deps)* update rust crate regex to v1.13.1 ([#645](https://github.com/jdx/pitchfork/pull/645))
- *(deps)* update rust crate globset to v0.4.19 ([#642](https://github.com/jdx/pitchfork/pull/642))
- *(deps)* update rust crate clx to v2.1.1 ([#641](https://github.com/jdx/pitchfork/pull/641))
- *(deps)* update rust crate clap to v4.6.2 ([#640](https://github.com/jdx/pitchfork/pull/640))
- *(deps)* update rust crate xx to v2.6.1 ([#611](https://github.com/jdx/pitchfork/pull/611))
- *(deps)* update rust crate ratatui to v0.30.2 ([#609](https://github.com/jdx/pitchfork/pull/609))
- *(deps)* update rust crate rcgen to v0.14.8 ([#610](https://github.com/jdx/pitchfork/pull/610))
- raise MSRV to Rust 1.88 ([#624](https://github.com/jdx/pitchfork/pull/624))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only release PR with no runtime code changes in the diff.
> 
> **Overview**
> **Release v2.18.0** — bumps `pitchfork-cli` from **2.17.0** to **2.18.0** across `Cargo.toml`, `Cargo.lock`, `pitchfork.usage.kdl`, and generated CLI docs (`docs/cli/commands.json`, `docs/cli/index.md`).
> 
> **CHANGELOG** gains a dated **[2.18.0]** section (2026-07-25) documenting what ships in this tag; the **[Unreleased]** section stays empty for the next cycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74b9e9cd22c64cd94798b9f549a6cf83ac7b9dec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->