### PR TITLE
fix: show full binary path in user-facing command hints

### DIFF
--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -180,7 +180,10 @@ impl ProxyStatus {
             println!("Proxy: disabled");
             println!();
             println!("Enable with:");
-            println!("  PITCHFORK_PROXY_ENABLE=true pitchfork supervisor start");
+            println!(
+                "  PITCHFORK_PROXY_ENABLE=true {} supervisor start",
+                crate::env::PITCHFORK_BIN.display()
+            );
             println!("  # or in pitchfork.toml: [settings.proxy] / enable = true");
             return Ok(());
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -346,20 +346,20 @@ pub enum IpcError {
         code(pitchfork::ipc::timeout),
         url("https://pitchfork.jdx.dev/supervisor"),
         help(
-            "the supervisor may be unresponsive or overloaded.\nCheck supervisor status: pitchfork supervisor status\nView logs: pitchfork logs"
+            "the supervisor may be unresponsive or overloaded.\nCheck supervisor status: {bin} supervisor status\nView logs: {bin} logs"
         )
     )]
-    Timeout { seconds: u64 },
+    Timeout { seconds: u64, bin: String },
 
     #[error("IPC connection closed unexpectedly")]
     #[diagnostic(
         code(pitchfork::ipc::connection_closed),
         url("https://pitchfork.jdx.dev/supervisor"),
         help(
-            "the supervisor may have crashed or been stopped.\nRestart with: pitchfork supervisor start"
+            "the supervisor may have crashed or been stopped.\nRestart with: {bin} supervisor start"
         )
     )]
-    ConnectionClosed,
+    ConnectionClosed { bin: String },
 
     #[error("failed to read IPC response")]
     #[diagnostic(code(pitchfork::ipc::read_failed))]
@@ -525,7 +525,10 @@ mod tests {
         assert!(err.to_string().contains("failed to connect"));
         assert!(err.to_string().contains("5 attempts"));
 
-        let err = IpcError::Timeout { seconds: 30 };
+        let err = IpcError::Timeout {
+            seconds: 30,
+            bin: "pitchfork".to_string(),
+        };
         assert!(err.to_string().contains("timed out"));
         assert!(err.to_string().contains("30s"));
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -139,9 +139,10 @@ impl IpcClient {
                             return Err(IpcError::ConnectionFailed {
                                 attempts: connect_attempts,
                                 source: Some(err),
-                                help:
-                                    "ensure the supervisor is running with: pitchfork supervisor start"
-                                        .to_string(),
+                                help: format!(
+                                    "ensure the supervisor is running with: {} supervisor start",
+                                    env::PITCHFORK_BIN.display()
+                                ),
                             }
                             .into());
                         }
@@ -151,8 +152,10 @@ impl IpcClient {
             Err(IpcError::ConnectionFailed {
                 attempts: connect_attempts,
                 source: None,
-                help: "ensure the supervisor is running with: pitchfork supervisor start"
-                    .to_string(),
+                help: format!(
+                    "ensure the supervisor is running with: {} supervisor start",
+                    env::PITCHFORK_BIN.display()
+                ),
             }
             .into())
         })
@@ -162,7 +165,8 @@ impl IpcClient {
                 attempts: connect_attempts,
                 source: None,
                 help: format!(
-                    "connection timed out after {connect_timeout:?}; ensure the supervisor is running with: pitchfork supervisor start"
+                    "connection timed out after {connect_timeout:?}; ensure the supervisor is running with: {} supervisor start",
+                    env::PITCHFORK_BIN.display()
                 ),
             }
             .into())
@@ -196,12 +200,16 @@ impl IpcClient {
             Err(_) => {
                 return Err(IpcError::Timeout {
                     seconds: timeout.as_secs(),
+                    bin: env::PITCHFORK_BIN.to_string_lossy().to_string(),
                 }
                 .into());
             }
         }
         if bytes.is_empty() {
-            return Err(IpcError::ConnectionClosed.into());
+            return Err(IpcError::ConnectionClosed {
+                bin: env::PITCHFORK_BIN.to_string_lossy().to_string(),
+            }
+            .into());
         }
         deserialize(&bytes).wrap_err("failed to deserialize IPC response")
     }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -1,5 +1,6 @@
 use crate::daemon::{Daemon, RunOptions};
 use crate::daemon_id::DaemonId;
+use crate::env;
 use crate::error::IpcError;
 use crate::ipc::batch::RunResult;
 use crate::ipc::{IpcRequest, IpcResponse, deserialize, fs_name, serialize};
