### PR TITLE
feat(config): add top-level env with tera template injection

### DIFF
--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -14,6 +14,16 @@
         }
       }
     },
+    "env": {
+      "description": "Top-level environment variables applied to all daemons as defaults.\nPer-daemon `env` overrides these on key conflicts. Values support Tera\ntemplates (e.g. `{{ daemons.api.port }}`, `{{ settings.proxy.tld }}`).",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "namespace": {
       "description": "Optional explicit namespace declared in this file.\n\nThis applies to per-file read/write flows. Merged configs may contain\ndaemons from multiple namespaces and leave this as `None`.",
       "type": [

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -519,6 +519,7 @@ impl IpcClient {
                         match crate::template::render_daemon_templates(
                             &mut rendered_config,
                             &template_ctx,
+                            pt.env.as_ref(),
                         ) {
                             Ok(()) => {}
                             Err(e) => {

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -142,6 +142,40 @@ pub fn build_run_options(
     Ok(run_opts)
 }
 
+/// Render Tera templates for a single daemon config before starting it.
+///
+/// Merges top-level `[env]` defaults into the daemon's env (per-daemon wins),
+/// renders all template-enabled fields, and uses the currently-running daemons'
+/// resolved ports (read from the state file) as template context.
+///
+/// Used by single-daemon start paths (`start_daemon`, proxy auto-start) that
+/// don't go through the batch dependency-resolution path.
+pub(crate) fn render_daemon_config(
+    id: &DaemonId,
+    daemon_config: &mut PitchforkTomlDaemon,
+    pt: &PitchforkToml,
+) -> Result<()> {
+    let resolved_daemons = crate::state_file::StateFile::read(&*crate::env::PITCHFORK_STATE_FILE)
+        .map(|sf| {
+            sf.daemons
+                .iter()
+                .filter_map(|(id, d)| {
+                    if d.resolved_port.is_empty() {
+                        None
+                    } else {
+                        Some((id.clone(), d.resolved_port.clone()))
+                    }
+                })
+                .collect::<HashMap<DaemonId, Vec<u16>>>()
+        })
+        .unwrap_or_default();
+
+    let mut ctx =
+        crate::template::TemplateContext::new(id, daemon_config, &resolved_daemons, &pt.daemons);
+    crate::template::render_daemon_templates(daemon_config, &mut ctx, pt.env.as_ref())
+        .map_err(|e| miette::miette!("Template render error for daemon {id}: {e}"))
+}
+
 fn merge_ready_http_override(
     configured: Option<ReadyHttp>,
     override_url: Option<String>,
@@ -510,7 +544,7 @@ impl IpcClient {
                     if let Some(daemon_config) = pt.daemons.get(&id) {
                         // Render Tera templates with context from previously started daemons
                         let mut rendered_config = daemon_config.clone();
-                        let template_ctx = crate::template::TemplateContext::new(
+                        let mut template_ctx = crate::template::TemplateContext::new(
                             &id,
                             daemon_config,
                             &resolved_ports_map,
@@ -518,7 +552,7 @@ impl IpcClient {
                         );
                         match crate::template::render_daemon_templates(
                             &mut rendered_config,
-                            &template_ctx,
+                            &mut template_ctx,
                             pt.env.as_ref(),
                         ) {
                             Ok(()) => {}
@@ -876,11 +910,14 @@ impl IpcClient {
     ) -> Result<RunResult> {
         let pt = PitchforkToml::all_merged_all_namespaces()?;
 
-        let daemon_config = pt
+        let mut daemon_config = pt
             .daemons
             .get(id)
             .cloned()
             .ok_or_else(|| miette::miette!("Daemon config not found for {id}"))?;
+
+        // Render Tera templates and merge top-level env (per-daemon wins).
+        render_daemon_config(id, &mut daemon_config, &pt)?;
 
         let run_opts =
             build_run_options(id, &daemon_config, overrides).map_err(|e| miette::miette!("{e}"))?;

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -110,6 +110,10 @@ struct PitchforkTomlRaw {
     pub namespace: Option<String>,
     #[serde(default)]
     pub daemons: IndexMap<String, PitchforkTomlDaemonRaw>,
+    /// Top-level environment variables applied to all daemons as defaults.
+    /// Per-daemon `env` overrides these. Values support Tera templates.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub env: Option<IndexMap<String, String>>,
     #[serde(default)]
     pub settings: Option<SettingsPartial>,
     /// Slug registry (only meaningful in global config).
@@ -241,6 +245,11 @@ pub struct PitchforkToml {
     /// Map of daemon IDs to their configurations
     #[serde(default)]
     pub daemons: IndexMap<DaemonId, PitchforkTomlDaemon>,
+    /// Top-level environment variables applied to all daemons as defaults.
+    /// Per-daemon `env` overrides these on key conflicts. Values support Tera
+    /// templates (e.g. `{{ daemons.api.port }}`, `{{ settings.proxy.tld }}`).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub env: Option<IndexMap<String, String>>,
     /// Optional explicit namespace declared in this file.
     ///
     /// This applies to per-file read/write flows. Merged configs may contain
@@ -953,6 +962,7 @@ impl PitchforkToml {
     pub fn new(path: PathBuf) -> Self {
         Self {
             daemons: Default::default(),
+            env: None,
             namespace: None,
             settings: SettingsPartial::default(),
             slugs: IndexMap::new(),
@@ -1116,6 +1126,9 @@ impl PitchforkToml {
             pt.settings = settings;
         }
 
+        // Copy top-level env
+        pt.env = raw_config.env;
+
         // Copy slugs registry (only meaningful in global config files)
         for (slug, entry) in raw_config.slugs {
             pt.slugs.insert(
@@ -1211,6 +1224,7 @@ impl PitchforkToml {
             // doesn't drop `[settings.*]`. Gate on is_empty to avoid a bare `[settings]`.
             let mut raw = PitchforkTomlRaw {
                 namespace: self.namespace.clone(),
+                env: self.env.clone(),
                 settings: (!self.settings.is_empty()).then(|| self.settings.clone()),
                 ..PitchforkTomlRaw::default()
             };
@@ -1342,6 +1356,13 @@ impl PitchforkToml {
     pub fn merge(&mut self, pt: Self) {
         for (id, d) in pt.daemons {
             self.daemons.insert(id, d);
+        }
+        // Merge top-level env - pt's values override self's values
+        if let Some(env) = pt.env {
+            let merged = self.env.get_or_insert_with(IndexMap::new);
+            for (k, v) in env {
+                merged.insert(k, v);
+            }
         }
         // Merge slugs - pt's values override self's values
         for (slug, entry) in pt.slugs {

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -1537,8 +1537,8 @@ async fn try_auto_start_inner(
         }
     };
 
-    let daemon_config = match pt.daemons.get(daemon_id) {
-        Some(cfg) => cfg,
+    let mut daemon_config = match pt.daemons.get(daemon_id) {
+        Some(cfg) => cfg.clone(),
         None => {
             log::debug!(
                 "Auto-start: daemon {daemon_id} not found in config at {}",
@@ -1548,12 +1548,18 @@ async fn try_auto_start_inner(
         }
     };
 
+    // Render Tera templates and merge top-level env (per-daemon wins).
+    if let Err(e) = crate::ipc::batch::render_daemon_config(daemon_id, &mut daemon_config, &pt) {
+        log::warn!("Auto-start: failed to render templates for {daemon_id}: {e}");
+        return ResolveResult::Error(format!("Failed to render templates: {e}"));
+    }
+
     let opts = crate::ipc::batch::StartOptions {
         quiet: true,
         ..crate::ipc::batch::StartOptions::default()
     };
     let mut run_opts =
-        match crate::ipc::batch::build_run_options(daemon_id, daemon_config, Some(&opts)) {
+        match crate::ipc::batch::build_run_options(daemon_id, &daemon_config, Some(&opts)) {
             Ok(o) => o,
             Err(e) => {
                 log::warn!("Auto-start: failed to build run options for {daemon_id}: {e}");

--- a/src/supervisor/hooks.rs
+++ b/src/supervisor/hooks.rs
@@ -259,11 +259,22 @@ async fn render_hook_template(
     };
 
     let daemon_config = pt.daemons.get(daemon_id);
-    let ctx = template::TemplateContext::new(
+    let mut ctx = template::TemplateContext::new(
         daemon_id,
         daemon_config.unwrap_or(&Default::default()),
         &resolved_daemons,
         &pt.daemons,
     );
+
+    // Merge top-level env with per-daemon env (per-daemon wins), render the
+    // values, and expose them as `{{ env.X }}` for hook templates.
+    if let Some(rendered_env) = template::render_env(
+        pt.env.as_ref(),
+        daemon_config.and_then(|d| d.env.as_ref()),
+        &ctx,
+    )? {
+        ctx.set_env(rendered_env);
+    }
+
     template::render_template(template_str, &ctx)
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -284,28 +284,23 @@ pub fn render_template(template: &str, context: &TemplateContext) -> Result<Stri
 /// at fire time via `fire_hook`, so pre-rendered hook strings are unused.
 pub fn render_daemon_templates(
     config: &mut PitchforkTomlDaemon,
-    context: &TemplateContext,
+    context: &mut TemplateContext,
     top_env: Option<&IndexMap<String, String>>,
 ) -> Result<(), RenderError> {
+    // Phase 1: merge top-level env into the daemon's env (per-daemon wins) and
+    // render env values. `env` is NOT yet in the context, so env values cannot
+    // reference {{ env.* }} (preventing cycles). render_env builds its own
+    // short-lived renderer without env in scope.
+    let rendered_env = render_env(top_env, config.env.as_ref(), context)?;
+    config.env = rendered_env;
+
+    // Phase 2: expose the rendered env on the context as the authoritative
+    // state, so to_tera_context() (used by TemplateRenderer::new) includes it.
+    if let Some(ref env) = config.env {
+        context.set_env(env.clone());
+    }
+
     let mut renderer = TemplateRenderer::new(context);
-
-    // Merge top-level env into the daemon's env (per-daemon wins).
-    config.env = merge_env(top_env, config.env.as_ref());
-
-    // Phase 1: render env values. `env` is NOT yet in the context, so env
-    // values cannot reference {{ env.* }} (preventing cycles).
-    if let Some(ref env) = config.env {
-        let rendered: IndexMap<String, String> = env
-            .iter()
-            .map(|(k, v)| Ok((k.clone(), renderer.render(v)?)))
-            .collect::<Result<_, RenderError>>()?;
-        config.env = Some(rendered);
-    }
-
-    // Phase 2: expose the rendered env so remaining fields can use {{ env.X }}.
-    if let Some(ref env) = config.env {
-        renderer.insert_env(env);
-    }
 
     config.run = renderer.render(&config.run)?;
 
@@ -423,16 +418,6 @@ impl TemplateRenderer {
             context: context.to_tera_context(),
             next_template_id: 0,
         }
-    }
-
-    /// Insert rendered env into the Tera context so subsequent renders can use
-    /// `{{ env.X }}`.
-    fn insert_env(&mut self, env: &IndexMap<String, String>) {
-        let map: serde_json::Map<String, serde_json::Value> = env
-            .iter()
-            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
-            .collect();
-        self.context.insert("env", &serde_json::Value::Object(map));
     }
 
     fn render(&mut self, template: &str) -> Result<String, RenderError> {
@@ -627,18 +612,18 @@ mod tests {
 
     #[test]
     fn test_render_daemon_templates_run() {
-        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
         let mut config = PitchforkTomlDaemon {
             run: "redis-cli -p {{ daemons.redis.port }}".to_string(),
             ..Default::default()
         };
-        render_daemon_templates(&mut config, &ctx, None).unwrap();
+        render_daemon_templates(&mut config, &mut ctx, None).unwrap();
         assert_eq!(config.run, "redis-cli -p 6379");
     }
 
     #[test]
     fn test_render_daemon_templates_env() {
-        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
         let mut config = PitchforkTomlDaemon {
             run: "echo".to_string(),
             env: Some(IndexMap::from([
@@ -650,7 +635,7 @@ mod tests {
             ])),
             ..Default::default()
         };
-        render_daemon_templates(&mut config, &ctx, None).unwrap();
+        render_daemon_templates(&mut config, &mut ctx, None).unwrap();
         let env = config.env.unwrap();
         assert_eq!(env["DATABASE_URL"], "redis://localhost:6379/0");
         assert_eq!(env["STATIC_VAR"], "unchanged");
@@ -658,7 +643,7 @@ mod tests {
 
     #[test]
     fn test_top_level_env_merged_as_defaults() {
-        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
         let top_env = IndexMap::from([
             ("GRAM_HOST".to_string(), "localhost".to_string()),
             (
@@ -674,7 +659,7 @@ mod tests {
             )])),
             ..Default::default()
         };
-        render_daemon_templates(&mut config, &ctx, Some(&top_env)).unwrap();
+        render_daemon_templates(&mut config, &mut ctx, Some(&top_env)).unwrap();
         let env = config.env.unwrap();
         // per-daemon wins
         assert_eq!(env["GRAM_HOST"], "0.0.0.0");
@@ -684,19 +669,19 @@ mod tests {
 
     #[test]
     fn test_env_exposed_in_context_for_other_fields() {
-        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
         let top_env = IndexMap::from([("GRAM_HOST".to_string(), "localhost".to_string())]);
         let mut config = PitchforkTomlDaemon {
             run: "echo {{ env.GRAM_HOST }}".to_string(),
             ..Default::default()
         };
-        render_daemon_templates(&mut config, &ctx, Some(&top_env)).unwrap();
+        render_daemon_templates(&mut config, &mut ctx, Some(&top_env)).unwrap();
         assert_eq!(config.run, "echo localhost");
     }
 
     #[test]
     fn test_env_values_cannot_self_reference() {
-        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
         let top_env = IndexMap::from([
             ("A".to_string(), "value-a".to_string()),
             // env is not available while env values are rendered
@@ -708,12 +693,12 @@ mod tests {
         };
         // Rendering env.B references {{ env.A }} which is undefined during
         // env-value rendering -> error propagates.
-        assert!(render_daemon_templates(&mut config, &ctx, Some(&top_env)).is_err());
+        assert!(render_daemon_templates(&mut config, &mut ctx, Some(&top_env)).is_err());
     }
 
     #[test]
     fn test_render_daemon_templates_on_output_run() {
-        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
         let mut config = PitchforkTomlDaemon {
             run: "echo".to_string(),
             hooks: Some(crate::config_types::PitchforkTomlHooks {
@@ -732,7 +717,7 @@ mod tests {
             ..Default::default()
         };
 
-        render_daemon_templates(&mut config, &ctx, None).unwrap();
+        render_daemon_templates(&mut config, &mut ctx, None).unwrap();
 
         let hooks = config.hooks.unwrap();
         let on_output = hooks.on_output.unwrap();
@@ -744,7 +729,7 @@ mod tests {
     fn test_render_daemon_templates_ready_fields() {
         use crate::config_types::{ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort};
 
-        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
         let mut config = PitchforkTomlDaemon {
             run: "echo".to_string(),
             ready_cmd: Some(ReadyCmd::new("redis-cli -p {{ daemons.redis.port }} ping")),
@@ -758,7 +743,7 @@ mod tests {
             ..Default::default()
         };
 
-        render_daemon_templates(&mut config, &ctx, None).unwrap();
+        render_daemon_templates(&mut config, &mut ctx, None).unwrap();
 
         assert_eq!(
             config.ready_cmd.as_ref().unwrap().run,
@@ -778,14 +763,14 @@ mod tests {
     fn test_render_daemon_templates_ready_port_invalid() {
         use crate::config_types::ReadyPort;
 
-        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
         let mut config = PitchforkTomlDaemon {
             run: "echo".to_string(),
             ready_port: Some(ReadyPort::from_template("{{ name }}")),
             ..Default::default()
         };
 
-        let err = render_daemon_templates(&mut config, &ctx, None).unwrap_err();
+        let err = render_daemon_templates(&mut config, &mut ctx, None).unwrap_err();
         assert!(matches!(err, RenderError::InvalidPort { .. }));
     }
 
@@ -793,20 +778,20 @@ mod tests {
     fn test_render_daemon_templates_ready_port_literal_untouched() {
         use crate::config_types::ReadyPort;
 
-        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
         let mut config = PitchforkTomlDaemon {
             run: "echo".to_string(),
             ready_port: Some(ReadyPort::new(8080)),
             ..Default::default()
         };
 
-        render_daemon_templates(&mut config, &ctx, None).unwrap();
+        render_daemon_templates(&mut config, &mut ctx, None).unwrap();
         assert_eq!(config.ready_port, Some(ReadyPort::new(8080)));
     }
 
     #[test]
     fn test_render_daemon_templates_hook_error_does_not_fail() {
-        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
         let mut config = PitchforkTomlDaemon {
             run: "echo".to_string(),
             hooks: Some(crate::config_types::PitchforkTomlHooks {
@@ -821,20 +806,20 @@ mod tests {
         };
 
         // Hook template errors are silently converted to None — daemon still starts
-        render_daemon_templates(&mut config, &ctx, None).unwrap();
+        render_daemon_templates(&mut config, &mut ctx, None).unwrap();
         let hooks = config.hooks.unwrap();
         assert!(hooks.on_ready.is_none());
     }
 
     #[test]
     fn test_render_daemon_templates_run_error_still_fails() {
-        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
         let mut config = PitchforkTomlDaemon {
             run: "{{ nonexistent }}".to_string(),
             ..Default::default()
         };
 
         // Non-hook template errors still propagate as Err
-        assert!(render_daemon_templates(&mut config, &ctx, None).is_err());
+        assert!(render_daemon_templates(&mut config, &mut ctx, None).is_err());
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -44,6 +44,11 @@ impl DaemonTemplateState {
 pub struct TemplateContext {
     self_state: DaemonTemplateState,
     daemon_states: HashMap<String, DaemonTemplateState>,
+    /// Rendered environment variables for the current daemon, exposed as `env`
+    /// in templates (e.g. `{{ env.GRAM_HOST }}`). Set via [`set_env`] after env
+    /// values have been rendered, so it is `None` during env-value rendering
+    /// itself (preventing self-reference cycles).
+    env: Option<IndexMap<String, String>>,
 }
 
 impl TemplateContext {
@@ -109,7 +114,16 @@ impl TemplateContext {
         Self {
             self_state,
             daemon_states,
+            env: None,
         }
+    }
+
+    /// Set the rendered environment variables to expose as `env` in templates.
+    ///
+    /// Call this **after** rendering env values so that other fields (`run`,
+    /// `hooks`, `ready_*`) can reference `{{ env.X }}` with the final value.
+    pub fn set_env(&mut self, env: IndexMap<String, String>) {
+        self.env = Some(env);
     }
 
     /// Convert this context into a Tera Context for rendering.
@@ -152,6 +166,15 @@ impl TemplateContext {
         let proxy_url = build_proxy_url(self.self_state.slug.as_deref(), &s);
         ctx.insert("proxy_url", &proxy_url);
 
+        // Rendered env for this daemon (set via set_env after env rendering)
+        if let Some(ref env) = self.env {
+            let map: serde_json::Map<String, serde_json::Value> = env
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                .collect();
+            ctx.insert("env", &serde_json::Value::Object(map));
+        }
+
         ctx
     }
 }
@@ -190,6 +213,52 @@ fn build_proxy_url(slug: Option<&str>, s: &crate::settings::Settings) -> Option<
 }
 
 // ---------------------------------------------------------------------------
+// Env merge + render helpers
+// ---------------------------------------------------------------------------
+
+/// Merge top-level env with per-daemon env. Per-daemon values win on conflicts.
+pub(crate) fn merge_env(
+    top: Option<&IndexMap<String, String>>,
+    daemon: Option<&IndexMap<String, String>>,
+) -> Option<IndexMap<String, String>> {
+    match (top, daemon) {
+        (None, None) => None,
+        (Some(t), None) => Some(t.clone()),
+        (None, Some(d)) => Some(d.clone()),
+        (Some(t), Some(d)) => {
+            let mut merged = t.clone();
+            for (k, v) in d {
+                merged.insert(k.clone(), v.clone());
+            }
+            Some(merged)
+        }
+    }
+}
+
+/// Merge top-level and per-daemon env, render template values, and return the
+/// rendered env. Used by hook rendering where the daemon config is not mutated.
+///
+/// Env values are rendered with a context that does **not** include `env`
+/// itself, preventing self-reference cycles. Callers that want `{{ env.X }}`
+/// available in subsequent rendering should set the result on the context via
+/// [`TemplateContext::set_env`].
+pub fn render_env(
+    top_env: Option<&IndexMap<String, String>>,
+    daemon_env: Option<&IndexMap<String, String>>,
+    context: &TemplateContext,
+) -> Result<Option<IndexMap<String, String>>, RenderError> {
+    let Some(merged) = merge_env(top_env, daemon_env) else {
+        return Ok(None);
+    };
+    let mut renderer = TemplateRenderer::new(context);
+    let rendered: IndexMap<String, String> = merged
+        .iter()
+        .map(|(k, v)| Ok((k.clone(), renderer.render(v)?)))
+        .collect::<Result<_, _>>()?;
+    Ok(Some(rendered))
+}
+
+// ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
 
@@ -203,6 +272,12 @@ pub fn render_template(template: &str, context: &TemplateContext) -> Result<Stri
 
 /// Render all template-enabled fields of a daemon config.
 ///
+/// Top-level `env` (from `[env]` in pitchfork.toml) is merged into the daemon's
+/// own `env` as defaults — per-daemon values win on key conflicts. Env values
+/// are rendered first (with a context that excludes `env` itself, preventing
+/// self-reference cycles), then the rendered env is exposed as `{{ env.X }}`
+/// for the remaining fields (`run`, `hooks`, `ready_*`).
+///
 /// Modifies the config in place. Returns the first error encountered from
 /// non-hook fields (`run`, `env`, `ready_*`). Hook template errors are
 /// logged as warnings and the hook is set to `None` — hooks are re-rendered
@@ -210,11 +285,15 @@ pub fn render_template(template: &str, context: &TemplateContext) -> Result<Stri
 pub fn render_daemon_templates(
     config: &mut PitchforkTomlDaemon,
     context: &TemplateContext,
+    top_env: Option<&IndexMap<String, String>>,
 ) -> Result<(), RenderError> {
     let mut renderer = TemplateRenderer::new(context);
 
-    config.run = renderer.render(&config.run)?;
+    // Merge top-level env into the daemon's env (per-daemon wins).
+    config.env = merge_env(top_env, config.env.as_ref());
 
+    // Phase 1: render env values. `env` is NOT yet in the context, so env
+    // values cannot reference {{ env.* }} (preventing cycles).
     if let Some(ref env) = config.env {
         let rendered: IndexMap<String, String> = env
             .iter()
@@ -222,6 +301,13 @@ pub fn render_daemon_templates(
             .collect::<Result<_, RenderError>>()?;
         config.env = Some(rendered);
     }
+
+    // Phase 2: expose the rendered env so remaining fields can use {{ env.X }}.
+    if let Some(ref env) = config.env {
+        renderer.insert_env(env);
+    }
+
+    config.run = renderer.render(&config.run)?;
 
     if let Some(ref hooks) = config.hooks {
         let rendered = crate::config_types::PitchforkTomlHooks {
@@ -337,6 +423,16 @@ impl TemplateRenderer {
             context: context.to_tera_context(),
             next_template_id: 0,
         }
+    }
+
+    /// Insert rendered env into the Tera context so subsequent renders can use
+    /// `{{ env.X }}`.
+    fn insert_env(&mut self, env: &IndexMap<String, String>) {
+        let map: serde_json::Map<String, serde_json::Value> = env
+            .iter()
+            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+            .collect();
+        self.context.insert("env", &serde_json::Value::Object(map));
     }
 
     fn render(&mut self, template: &str) -> Result<String, RenderError> {
@@ -536,7 +632,7 @@ mod tests {
             run: "redis-cli -p {{ daemons.redis.port }}".to_string(),
             ..Default::default()
         };
-        render_daemon_templates(&mut config, &ctx).unwrap();
+        render_daemon_templates(&mut config, &ctx, None).unwrap();
         assert_eq!(config.run, "redis-cli -p 6379");
     }
 
@@ -554,10 +650,65 @@ mod tests {
             ])),
             ..Default::default()
         };
-        render_daemon_templates(&mut config, &ctx).unwrap();
+        render_daemon_templates(&mut config, &ctx, None).unwrap();
         let env = config.env.unwrap();
         assert_eq!(env["DATABASE_URL"], "redis://localhost:6379/0");
         assert_eq!(env["STATIC_VAR"], "unchanged");
+    }
+
+    #[test]
+    fn test_top_level_env_merged_as_defaults() {
+        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let top_env = IndexMap::from([
+            ("GRAM_HOST".to_string(), "localhost".to_string()),
+            (
+                "GRAM_URL".to_string(),
+                "redis://{{ daemons.redis.port }}".to_string(),
+            ),
+        ]);
+        let mut config = PitchforkTomlDaemon {
+            run: "echo".to_string(),
+            env: Some(IndexMap::from([(
+                "GRAM_HOST".to_string(),
+                "0.0.0.0".to_string(),
+            )])),
+            ..Default::default()
+        };
+        render_daemon_templates(&mut config, &ctx, Some(&top_env)).unwrap();
+        let env = config.env.unwrap();
+        // per-daemon wins
+        assert_eq!(env["GRAM_HOST"], "0.0.0.0");
+        // top-level default with template rendered
+        assert_eq!(env["GRAM_URL"], "redis://6379");
+    }
+
+    #[test]
+    fn test_env_exposed_in_context_for_other_fields() {
+        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let top_env = IndexMap::from([("GRAM_HOST".to_string(), "localhost".to_string())]);
+        let mut config = PitchforkTomlDaemon {
+            run: "echo {{ env.GRAM_HOST }}".to_string(),
+            ..Default::default()
+        };
+        render_daemon_templates(&mut config, &ctx, Some(&top_env)).unwrap();
+        assert_eq!(config.run, "echo localhost");
+    }
+
+    #[test]
+    fn test_env_values_cannot_self_reference() {
+        let ctx = make_context_with_daemon("redis", vec![6379]);
+        let top_env = IndexMap::from([
+            ("A".to_string(), "value-a".to_string()),
+            // env is not available while env values are rendered
+            ("B".to_string(), "{{ env.A }}".to_string()),
+        ]);
+        let mut config = PitchforkTomlDaemon {
+            run: "echo".to_string(),
+            ..Default::default()
+        };
+        // Rendering env.B references {{ env.A }} which is undefined during
+        // env-value rendering -> error propagates.
+        assert!(render_daemon_templates(&mut config, &ctx, Some(&top_env)).is_err());
     }
 
     #[test]
@@ -581,7 +732,7 @@ mod tests {
             ..Default::default()
         };
 
-        render_daemon_templates(&mut config, &ctx).unwrap();
+        render_daemon_templates(&mut config, &ctx, None).unwrap();
 
         let hooks = config.hooks.unwrap();
         let on_output = hooks.on_output.unwrap();
@@ -607,7 +758,7 @@ mod tests {
             ..Default::default()
         };
 
-        render_daemon_templates(&mut config, &ctx).unwrap();
+        render_daemon_templates(&mut config, &ctx, None).unwrap();
 
         assert_eq!(
             config.ready_cmd.as_ref().unwrap().run,
@@ -634,7 +785,7 @@ mod tests {
             ..Default::default()
         };
 
-        let err = render_daemon_templates(&mut config, &ctx).unwrap_err();
+        let err = render_daemon_templates(&mut config, &ctx, None).unwrap_err();
         assert!(matches!(err, RenderError::InvalidPort { .. }));
     }
 
@@ -649,7 +800,7 @@ mod tests {
             ..Default::default()
         };
 
-        render_daemon_templates(&mut config, &ctx).unwrap();
+        render_daemon_templates(&mut config, &ctx, None).unwrap();
         assert_eq!(config.ready_port, Some(ReadyPort::new(8080)));
     }
 
@@ -670,7 +821,7 @@ mod tests {
         };
 
         // Hook template errors are silently converted to None — daemon still starts
-        render_daemon_templates(&mut config, &ctx).unwrap();
+        render_daemon_templates(&mut config, &ctx, None).unwrap();
         let hooks = config.hooks.unwrap();
         assert!(hooks.on_ready.is_none());
     }
@@ -684,6 +835,6 @@ mod tests {
         };
 
         // Non-hook template errors still propagate as Err
-        assert!(render_daemon_templates(&mut config, &ctx).is_err());
+        assert!(render_daemon_templates(&mut config, &ctx, None).is_err());
     }
 }

--- a/tests/test_pitchfork_toml.rs
+++ b/tests/test_pitchfork_toml.rs
@@ -2428,3 +2428,94 @@ fn test_namespace_from_home_dot_config_local_is_not_global() {
         "Home .config/pitchfork.local.toml should derive namespace from home directory name"
     );
 }
+
+/// Test that top-level [env] is parsed correctly.
+#[test]
+fn test_top_level_env_parsed() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[env]
+GRAM_HOST = "localhost"
+GRAM_URL = "https://{{ daemons.api.slug }}.{{ settings.proxy.tld }}"
+
+[daemons.api]
+run = "go run ./cmd/api"
+"#;
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let env = pt.env.as_ref().expect("top-level env should be set");
+    assert_eq!(env.get("GRAM_HOST").unwrap(), "localhost");
+    assert_eq!(
+        env.get("GRAM_URL").unwrap(),
+        "https://{{ daemons.api.slug }}.{{ settings.proxy.tld }}"
+    );
+
+    Ok(())
+}
+
+/// Test that top-level [env] merges across config files (later wins).
+#[test]
+fn test_top_level_env_merges_across_files() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+
+    let base_path = temp_dir.path().join("base.toml");
+    fs::write(
+        &base_path,
+        r#"
+[env]
+GRAM_HOST = "localhost"
+GRAM_PORT = "3000"
+"#,
+    )
+    .unwrap();
+
+    let override_path = temp_dir.path().join("override.toml");
+    fs::write(
+        &override_path,
+        r#"
+[env]
+GRAM_HOST = "0.0.0.0"
+"#,
+    )
+    .unwrap();
+
+    let mut merged = pitchfork_toml::PitchforkToml::default();
+    merged.merge(pitchfork_toml::PitchforkToml::read(&base_path)?);
+    merged.merge(pitchfork_toml::PitchforkToml::read(&override_path)?);
+
+    let env = merged.env.as_ref().expect("env should be set");
+    // override wins
+    assert_eq!(env.get("GRAM_HOST").unwrap(), "0.0.0.0");
+    // base value preserved
+    assert_eq!(env.get("GRAM_PORT").unwrap(), "3000");
+
+    Ok(())
+}
+
+/// Test that top-level [env] survives a write-read round trip.
+#[test]
+fn test_top_level_env_round_trip() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let pt = pitchfork_toml::PitchforkToml::parse_str(
+        r#"
+[env]
+GRAM_HOST = "localhost"
+
+[daemons.api]
+run = "echo"
+"#,
+        &toml_path,
+    )?;
+    pt.write()?;
+
+    let reread = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let env = reread.env.as_ref().expect("env should survive round trip");
+    assert_eq!(env.get("GRAM_HOST").unwrap(), "localhost");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Add a top-level \`[env]\` table to \`pitchfork.toml\` that applies default environment variables to all daemons. Per-daemon \`env\` still wins on key conflicts. Values support Tera templates, and the rendered env is injected back into the template context so other fields can reference it via \`{{ env.X }}\`.

```toml
[env]
GRAM_HOST = "localhost"
GRAM_SITE_URL = "https://{{ daemons.site.slug }}.{{ settings.proxy.tld }}"
GRAM_API_URL = "http://localhost:{{ daemons.api.port }}"

[daemons.site]
run = "pnpm dev"
port = 5173

[daemons.api]
run = "go run ./cmd/api"
env = { GRAM_HOST = "0.0.0.0" }   # per-daemon still wins
```

## How it works

Rendering happens in two phases to keep the semantics predictable and avoid self-reference cycles:

1. **Phase 1 (render env values):** top-level \`env\` is merged into each daemon's \`env\` (per-daemon wins), then env values are rendered. At this point \`env\` is **not** in scope, so an env value cannot reference \`{{ env.* }}\` (which would otherwise cycle). It can still reference \`{{ daemons.* }}\`, \`{{ settings.* }}\`, \`{{ name }}\`, etc.
2. **Phase 2 (expose env):** the rendered env is inserted into the Tera context, so the remaining fields (\`run\`, \`hooks\`, \`ready_*\`) can reference \`{{ env.GRAM_HOST }}\` with the final value.

Hooks are re-rendered at fire time via \`render_hook_template\`, which now also merges + renders env and exposes it in the context, so hook commands can use \`{{ env.X }}\` too.

## Changes

- \`src/pitchfork_toml.rs\`: new \`env\` field on \`PitchforkToml\` and \`PitchforkTomlRaw\`; merged across config files (later overrides earlier); preserved on write/read round-trip.
- \`src/template.rs\`: \`render_daemon_templates\` gains a \`top_env\` param; two-phase render; \`TemplateContext::set_env()\` exposes rendered env; \`render_env()\` helper for hook-time rendering; \`merge_env()\` helper (per-daemon wins).
- \`src/ipc/batch.rs\`: pass \`pt.env\` into \`render_daemon_templates\`.
- \`src/supervisor/hooks.rs\`: \`render_hook_template\` merges + renders env and sets it on the context.
- \`docs/public/schema.json\`: regenerated to include the new \`env\` property.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --lib\` (203 passed)
- [x] \`cargo test --test test_pitchfork_toml\` (79 passed)
- [x] New unit tests: top-level env merged as defaults (per-daemon wins), \`{{ env.X }}\` exposed for \`run\`, env values cannot self-reference.
- [x] New integration tests: top-level env parsed, merges across files (later wins), write/read round-trip preserved.

*This PR description was generated by Claude Code.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level `[env]` section to define global environment variables for all daemons.
  * Per-daemon `[env]` overrides global defaults on key conflicts.
  * Global env values can be template-rendered and used by later configuration fields.
  * Global env settings are preserved across reading, merging, and writing configuration files.
* **Tests**
  * Added coverage for parsing, merging, persistence, rendering, and precedence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->