### PR TITLE
fix(deps): make supportedArchitectures explicit for portable lockfile

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,15 +12,14 @@
   "pnpm": {
     "supportedArchitectures": {
       "os": [
-        "current",
-        "linux"
+        "linux",
+        "darwin"
       ],
       "cpu": [
-        "current",
-        "x64"
+        "x64",
+        "arm64"
       ],
       "libc": [
-        "current",
         "glibc"
       ]
     },


### PR DESCRIPTION
## Why

The shared `aube-lock` workflow regenerates `docs/aube-lock.yaml` on `renovate/**` branches, running on `ubuntu-latest`. With `supportedArchitectures` set to `"current"`, an ubuntu regen produces a **linux-only** lockfile, stripping the `rollup`/`esbuild` **darwin-arm64** binaries that macOS CI (`docs:build`) needs.

List `os`/`cpu` explicitly (`linux`+`darwin`, `x64`+`arm64`) so the lockfile stays platform-complete regardless of where it's generated. The committed lockfile already contains all platforms, so no regeneration is required — the frozen check passes as-is.

Same fix as [jdx/hk#1095](https://github.com/jdx/hk/pull/1095); discovered while rolling out the aube-lock workflow.

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only pnpm config change with no runtime or security impact; lockfile content is unchanged per PR description.
> 
> **Overview**
> Updates **`docs/package.json`** so pnpm **`supportedArchitectures`** no longer uses **`"current"`** for OS/CPU. It now pins **`linux`** and **`darwin`**, **`x64`** and **`arm64`**, and keeps **`glibc`** only under **`libc`**.
> 
> This keeps **`docs/aube-lock.yaml`** complete when the shared **aube-lock** workflow regenerates it on **ubuntu-latest**, so **darwin-arm64** **rollup**/**esbuild** binaries are not dropped and **macOS** **`docs:build`** CI still resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 589bbb0df58d9cee94ea7eed3b7ac2c9825d73b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->