### PR TITLE
chore(deps): hold typescript below v7 until vue-tsc supports tsgo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>jdx/renovate-config"]
+  "extends": ["local>jdx/renovate-config"],
+  "packageRules": [
+    {
+      "description": "Hold TypeScript at <7 until vue-tsc supports the TS7 native compiler (tsgo); tracked by vuejs/language-tools#5381, expected with TS 7.1",
+      "matchPackageNames": ["typescript"],
+      "matchFileNames": ["ui/package.json"],
+      "allowedVersions": "<7"
+    }
+  ]
 }


### PR DESCRIPTION
## What

Adds a Renovate `packageRules` entry pinning `ui`'s `typescript` to `<7`.

## Why

TypeScript 7 ships the new Go-native compiler (`tsgo`), which no longer exposes the programmatic `typescript/lib/tsc` API that `vue-tsc`/Volar import to type-check `.vue` files. This broke the `build:ui` step with:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/tsc' is not defined
by "exports" in .../node_modules/typescript/package.json
    at Object.run (.../vue-tsc/index.js:40:32)
```

The whole Vue ecosystem is waiting on the stable programmatic API returning in **TS 7.1** before `vue-tsc` can support `tsgo` (tracked in [vuejs/language-tools#5381](https://github.com/vuejs/language-tools/issues/5381)). TS 6 is the correct ceiling until then.

Closes #613 (the failed TS7 bump). Renovate will re-raise the upgrade once the `<7` constraint is lifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes Renovate configuration for the UI package’s TypeScript version ceiling; no runtime, auth, or application logic is modified.
> 
> **Overview**
> Adds a Renovate **`packageRules`** entry so dependency updates for **`typescript`** in **`ui/package.json`** are limited to **`allowedVersions`: `<7`**.
> 
> This blocks automated bumps to TypeScript 7, which breaks **`build:ui`** because **`vue-tsc`** still relies on the removed **`typescript/lib/tsc`** API under TS 7’s **`tsgo`** compiler; the rule documents tracking via **vuejs/language-tools#5381** and an expected fix around **TS 7.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38e16b9d69069b130f5aa1974d73489dc43e59c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->