@@ -30,6 +31,10 @@ impl IpcClient {
         let client = Self::connect_(&id, "main").await?;
         trace!("Connected to IPC socket");
         let client_version = env!("CARGO_PKG_VERSION").to_string();
+        // Resolve the running CLI's binary path so the restart hint points at
+        // the exact binary the user invoked, not whatever `pitchfork` resolves
+        // to on PATH (which may be a different version).
+        let exe = env::PITCHFORK_BIN.display();
 
         // Try ConnectV2 first (supervisor that knows about it will return ConnectOk with its version).
         // If the supervisor is older and doesn't recognize ConnectV2, it will return Error,
@@ -46,7 +51,7 @@ impl IpcClient {
                 if supervisor_version != client_version {
                     warn!(
                         "CLI version {client_version} differs from supervisor version {supervisor_version}. \
-                         Restart the supervisor with: pitchfork supervisor start --force"
+                         Restart the supervisor with: {exe} supervisor start --force"
                     );
                 }
             }
@@ -63,7 +68,7 @@ impl IpcClient {
                 }
                 warn!(
                     "Supervisor is running an older version. \
-                     Restart the supervisor with: pitchfork supervisor start --force"
+                     Restart the supervisor with: {exe} supervisor start --force"
                 );
             }
             _ => {

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -1630,7 +1630,8 @@ fn bind_error_message(port: u16, err: &std::io::Error) -> String {
         format!(
             "Failed to bind proxy server to port {port}: {err}\n\
              Hint: ports below 1024 require elevated privileges. \
-             Try: sudo pitchfork supervisor start"
+             Try: sudo {} supervisor start",
+            crate::env::PITCHFORK_BIN.display()
         )
     } else {
         format!(

--- a/src/proxy/trust.rs
+++ b/src/proxy/trust.rs
@@ -137,12 +137,13 @@ pub fn install_cert(cert_path: &std::path::Path) -> Result<()> {
             "CA certificate not found at {}\n\
              \n\
              The proxy CA certificate is generated automatically when the proxy\n\
-             starts with `proxy.https = true`. Start the supervisor first:\n\
+             starts with `proxy.https = true`. Start the supervisor first.\n\
              \n\
-             pitchfork supervisor start\n\
+             {} supervisor start\n\
              \n\
              Or specify a custom certificate path with --cert.",
-            cert_path.display()
+            cert_path.display(),
+            crate::env::PITCHFORK_BIN.display()
         );
     }
 

--- a/src/supervisor/ipc_handlers.rs
+++ b/src/supervisor/ipc_handlers.rs
@@ -52,8 +52,7 @@ impl Supervisor {
                 if client_version != VERSION {
                     warn!(
                         "Client version {client_version} differs from supervisor version {VERSION}. \
-                            Restart the supervisor with: {} supervisor start --force",
-                        crate::env::PITCHFORK_BIN.display()
+                            Restart the supervisor with: pitchfork supervisor start --force"
                     );
                 }
                 IpcResponse::ConnectOk {

--- a/src/supervisor/ipc_handlers.rs
+++ b/src/supervisor/ipc_handlers.rs
@@ -52,7 +52,8 @@ impl Supervisor {
                 if client_version != VERSION {
                     warn!(
                         "Client version {client_version} differs from supervisor version {VERSION}. \
-                            Restart the supervisor with: pitchfork supervisor start --force"
+                            Restart the supervisor with: {} supervisor start --force",
+                        crate::env::PITCHFORK_BIN.display()
                     );
                 }
                 IpcResponse::ConnectOk {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -165,9 +165,12 @@ fn draw_daemon_table(f: &mut Frame, area: Rect, app: &App) {
 
     if filtered.is_empty() {
         let msg = if app.daemons.is_empty() {
-            "No daemons running. Start one with: pitchfork start <name>"
+            format!(
+                "No daemons running. Start one with: {} start <name>",
+                crate::env::PITCHFORK_BIN.display()
+            )
         } else {
-            "No daemons match the search query"
+            "No daemons match the search query".to_string()
         };
         let paragraph = Paragraph::new(msg)
             .alignment(Alignment::Center)

--- a/src/web/routes/api/proxies.rs
+++ b/src/web/routes/api/proxies.rs
@@ -86,8 +86,10 @@ pub async fn list() -> Json<Vec<ApiProxyWorktreeEntry>> {
 
         let error = if !is_registered {
             Some(format!(
-                "Namespace '{}' is not registered. Run 'pitchfork supervisor namespace add {} /path/to/dir'",
-                ns_name, ns_name
+                "Namespace '{}' is not registered. Run '{} supervisor namespace add {} /path/to/dir'",
+                ns_name,
+                crate::env::PITCHFORK_BIN.display(),
+                ns_name
             ))
         } else {
             None

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -328,7 +328,8 @@ EOF
 
   assert_success
   # Same parallel-bats scheduling-latency tolerance as the ready_pattern test
-  # above; 8s (10s on Windows) stays well under the daemon's trailing 10s sleep.
+  # above. The regression path (no early return → daemon exit ~11s) still
+  # exceeds the 8s (10s on Windows) bound, preserving the detection margin.
   local max_elapsed=8
   if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
     max_elapsed=10

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -303,7 +303,11 @@ EOF
   elapsed=$(($(date +%s) - start_time))
 
   assert_success
-  [[ $elapsed -lt 3 ]]
+  # bats runs 16-way parallel on a shared CI runner, so stdout delivery and
+  # ready-pattern matching can lag a few seconds under scheduling pressure.
+  # 8s is still well under the daemon's trailing 10s sleep, so a regression
+  # that skips early return (waits for daemon exit ~11s) still fails here.
+  [[ $elapsed -lt 8 ]]
 
   wait_for_logs ready_pattern "READY" 5
 
@@ -323,9 +327,11 @@ EOF
   elapsed=$(($(date +%s) - start_time))
 
   assert_success
-  local max_elapsed=3
+  # Same parallel-bats scheduling-latency tolerance as the ready_pattern test
+  # above; 8s (10s on Windows) stays well under the daemon's trailing 10s sleep.
+  local max_elapsed=8
   if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
-    max_elapsed=5
+    max_elapsed=10
   fi
   [[ $elapsed -lt $max_elapsed ]]
 


### PR DESCRIPTION
## Problem

Several runtime messages tell the user to run `pitchfork <cmd> ...`, relying on whatever `pitchfork` resolves to on `PATH`. When the `PATH` binary differs from the one the user just invoked — e.g. a newer build in `~/.cargo/bin` while `PATH` still points at an older `/usr/bin/pitchfork`, or under `sudo` (whose `PATH` differs) — following the hint runs the wrong binary and the problem persists.

## Fix

Use the existing `env::PITCHFORK_BIN` (`current_exe().canonicalize()`, with a fallback) so hints name the exact binary:

```
Restart the supervisor with: /home/user/.cargo/bin/pitchfork supervisor start --force
Hint: ports below 1024 require elevated privileges. Try: sudo /home/user/.cargo/bin/pitchfork supervisor start
```

### CLI-side hints (authoritative)
`current_exe` is the binary the user just ran — the right one to point at.

- `src/proxy/server.rs` — `sudo pitchfork supervisor start` on low-port bind (the `sudo` case is especially important, since sudo's `PATH` differs).
- `src/ipc/client.rs` — three `ensure the supervisor is running with: pitchfork supervisor start` connection-error helps; plus the original version-mismatch warning (`Restart the supervisor with: <bin> supervisor start --force`).
- `src/cli/proxy.rs` — `PITCHFORK_PROXY_ENABLE=true pitchfork supervisor start`.
- `src/proxy/trust.rs` — `pitchfork supervisor start` in the missing-CA hint (`install_cert` is called from the CLI).
- `src/tui/ui.rs` — `Start one with: pitchfork start <name>`.

### Other supervisor-side hints (operational, not version-sensitive)
`current_exe` is the running supervisor binary — a known-working binary. Fine for operational hints that aren't about upgrading.

- `src/proxy/server.rs` — `sudo <bin> supervisor start` on low-port bind (elevation, not upgrade).
- `src/web/routes/api/proxies.rs` — namespace registration hint.

### Intentionally NOT converted
- `src/supervisor/ipc_handlers.rs` — the version-mismatch restart hint is left as bare `pitchfork supervisor start --force`. This hint is version-sensitive (its whole purpose is to upgrade the supervisor), and the supervisor resolves `PITCHFORK_BIN` to its OWN (potentially old) binary. In the two-binaries case this PR handles (new CLI vs old supervisor), a full path there would point at the wrong (old) executable — reintroducing the problem on the other side. The supervisor can't know which CLI binary the user invoked (`ConnectV2` only carries the version string), so the authoritative full-path hint is the CLI-side one in `ipc/client.rs`.

### `error.rs`
The two IPC diagnostic helps (`#[diagnostic(help("..."))]`) are static attribute literals, so they can't interpolate a runtime path directly. Added a `bin: String` field to `Timeout` and `ConnectionClosed` and interpolate `{bin}` in the help text, populated from `PITCHFORK_BIN` at construction (CLI-side, authoritative).

### Not changed
CLI help text / doc-comment examples (e.g. `pitchfork start api`, `pitchfork logs ...`) are intentionally left as `pitchfork` — that's documentation, not a runtime hint, and the program name should read as `pitchfork`.

## CI flake mitigation

The Linux `ci-bats` job was flaking on `ready output pattern matches and returns early` because `mise run test:bats` runs `bats --jobs 16` on a runner shared with the build/rust-tests/web-ui workflows, so the supervisor's tokio output processing can be starved for a few seconds. The `< 3s` early-return bound was too tight (one run detected ready at ~4s while the identical sibling "ready output regex" test passed the same run). Raised the bound to `8s` (10s on Windows); the daemon's trailing `sleep 10` still gives a deterministic ~11s regression baseline, so a regression that skips early return still fails the bound. The timer-based `custom ready delay` test is untouched (its `ready_delay` fires on a wall-clock timer, not stdout delivery).

## Verification
- `cargo fmt --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo nextest run`: 476 passed
- `mise run render`: no doc diff (no CLI/schema change)

---

*This PR description was generated by Claude Code.*
