### PR TITLE
chore: regenerate aube-lock.yaml on renovate branches

### DIFF
--- a/.github/workflows/aube-lock.yml
+++ b/.github/workflows/aube-lock.yml
@@ -1,0 +1,20 @@
+name: aube-lock
+
+# Regenerates aube-lock.yaml on Renovate branches. Renovate's npm manager
+# updates package.json but has no aube support, leaving the lockfile stale
+# and breaking `aube install --frozen-lockfile` in CI. See
+# jdx/renovate-config for the workflow implementation.
+
+on:
+  push:
+    branches: ["renovate/**"]
+
+permissions:
+  contents: write
+
+jobs:
+  aube-lock:
+    uses: jdx/renovate-config/.github/workflows/aube-lock.yml@d619510c737e7ebf8a8ad25f8268120bf01f4976 # main
+    secrets:
+      AUBE_LOCK_APP_ID: ${{ secrets.AUBE_LOCK_APP_ID }}
+      AUBE_LOCK_APP_PRIVATE_KEY: ${{ secrets.AUBE_LOCK_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

Renovate has no native aube manager: its npm manager updates `package.json` but leaves `aube-lock.yaml` stale, so `aube install --frozen-lockfile` in CI fails on JS dependency bumps.

## Fix

Add a caller for the shared `aube-lock` reusable workflow ([jdx/renovate-config](https://github.com/jdx/renovate-config)). On pushes to `renovate/**` branches (gated to renovate[bot]), it runs `aube install --no-frozen-lockfile` and commits the regenerated `aube-lock.yaml` back. Pinned to the merged renovate-config SHA `d619510`.

Requires repo secrets `AUBE_LOCK_APP_ID` / `AUBE_LOCK_APP_PRIVATE_KEY` (GitHub App, `contents: write`) for the fix push to retrigger CI; without them it falls back to `GITHUB_TOKEN` (lockfile still fixed, checks need a manual re-run).

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation with no runtime or application code changes; risk is limited to workflow permissions and optional GitHub App secrets for lockfile commits.
> 
> **Overview**
> Adds **`.github/workflows/aube-lock.yml`**, which runs on pushes to `renovate/**` and delegates to the pinned reusable workflow in `jdx/renovate-config`. That job refreshes **`aube-lock.yaml`** after Renovate updates **`package.json`** via npm, so CI steps that run **`aube install`** (with a frozen lockfile) no longer fail on dependency bump PRs.
> 
> The caller grants **`contents: write`** and passes optional **`AUBE_LOCK_APP_*`** secrets so the bot can commit the lockfile and retrigger checks; without those secrets the shared workflow can still commit using **`GITHUB_TOKEN`** with a possible manual re-run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77917bd9dd770548961ee486434ea5699f6bb36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->