### PR TITLE
test: retry flaky timing-sensitive e2e tests on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,14 @@ jobs:
         env:
           SHARD: ${{ matrix.shard }}
           SHARD_COUNT: 4
+          # Windows runners have slow, highly variable process/bash startup, which
+          # makes the timing-sensitive e2e assertions (ready-delay windows, elapsed
+          # bounds) flaky. Retry each failed test a couple of times so transient
+          # timing slips don't red the build; genuine failures still fail 3x.
+          # Consumed by _common_setup, which sets bats' BATS_TEST_RETRIES from it
+          # (bats resets BATS_TEST_RETRIES to 0 per file, so the env var alone
+          # would be ignored).
+          PITCHFORK_TEST_RETRIES: 2
         run: |
           export PATH="$PWD/target/debug:$PATH"
           tests=$(ls -1 test/*.bats | sort | awk -v t="$SHARD" -v n="$SHARD_COUNT" 'NR % n == t')

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -58,6 +58,14 @@ _common_setup() {
   # Verbose logging for easier debugging
   export PITCHFORK_LOG=debug
 
+  # Retry flaky tests when the runner asks for it. Windows CI sets
+  # PITCHFORK_TEST_RETRIES because slow, highly variable process/bash startup
+  # there makes the timing-sensitive assertions (ready-delay windows, elapsed
+  # bounds) flaky. bats hardcodes BATS_TEST_RETRIES=0 per test file, so it must
+  # be (re)set here in setup rather than via the environment, which gets
+  # clobbered. Defaults to 0 (no retries) on Linux so real regressions surface.
+  export BATS_TEST_RETRIES="${PITCHFORK_TEST_RETRIES:-0}"
+
   # Work inside the temp dir so pitchfork.toml is discovered there
   cd "$TEST_TEMP_DIR" || return 1
 


### PR DESCRIPTION
## Why

The Windows `bats-tests` job fails intermittently across **many** PRs and on `main`. It's not one bug — different timing-sensitive e2e tests trip on different runs, and the same test passes elsewhere:

| Run | Failed test |
|-----|-------------|
| `renovate/xx` | `not ok 1 instant fail task fails start command quickly` |
| `push main` | `not ok 48 retry with ready_output re-checks on each attempt` |
| `renovate/ratatui` | `not ok 7 wait command waits for daemon to exit` |

## Root cause

Windows runners have slow, highly variable process/`bash` (Git-bash/msys) **cold-start latency**. The affected tests assert tight timing margins around the ~3s ready boundary. Example from `basic.bats` "instant fail…":

```
18:07:27 started daemon instant_fail (bash fail.sh 0, ready_delay=3)
18:07:30 daemon ready: delay elapsed        ← 3s ready-delay elapsed → start returns SUCCESS
18:07:31 daemon exited with status exit code 1   ← process only now exits (after ~4s of bash startup)
```

The test expects `pitchfork start` to **fail** (the process dies before ready), but bash took ~4s to even begin, so the 3s ready-delay won the race and `start` reported success. Every test with a ~1s margin around that boundary is a coin-flip on Windows.

## Fix

Enable bats per-test retries on the Windows job. A transient timing slip is retried instead of reddening the build; a genuine failure still fails all 3 attempts. Linux keeps 0 retries, so real regressions there surface immediately.

- `bats` hardcodes `BATS_TEST_RETRIES=0` at the start of each test file, so setting it via the environment alone is ignored. Instead the workflow sets `PITCHFORK_TEST_RETRIES=2`, and `_common_setup` (which runs in `setup`, after the reset) applies it to `BATS_TEST_RETRIES`.
- Verified the wiring locally: with `PITCHFORK_TEST_RETRIES=2` a test that only passes on its 3rd attempt goes green; with `0` it fails.
- This is the same approach bats' own suite uses for flaky macOS runners.

## Notes

- Scoped to Windows only — no masking of Linux flakiness.
- Independent of #626 (which gates `final` on these jobs); if #626 merges first, the workflow hunk rebases onto `ci.yml`.
- A follow-up could widen the timing margins in the affected tests to remove the flakiness at the source, but retries reliably de-flake the required gate now.

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only test harness wiring with no runtime or Linux test behavior change.
> 
> **Overview**
> Reduces intermittent **Windows** `bats-tests` failures caused by slow, variable Git Bash/process startup racing timing-sensitive assertions (ready-delay windows, elapsed bounds).
> 
> The **Windows** `bats-tests` job now sets **`PITCHFORK_TEST_RETRIES=2`** (up to three attempts per test). **`_common_setup`** copies that into **`BATS_TEST_RETRIES`** during each test’s `setup`, because bats resets retries at the start of every file so the env var alone would not apply. Linux **`ci-bats`** leaves the default **0** retries.
> 
> No product or test assertion logic changes—only CI resilience for the Windows e2e gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304ca1d09e7610a50461da452b99e994260b5dd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->