### PR TITLE
fix(supervisor): verify process identity before killing orphaned daemons

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -757,12 +757,16 @@ description = "Kill orphaned daemon processes when supervisor starts"
 docs = """
 When enabled, the supervisor scans the state file on startup for daemon
 processes left behind by a previous supervisor instance that was killed
-unexpectedly (for example, with `kill -9`). Any matching live processes are
-terminated so the new supervisor starts with a clean slate.
+unexpectedly (for example, with `kill -9`). On supported platforms, matching
+live processes are terminated so the new supervisor starts with a clean slate.
 
 Before terminating, the recorded process identity (PID plus kernel start
-time) is verified so that a PID recycled by the OS to an unrelated process
-is never killed — in that case only the stale state entry is cleared.
+time) is verified. Linux and Windows also pin that identity with a pidfd or
+open process handle while terminating, so a recycled PID cannot target an
+unrelated process. On Unix platforms without durable process handles, cleanup
+fails closed: the live process and its running state are retained rather than
+risk signaling a recycled process group or allowing a duplicate instance to
+start.
 
 This is recommended for local development where an unclean shutdown (IDE
 restart, system crash, etc.) would otherwise leave stale processes holding

--- a/settings.toml
+++ b/settings.toml
@@ -760,6 +760,10 @@ processes left behind by a previous supervisor instance that was killed
 unexpectedly (for example, with `kill -9`). Any matching live processes are
 terminated so the new supervisor starts with a clean slate.
 
+Before terminating, the recorded process identity (PID plus kernel start
+time) is verified so that a PID recycled by the OS to an unrelated process
+is never killed — in that case only the stale state entry is cleared.
+
 This is recommended for local development where an unclean shutdown (IDE
 restart, system crash, etc.) would otherwise leave stale processes holding
 ports and consuming resources.

--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -141,10 +141,11 @@ impl ListCmd {
             return print_json(&entries);
         }
         for (key, info) in meta.iter() {
-            if let Some(ref group) = self.group {
-                if !key.starts_with(&format!("{group}.")) && key != group {
-                    continue;
-                }
+            if let Some(ref group) = self.group
+                && !key.starts_with(&format!("{group}."))
+                && key != group
+            {
+                continue;
             }
             let default = info.default_value.unwrap_or("(none)");
             let env_hint = info.env_var.map(|e| format!(" [{e}]")).unwrap_or_default();

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -603,10 +603,10 @@ impl<'de> Deserialize<'de> for ReadyPort {
                         "ready_port object must have either 'port' or 'template'",
                     ));
                 }
-                if let Some(port) = raw.port {
-                    if port == 0 {
-                        return Err(serde::de::Error::custom("port must be between 1 and 65535"));
-                    }
+                if let Some(port) = raw.port
+                    && port == 0
+                {
+                    return Err(serde::de::Error::custom("port must be between 1 and 65535"));
                 }
                 let timeout = parse_timeout(&raw.timeout).map_err(serde::de::Error::custom)?;
                 Ok(ReadyPort {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -39,10 +39,10 @@ pub struct Daemon {
     pub id: DaemonId,
     pub title: Option<String>,
     pub pid: Option<u32>,
-    /// Kernel start time of the process (seconds since epoch), recorded at
-    /// spawn. Together with `pid` this identifies the process across a
-    /// supervisor crash: a recycled PID has a different start time, so orphan
-    /// cleanup can tell a genuine orphan from an unrelated process.
+    /// High-resolution kernel start token recorded at spawn. Together with
+    /// `pid` this identifies the process across a supervisor crash: a recycled
+    /// PID has a different token, so orphan cleanup can tell a genuine orphan
+    /// from an unrelated process.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub start_time: Option<u64>,
     pub shell_pid: Option<u32>,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -39,6 +39,12 @@ pub struct Daemon {
     pub id: DaemonId,
     pub title: Option<String>,
     pub pid: Option<u32>,
+    /// Kernel start time of the process (seconds since epoch), recorded at
+    /// spawn. Together with `pid` this identifies the process across a
+    /// supervisor crash: a recycled PID has a different start time, so orphan
+    /// cleanup can tell a genuine orphan from an unrelated process.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub start_time: Option<u64>,
     pub shell_pid: Option<u32>,
     pub status: DaemonStatus,
     pub dir: Option<PathBuf>,

--- a/src/env.rs
+++ b/src/env.rs
@@ -26,12 +26,11 @@ pub static HOME_DIR: Lazy<PathBuf> = Lazy::new(|| {
     // actually running as root). SUDO_USER can leak into non-sudo environments
     // (e.g. inherited env, containers) and would misdirect all state paths.
     #[cfg(unix)]
-    if nix::unistd::Uid::effective().is_root() {
-        if let Ok(sudo_user) = std::env::var("SUDO_USER") {
-            if let Some(home) = home_dir_for_user(&sudo_user) {
-                return home;
-            }
-        }
+    if nix::unistd::Uid::effective().is_root()
+        && let Ok(sudo_user) = std::env::var("SUDO_USER")
+        && let Some(home) = home_dir_for_user(&sudo_user)
+    {
+        return home;
     }
     dirs::home_dir().unwrap_or_else(|| {
         eprintln!("Warning: Could not determine home directory");

--- a/src/log_parse.rs
+++ b/src/log_parse.rs
@@ -236,10 +236,10 @@ fn unescape_logfmt_value(s: &str) -> String {
 /// (pino/syslog style). See `normalize_level_value` for the mapping.
 fn extract_level(obj: &Map<String, Value>) -> Option<String> {
     for key in &["level", "severity", "lvl", "PRIORITY", "@level"] {
-        if let Some(val) = obj.get(*key) {
-            if let Some(level) = normalize_level_value(val) {
-                return Some(level);
-            }
+        if let Some(val) = obj.get(*key)
+            && let Some(level) = normalize_level_value(val)
+        {
+            return Some(level);
         }
     }
     None

--- a/src/log_store/sqlite.rs
+++ b/src/log_store/sqlite.rs
@@ -230,10 +230,10 @@ impl SqliteLogStore {
                 // individual writeln! has touched the underlying pipe yet, so
                 // without this flush the failure would be lost and the entries
                 // deleted without ever being delivered to the hook.
-                if result.is_ok() {
-                    if let Err(e) = stdin.flush() {
-                        result = Err(miette::miette!("failed to flush archive hook stdin: {e}"));
-                    }
+                if result.is_ok()
+                    && let Err(e) = stdin.flush()
+                {
+                    result = Err(miette::miette!("failed to flush archive hook stdin: {e}"));
                 }
                 result
                 // BufWriter + ChildStdin drop here, closing stdin (EOF signal).
@@ -489,13 +489,13 @@ impl SqliteLogStore {
             total_migrated += self.insert_batch(daemon_id, &entries)?;
         }
 
-        if total_migrated > 0 {
-            if let Err(e) = std::fs::remove_file(&text_path) {
-                log::warn!(
-                    "failed to remove legacy log file after migration {}: {e}",
-                    text_path.display()
-                );
-            }
+        if total_migrated > 0
+            && let Err(e) = std::fs::remove_file(&text_path)
+        {
+            log::warn!(
+                "failed to remove legacy log file after migration {}: {e}",
+                text_path.display()
+            );
         }
 
         Ok(total_migrated)
@@ -763,10 +763,10 @@ impl SqliteLogStore {
             }
         }
 
-        if let Some(limit) = opts.limit {
-            if merged.len() > limit {
-                merged.truncate(limit);
-            }
+        if let Some(limit) = opts.limit
+            && merged.len() > limit
+        {
+            merged.truncate(limit);
         }
 
         Ok(merged)
@@ -886,12 +886,13 @@ impl LogStore for SqliteLogStore {
 
     fn query(&self, opts: &LogQuery) -> Result<Vec<LogEntry>> {
         // Delegate to parallel path for large single-daemon queries.
-        if Self::should_parallelize(opts) && self.path.as_os_str() != ":memory:" {
-            if let Ok(entries) = self.query_parallel(opts) {
-                return Ok(entries);
-            }
-            // Fall back to single-threaded on parallel failure.
+        if Self::should_parallelize(opts)
+            && self.path.as_os_str() != ":memory:"
+            && let Ok(entries) = self.query_parallel(opts)
+        {
+            return Ok(entries);
         }
+        // Fall back to single-threaded on parallel failure.
 
         // Single-threaded path.
         let conn = self.conn.lock().unwrap();

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -461,29 +461,29 @@ impl PitchforkToml {
         if let Some(entry) = global_slugs.get(user_id) {
             // Load the project's config from the slug's dir to find the daemon ID
             let daemon_name = entry.daemon.as_deref().unwrap_or(user_id);
-            if let Some(dir) = entry.resolve_dir() {
-                if let Ok(project_config) = Self::all_merged_from(&dir) {
-                    // Find daemon by short name in that project
-                    let matches: Vec<DaemonId> = project_config
-                        .daemons
-                        .keys()
-                        .filter(|id| id.name() == daemon_name)
-                        .cloned()
-                        .collect();
-                    match matches.as_slice() {
-                        [] => {}
-                        [id] => return Ok(vec![id.clone()]),
-                        _ => {
-                            let mut candidates: Vec<String> =
-                                matches.iter().map(|id| id.qualified()).collect();
-                            candidates.sort();
-                            return Err(miette::miette!(
-                                "slug '{}' maps to daemon '{}' which matches multiple daemons: {}",
-                                user_id,
-                                daemon_name,
-                                candidates.join(", ")
-                            ));
-                        }
+            if let Some(dir) = entry.resolve_dir()
+                && let Ok(project_config) = Self::all_merged_from(&dir)
+            {
+                // Find daemon by short name in that project
+                let matches: Vec<DaemonId> = project_config
+                    .daemons
+                    .keys()
+                    .filter(|id| id.name() == daemon_name)
+                    .cloned()
+                    .collect();
+                match matches.as_slice() {
+                    [] => {}
+                    [id] => return Ok(vec![id.clone()]),
+                    _ => {
+                        let mut candidates: Vec<String> =
+                            matches.iter().map(|id| id.qualified()).collect();
+                        candidates.sort();
+                        return Err(miette::miette!(
+                            "slug '{}' maps to daemon '{}' which matches multiple daemons: {}",
+                            user_id,
+                            daemon_name,
+                            candidates.join(", ")
+                        ));
                     }
                 }
             }
@@ -590,28 +590,28 @@ impl PitchforkToml {
         let global_slugs = Self::read_global_slugs();
         if let Some(entry) = global_slugs.get(user_id) {
             let daemon_name = entry.daemon.as_deref().unwrap_or(user_id);
-            if let Some(dir) = entry.resolve_dir() {
-                if let Ok(project_config) = Self::all_merged_from(&dir) {
-                    let matches: Vec<DaemonId> = project_config
-                        .daemons
-                        .keys()
-                        .filter(|id| id.name() == daemon_name)
-                        .cloned()
-                        .collect();
-                    match matches.as_slice() {
-                        [] => {}
-                        [id] => return Ok(id.clone()),
-                        _ => {
-                            let mut candidates: Vec<String> =
-                                matches.iter().map(|id| id.qualified()).collect();
-                            candidates.sort();
-                            return Err(miette::miette!(
-                                "slug '{}' maps to daemon '{}' which matches multiple daemons: {}",
-                                user_id,
-                                daemon_name,
-                                candidates.join(", ")
-                            ));
-                        }
+            if let Some(dir) = entry.resolve_dir()
+                && let Ok(project_config) = Self::all_merged_from(&dir)
+            {
+                let matches: Vec<DaemonId> = project_config
+                    .daemons
+                    .keys()
+                    .filter(|id| id.name() == daemon_name)
+                    .cloned()
+                    .collect();
+                match matches.as_slice() {
+                    [] => {}
+                    [id] => return Ok(id.clone()),
+                    _ => {
+                        let mut candidates: Vec<String> =
+                            matches.iter().map(|id| id.qualified()).collect();
+                        candidates.sort();
+                        return Err(miette::miette!(
+                            "slug '{}' maps to daemon '{}' which matches multiple daemons: {}",
+                            user_id,
+                            daemon_name,
+                            candidates.join(", ")
+                        ));
                     }
                 }
             }
@@ -1456,17 +1456,17 @@ impl PitchforkToml {
         // If caller provided a namespace that isn't yet registered,
         // auto-register it at the directory we can resolve.
         // Falls back to CWD if the slug dir cannot be resolved.
-        if let Some(ns) = namespace {
-            if !pt.namespaces.contains_key(ns) {
-                let dir = pt
-                    .slugs
-                    .get(slug)
-                    .and_then(|e| e.resolve_dir())
-                    .or_else(|| namespace.and_then(|_| env::CWD.as_path().canonicalize().ok()));
-                if let Some(ref d) = dir {
-                    pt.namespaces
-                        .insert(ns.to_string(), NamespaceEntry { dir: d.clone() });
-                }
+        if let Some(ns) = namespace
+            && !pt.namespaces.contains_key(ns)
+        {
+            let dir = pt
+                .slugs
+                .get(slug)
+                .and_then(|e| e.resolve_dir())
+                .or_else(|| namespace.and_then(|_| env::CWD.as_path().canonicalize().ok()));
+            if let Some(ref d) = dir {
+                pt.namespaces
+                    .insert(ns.to_string(), NamespaceEntry { dir: d.clone() });
             }
         }
 

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -153,7 +153,25 @@ impl Procs {
         stop_timeout: Option<std::time::Duration>,
     ) -> Result<bool> {
         tokio::task::spawn_blocking(move || {
-            PROCS.kill_process_group(pid, stop_signal, stop_timeout)
+            PROCS.kill_process_group(pid, stop_signal, stop_timeout, None)
+        })
+        .await
+        .into_diagnostic()?
+    }
+
+    /// Kill a process group only while its leader still has `expected_start_time`.
+    ///
+    /// Identity is refreshed inside the blocking kill operation, immediately
+    /// before signaling, and checked again before escalation to SIGKILL.
+    pub async fn kill_process_group_if_start_time_matches_async(
+        &self,
+        pid: u32,
+        expected_start_time: u64,
+        stop_signal: i32,
+        stop_timeout: Option<std::time::Duration>,
+    ) -> Result<bool> {
+        tokio::task::spawn_blocking(move || {
+            PROCS.kill_process_group(pid, stop_signal, stop_timeout, Some(expected_start_time))
         })
         .await
         .into_diagnostic()?
@@ -173,9 +191,18 @@ impl Procs {
         pid: u32,
         stop_signal: i32,
         stop_timeout: Option<std::time::Duration>,
+        expected_start_time: Option<u64>,
     ) -> Result<bool> {
         let pgid = pid as i32;
         let signal_name = signal_name(stop_signal);
+
+        if let Some(expected) = expected_start_time {
+            self.refresh_pids(&[pid]);
+            if self.start_time(pid) != Some(expected) {
+                debug!("process group {pgid} leader identity changed before {signal_name}");
+                return Ok(false);
+            }
+        }
 
         debug!("killing process group {pgid} with {signal_name}");
 
@@ -219,8 +246,22 @@ impl Procs {
             std::thread::sleep(sleep_duration);
             self.refresh_pids(&[pid]);
             elapsed_ms += sleep_duration.as_millis() as u64;
+            if let Some(expected) = expected_start_time
+                && self.start_time(pid) != Some(expected)
+            {
+                debug!("original process group {pgid} leader exited after {signal_name}");
+                return Ok(true);
+            }
             if self.is_terminated_or_zombie(sysinfo::Pid::from_u32(pid)) {
                 debug!("process group {pgid} terminated after {signal_name} ({elapsed_ms} ms)",);
+                return Ok(true);
+            }
+        }
+
+        if let Some(expected) = expected_start_time {
+            self.refresh_pids(&[pid]);
+            if self.start_time(pid) != Some(expected) {
+                debug!("original process group {pgid} leader exited before SIGKILL");
                 return Ok(true);
             }
         }
@@ -249,6 +290,7 @@ impl Procs {
         pid: u32,
         _stop_signal: i32,
         _stop_timeout: Option<std::time::Duration>,
+        _expected_start_time: Option<u64>,
     ) -> Result<bool> {
         self.kill(pid, 0, None)
     }
@@ -714,6 +756,46 @@ mod tests {
             let _ = unsafe { libc::killpg(pid, libc::SIGKILL) };
             let _ = self.0.wait();
         }
+    }
+
+    #[tokio::test]
+    async fn orphan_identity_checked_group_kill_rejects_mismatch() {
+        let mut command = Command::new("sleep");
+        command
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        let child = command.spawn().expect("failed to spawn test process");
+        let pid = child.id();
+        let _child = ChildGuard(child);
+
+        PROCS.refresh_pids(&[pid]);
+        let actual_start_time = PROCS
+            .start_time(pid)
+            .expect("test process should have a start time");
+
+        let killed = PROCS
+            .kill_process_group_if_start_time_matches_async(
+                pid,
+                actual_start_time.saturating_add(1),
+                libc::SIGTERM,
+                Some(Duration::from_millis(100)),
+            )
+            .await
+            .expect("identity-checked kill should not error");
+
+        assert!(!killed);
+        assert!(PROCS.is_running(pid), "mismatched process must survive");
     }
 
     #[test]

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -59,6 +59,17 @@ impl Procs {
             .map(|p| p.name().to_string_lossy().to_string())
     }
 
+    /// Kernel start time of the process in seconds since the epoch.
+    ///
+    /// Combined with the PID this forms a stable identity for the lifetime of
+    /// a process: a recycled PID always has a different start time. Requires
+    /// the process cache to be populated for `pid` (see `refresh_pids`).
+    pub fn start_time(&self, pid: u32) -> Option<u64> {
+        self.lock_system()
+            .process(sysinfo::Pid::from_u32(pid))
+            .map(|p| p.start_time())
+    }
+
     pub fn is_running(&self, pid: u32) -> bool {
         // Use kill(pid, 0) on Unix for an O(1) liveness check that does not
         // depend on the process cache being populated. This avoids the need

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -330,7 +330,9 @@ impl Procs {
                 Ok(added) => added,
                 Err(err) => {
                     let _ = signal_pidfds(&members, libc::SIGCONT, "SIGCONT");
-                    return Err(err.into());
+                    return Err(miette::miette!(
+                        "failed to scan pinned process group {pid}: {err}"
+                    ));
                 }
             };
             if added == 0 {

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -4,10 +4,18 @@ use crate::settings::settings;
 use miette::IntoDiagnostic;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
+#[cfg(target_os = "linux")]
+use std::os::fd::{FromRawFd, OwnedFd};
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 use std::sync::Mutex;
 use sysinfo::ProcessesToUpdate;
+#[cfg(windows)]
+use windows_sys::Win32::Foundation::{CloseHandle, FILETIME};
+#[cfg(windows)]
+use windows_sys::Win32::System::Threading::{
+    GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+};
 
 /// Map from parent PID to its child PIDs.
 type ParentToChildren = HashMap<u32, Vec<u32>>;
@@ -59,19 +67,16 @@ impl Procs {
             .map(|p| p.name().to_string_lossy().to_string())
     }
 
-    /// Kernel start time of the process in seconds since the epoch.
+    /// High-resolution kernel start token for the process.
     ///
-    /// Combined with the PID this forms a stable identity for the lifetime of
-    /// a process: a recycled PID always has a different start time. Requires
-    /// the process cache to be populated for `pid` (see `refresh_pids`).
+    /// Combined with the PID this forms a stable identity for the lifetime of a
+    /// process. Unlike sysinfo's seconds-since-epoch value, this preserves the
+    /// native platform resolution so same-second PID reuse cannot compare equal.
     pub fn start_time(&self, pid: u32) -> Option<u64> {
-        self.lock_system()
-            .process(sysinfo::Pid::from_u32(pid))
-            .map(|p| p.start_time())
+        process_start_token(pid)
     }
 
-    fn refresh_and_start_time_matches(&self, pid: u32, expected: u64) -> bool {
-        self.refresh_pids(&[pid]);
+    fn start_time_matches(&self, pid: u32, expected: u64) -> bool {
         self.start_time(pid) == Some(expected)
     }
 
@@ -201,8 +206,23 @@ impl Procs {
         let pgid = pid as i32;
         let signal_name = signal_name(stop_signal);
 
+        // Holding a pidfd pins the kernel PID object, so the numeric PID/PGID
+        // cannot be recycled between identity validation and killpg.
+        #[cfg(target_os = "linux")]
+        let _pidfd_guard = if expected_start_time.is_some() {
+            match open_pidfd(pid) {
+                Ok(pidfd) => Some(pidfd),
+                Err(err) => {
+                    warn!("cannot securely identify process group {pgid}: {err}");
+                    return Ok(false);
+                }
+            }
+        } else {
+            None
+        };
+
         if let Some(expected) = expected_start_time
-            && !self.refresh_and_start_time_matches(pid, expected)
+            && !self.start_time_matches(pid, expected)
         {
             debug!("process group {pgid} leader identity changed before {signal_name}");
             return Ok(false);
@@ -297,7 +317,7 @@ impl Procs {
         expected_start_time: Option<u64>,
     ) -> Result<bool> {
         if let Some(expected) = expected_start_time
-            && !self.refresh_and_start_time_matches(pid, expected)
+            && !self.start_time_matches(pid, expected)
         {
             debug!("process {pid} identity changed before taskkill");
             return Ok(false);
@@ -647,6 +667,84 @@ impl Procs {
     }
 }
 
+#[cfg(target_os = "linux")]
+fn process_start_token(pid: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let command_end = stat.rfind(')')?;
+    // Fields after the command start at field 3 (state); starttime is field 22.
+    stat.get(command_end + 1..)?
+        .split_whitespace()
+        .nth(19)?
+        .parse()
+        .ok()
+}
+
+#[cfg(target_os = "macos")]
+fn process_start_token(pid: u32) -> Option<u64> {
+    let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+    let size = std::mem::size_of::<libc::proc_bsdinfo>() as i32;
+    let read = unsafe {
+        libc::proc_pidinfo(
+            pid as i32,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            size,
+        )
+    };
+    if read != size {
+        return None;
+    }
+    let info = unsafe { info.assume_init() };
+    info.pbi_start_tvsec
+        .checked_mul(1_000_000)?
+        .checked_add(info.pbi_start_tvusec)
+}
+
+#[cfg(windows)]
+fn process_start_token(pid: u32) -> Option<u64> {
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        return None;
+    }
+
+    let mut creation = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut exit = creation;
+    let mut kernel = creation;
+    let mut user = creation;
+    let ok = unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) };
+    unsafe {
+        CloseHandle(handle);
+    }
+    if ok == 0 {
+        return None;
+    }
+
+    Some((u64::from(creation.dwHighDateTime) << 32) | u64::from(creation.dwLowDateTime))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+fn process_start_token(pid: u32) -> Option<u64> {
+    let mut system = sysinfo::System::new();
+    let sysinfo_pid = sysinfo::Pid::from_u32(pid);
+    system.refresh_processes(ProcessesToUpdate::Some(&[sysinfo_pid]), true);
+    system
+        .process(sysinfo_pid)
+        .map(|process| process.start_time())
+}
+
+#[cfg(target_os = "linux")]
+fn open_pidfd(pid: u32) -> std::io::Result<OwnedFd> {
+    let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(unsafe { OwnedFd::from_raw_fd(fd as i32) })
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ProcessStats {
     pub cpu_percent: f32,
@@ -740,7 +838,7 @@ mod format_tests {
             .start_time(pid)
             .expect("current process should have a start time");
 
-        assert!(!procs.refresh_and_start_time_matches(pid, actual.saturating_add(1)));
+        assert!(!procs.start_time_matches(pid, actual.saturating_add(1)));
     }
 
     #[test]

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -366,6 +366,7 @@ impl Procs {
         }
 
         warn!("one or more pinned processes in orphan group {pid} remained alive after SIGKILL");
+        let _ = signal_pidfds(&members, libc::SIGCONT, "SIGCONT");
         Ok(false)
     }
 

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -11,7 +11,7 @@ use std::os::windows::process::CommandExt;
 use std::sync::Mutex;
 use sysinfo::ProcessesToUpdate;
 #[cfg(windows)]
-use windows_sys::Win32::Foundation::{CloseHandle, FILETIME};
+use windows_sys::Win32::Foundation::{CloseHandle, FILETIME, HANDLE};
 #[cfg(windows)]
 use windows_sys::Win32::System::Threading::{
     GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
@@ -172,7 +172,9 @@ impl Procs {
     /// Kill a process group only while its leader still has `expected_start_time`.
     ///
     /// Identity is refreshed inside the blocking kill operation, immediately
-    /// before signaling, and checked again before escalation to SIGKILL.
+    /// before signaling. Linux holds a pidfd and Windows holds an open process
+    /// handle across termination so the validated PID cannot be recycled.
+    /// Unix platforms without a durable process handle fail closed.
     pub async fn kill_process_group_if_start_time_matches_async(
         &self,
         pid: u32,
@@ -205,6 +207,17 @@ impl Procs {
     ) -> Result<bool> {
         let pgid = pid as i32;
         let signal_name = signal_name(stop_signal);
+
+        // A start-time check alone cannot prevent the numeric PID/PGID from
+        // being recycled before killpg. Linux closes that race with a pidfd;
+        // other Unix platforms must refuse identity-checked termination.
+        #[cfg(not(target_os = "linux"))]
+        if expected_start_time.is_some() {
+            warn!(
+                "cannot securely identify process group {pgid} on this platform; refusing to signal it"
+            );
+            return Ok(false);
+        }
 
         // Holding a pidfd pins the kernel PID object, so the numeric PID/PGID
         // cannot be recycled between identity validation and killpg.
@@ -329,12 +342,34 @@ impl Procs {
         _stop_timeout: Option<std::time::Duration>,
         expected_start_time: Option<u64>,
     ) -> Result<bool> {
+        // Keep the Windows process object alive through taskkill so its
+        // numeric PID cannot be recycled after identity validation.
+        #[cfg(windows)]
+        let _identity_handle = if let Some(expected) = expected_start_time {
+            let handle = match open_process_handle(pid) {
+                Ok(handle) => handle,
+                Err(err) => {
+                    warn!("cannot securely identify process {pid}: {err}");
+                    return Ok(false);
+                }
+            };
+            if process_start_token_from_handle(handle.0) != Some(expected) {
+                debug!("process {pid} identity changed before taskkill");
+                return Ok(false);
+            }
+            Some(handle)
+        } else {
+            None
+        };
+
+        #[cfg(not(windows))]
         if let Some(expected) = expected_start_time
             && !self.start_time_matches(pid, expected)
         {
-            debug!("process {pid} identity changed before taskkill");
+            debug!("process {pid} identity changed before termination");
             return Ok(false);
         }
+
         self.kill(pid, 0, None)
     }
 
@@ -716,11 +751,12 @@ fn process_start_token(pid: u32) -> Option<u64> {
 
 #[cfg(windows)]
 fn process_start_token(pid: u32) -> Option<u64> {
-    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
-    if handle.is_null() {
-        return None;
-    }
+    let handle = open_process_handle(pid).ok()?;
+    process_start_token_from_handle(handle.0)
+}
 
+#[cfg(windows)]
+fn process_start_token_from_handle(handle: HANDLE) -> Option<u64> {
     let mut creation = FILETIME {
         dwLowDateTime: 0,
         dwHighDateTime: 0,
@@ -729,14 +765,32 @@ fn process_start_token(pid: u32) -> Option<u64> {
     let mut kernel = creation;
     let mut user = creation;
     let ok = unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) };
-    unsafe {
-        CloseHandle(handle);
-    }
     if ok == 0 {
         return None;
     }
 
     Some((u64::from(creation.dwHighDateTime) << 32) | u64::from(creation.dwLowDateTime))
+}
+
+#[cfg(windows)]
+struct ProcessHandle(HANDLE);
+
+#[cfg(windows)]
+impl Drop for ProcessHandle {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn open_process_handle(pid: u32) -> std::io::Result<ProcessHandle> {
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(ProcessHandle(handle))
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
@@ -937,6 +991,50 @@ mod tests {
 
         assert!(!killed);
         assert!(PROCS.is_running(pid), "mismatched process must survive");
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[tokio::test]
+    async fn orphan_identity_checked_group_kill_fails_closed_without_pidfd() {
+        let mut command = Command::new("sleep");
+        command
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        let child = command.spawn().expect("failed to spawn test process");
+        let pid = child.id();
+        let _child = ChildGuard(child);
+
+        PROCS.refresh_pids(&[pid]);
+        let actual_start_time = PROCS
+            .start_time(pid)
+            .expect("test process should have a start time");
+
+        let killed = PROCS
+            .kill_process_group_if_start_time_matches_async(
+                pid,
+                actual_start_time,
+                libc::SIGTERM,
+                Some(Duration::from_millis(100)),
+            )
+            .await
+            .expect("identity-checked kill should not error");
+
+        assert!(!killed);
+        assert!(
+            PROCS.is_running(pid),
+            "process must survive when identity cannot be pinned"
+        );
     }
 
     #[test]

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -70,6 +70,11 @@ impl Procs {
             .map(|p| p.start_time())
     }
 
+    fn refresh_and_start_time_matches(&self, pid: u32, expected: u64) -> bool {
+        self.refresh_pids(&[pid]);
+        self.start_time(pid) == Some(expected)
+    }
+
     pub fn is_running(&self, pid: u32) -> bool {
         // Use kill(pid, 0) on Unix for an O(1) liveness check that does not
         // depend on the process cache being populated. This avoids the need
@@ -196,12 +201,11 @@ impl Procs {
         let pgid = pid as i32;
         let signal_name = signal_name(stop_signal);
 
-        if let Some(expected) = expected_start_time {
-            self.refresh_pids(&[pid]);
-            if self.start_time(pid) != Some(expected) {
-                debug!("process group {pgid} leader identity changed before {signal_name}");
-                return Ok(false);
-            }
+        if let Some(expected) = expected_start_time
+            && !self.refresh_and_start_time_matches(pid, expected)
+        {
+            debug!("process group {pgid} leader identity changed before {signal_name}");
+            return Ok(false);
         }
 
         debug!("killing process group {pgid} with {signal_name}");
@@ -290,8 +294,14 @@ impl Procs {
         pid: u32,
         _stop_signal: i32,
         _stop_timeout: Option<std::time::Duration>,
-        _expected_start_time: Option<u64>,
+        expected_start_time: Option<u64>,
     ) -> Result<bool> {
+        if let Some(expected) = expected_start_time
+            && !self.refresh_and_start_time_matches(pid, expected)
+        {
+            debug!("process {pid} identity changed before taskkill");
+            return Ok(false);
+        }
         self.kill(pid, 0, None)
     }
 
@@ -720,6 +730,18 @@ fn signal_name(sig: i32) -> &'static str {
 #[cfg(test)]
 mod format_tests {
     use super::*;
+
+    #[test]
+    fn process_start_time_check_rejects_mismatch() {
+        let procs = Procs::new();
+        let pid = std::process::id();
+        procs.refresh_pids(&[pid]);
+        let actual = procs
+            .start_time(pid)
+            .expect("current process should have a start time");
+
+        assert!(!procs.refresh_and_start_time_matches(pid, actual.saturating_add(1)));
+    }
 
     #[test]
     fn test_format_bytes() {

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -296,8 +296,8 @@ impl Procs {
         &self,
         pid: u32,
         expected_start_time: u64,
-        stop_signal: i32,
-        stop_timeout: Option<std::time::Duration>,
+        _stop_signal: i32,
+        _stop_timeout: Option<std::time::Duration>,
     ) -> Result<bool> {
         let leader = match open_pidfd(pid) {
             Ok(pidfd) => pidfd,
@@ -312,62 +312,38 @@ impl Procs {
         }
 
         let mut members = vec![(pid, leader)];
-        extend_process_group_pidfds(pid as i32, &mut members);
-
-        // Candidate membership was read through numeric PIDs. Only use those
-        // handles if the validated leader remained alive for the full scan, so
-        // the numeric process-group ID could not have been recycled.
+        if let Err(err) = stop_pidfds(&members) {
+            let _ = signal_pidfds(&members, libc::SIGCONT, "SIGCONT");
+            return Err(err);
+        }
         if !pidfd_is_running(&members[0].1) {
-            debug!("process group {pid} leader exited before signaling");
+            debug!("process group {pid} leader exited before it could be frozen");
             return Ok(false);
         }
 
-        let signal_name = signal_name(stop_signal);
-        debug!(
-            "killing {} pinned process(es) in group {pid} with {signal_name}",
-            members.len()
-        );
-        signal_pidfds(&members, stop_signal, signal_name)?;
-
-        let stop_timeout = stop_timeout.unwrap_or_else(|| settings().supervisor_stop_timeout());
-        let fast_ms = 10u64;
-        let slow_ms = 50u64;
-        let total_ms = stop_timeout.as_millis().max(1) as u64;
-        let fast_count = ((total_ms / fast_ms) as usize).min(10);
-        let fast_total_ms = fast_ms * fast_count as u64;
-        let remaining_ms = total_ms.saturating_sub(fast_total_ms);
-        let slow_count = (remaining_ms / slow_ms) as usize;
-        let fast_checks =
-            std::iter::repeat_n(std::time::Duration::from_millis(fast_ms), fast_count);
-        let slow_checks =
-            std::iter::repeat_n(std::time::Duration::from_millis(slow_ms), slow_count);
-        let mut elapsed_ms = 0u64;
-
-        for sleep_duration in fast_checks.chain(slow_checks) {
-            std::thread::sleep(sleep_duration);
-            elapsed_ms += sleep_duration.as_millis() as u64;
-            if members.iter().all(|(_, fd)| !pidfd_is_running(fd)) {
-                debug!("process group {pid} terminated after {signal_name} ({elapsed_ms} ms)");
-                return Ok(true);
+        // Stop newly discovered members before rescanning. Once a scan adds
+        // nothing, every process capable of forking into this group is frozen,
+        // so the pinned set is complete and the PGID cannot be recycled.
+        loop {
+            let known_members = members.len();
+            extend_process_group_pidfds(pid as i32, &mut members);
+            if members.len() == known_members {
+                break;
+            }
+            if let Err(err) = stop_pidfds(&members[known_members..]) {
+                let _ = signal_pidfds(&members, libc::SIGCONT, "SIGCONT");
+                return Err(err);
             }
         }
 
-        // At least one pinned member still anchors the original group, so it
-        // is safe to discover children that appeared during graceful shutdown.
-        let anchored_members = members.len();
-        extend_process_group_pidfds(pid as i32, &mut members);
-        if members[..anchored_members]
-            .iter()
-            .all(|(_, fd)| !pidfd_is_running(fd))
-        {
-            debug!("all pinned members of process group {pid} exited before escalation");
-            return Ok(true);
-        }
         warn!(
-            "process group {pid} did not respond to {signal_name} after {}ms, sending SIGKILL",
-            stop_timeout.as_millis()
+            "force-terminating {} pinned orphan process(es) in group {pid}",
+            members.len()
         );
-        signal_pidfds(&members, libc::SIGKILL, "SIGKILL")?;
+        if let Err(err) = signal_pidfds(&members, libc::SIGKILL, "SIGKILL") {
+            let _ = signal_pidfds(&members, libc::SIGCONT, "SIGCONT");
+            return Err(err);
+        }
         std::thread::sleep(std::time::Duration::from_millis(100));
         Ok(true)
     }
@@ -898,6 +874,22 @@ fn signal_pidfds(members: &[(u32, OwnedFd)], signal: i32, signal_name: &str) -> 
 }
 
 #[cfg(target_os = "linux")]
+fn stop_pidfds(members: &[(u32, OwnedFd)]) -> Result<()> {
+    signal_pidfds(members, libc::SIGSTOP, "SIGSTOP")?;
+    for _ in 0..200 {
+        if members.iter().all(|(pid, pidfd)| {
+            !pidfd_is_running(pidfd) || matches!(linux_process_state(*pid), Some('T' | 't'))
+        }) {
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    Err(miette::miette!(
+        "timed out while freezing orphan process group"
+    ))
+}
+
+#[cfg(target_os = "linux")]
 fn extend_process_group_pidfds(pgid: i32, members: &mut Vec<(u32, OwnedFd)>) {
     let Ok(entries) = std::fs::read_dir("/proc") else {
         return;
@@ -932,6 +924,17 @@ fn linux_process_group(pid: u32) -> Option<i32> {
         .nth(2)?
         .parse()
         .ok()
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_state(pid: u32) -> Option<char> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let command_end = stat.rfind(')')?;
+    stat.get(command_end + 1..)?
+        .split_whitespace()
+        .next()?
+        .chars()
+        .next()
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -220,6 +220,10 @@ impl Procs {
         } else {
             None
         };
+        #[cfg(target_os = "linux")]
+        let identity_pinned = _pidfd_guard.is_some();
+        #[cfg(not(target_os = "linux"))]
+        let identity_pinned = false;
 
         if let Some(expected) = expected_start_time
             && !self.start_time_matches(pid, expected)
@@ -270,6 +274,13 @@ impl Procs {
             std::thread::sleep(sleep_duration);
             self.refresh_pids(&[pid]);
             elapsed_ms += sleep_duration.as_millis() as u64;
+            if identity_pinned {
+                if !process_group_is_running(pgid) {
+                    debug!("process group {pgid} terminated after {signal_name} ({elapsed_ms} ms)",);
+                    return Ok(true);
+                }
+                continue;
+            }
             if let Some(expected) = expected_start_time
                 && self.start_time(pid) != Some(expected)
             {
@@ -282,7 +293,9 @@ impl Procs {
             }
         }
 
-        if let Some(expected) = expected_start_time {
+        if let Some(expected) = expected_start_time
+            && !identity_pinned
+        {
             self.refresh_pids(&[pid]);
             if self.start_time(pid) != Some(expected) {
                 debug!("original process group {pgid} leader exited before SIGKILL");
@@ -743,6 +756,14 @@ fn open_pidfd(pid: u32) -> std::io::Result<OwnedFd> {
         return Err(std::io::Error::last_os_error());
     }
     Ok(unsafe { OwnedFd::from_raw_fd(fd as i32) })
+}
+
+#[cfg(unix)]
+fn process_group_is_running(pgid: i32) -> bool {
+    if unsafe { libc::killpg(pgid, 0) } == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -5,7 +5,7 @@ use miette::IntoDiagnostic;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 #[cfg(target_os = "linux")]
-use std::os::fd::{FromRawFd, OwnedFd};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 use std::sync::Mutex;
@@ -76,6 +76,7 @@ impl Procs {
         process_start_token(pid)
     }
 
+    #[cfg(any(target_os = "linux", windows))]
     fn start_time_matches(&self, pid: u32, expected: u64) -> bool {
         self.start_time(pid) == Some(expected)
     }
@@ -208,6 +209,11 @@ impl Procs {
         let pgid = pid as i32;
         let signal_name = signal_name(stop_signal);
 
+        #[cfg(target_os = "linux")]
+        if let Some(expected) = expected_start_time {
+            return self.kill_process_group_with_pidfds(pid, expected, stop_signal, stop_timeout);
+        }
+
         // A start-time check alone cannot prevent the numeric PID/PGID from
         // being recycled before killpg. Linux closes that race with a pidfd;
         // other Unix platforms must refuse identity-checked termination.
@@ -216,32 +222,6 @@ impl Procs {
             warn!(
                 "cannot securely identify process group {pgid} on this platform; refusing to signal it"
             );
-            return Ok(false);
-        }
-
-        // Holding a pidfd pins the kernel PID object, so the numeric PID/PGID
-        // cannot be recycled between identity validation and killpg.
-        #[cfg(target_os = "linux")]
-        let _pidfd_guard = if expected_start_time.is_some() {
-            match open_pidfd(pid) {
-                Ok(pidfd) => Some(pidfd),
-                Err(err) => {
-                    warn!("cannot securely identify process group {pgid}: {err}");
-                    return Ok(false);
-                }
-            }
-        } else {
-            None
-        };
-        #[cfg(target_os = "linux")]
-        let identity_pinned = _pidfd_guard.is_some();
-        #[cfg(not(target_os = "linux"))]
-        let identity_pinned = false;
-
-        if let Some(expected) = expected_start_time
-            && !self.start_time_matches(pid, expected)
-        {
-            debug!("process group {pgid} leader identity changed before {signal_name}");
             return Ok(false);
         }
 
@@ -287,31 +267,8 @@ impl Procs {
             std::thread::sleep(sleep_duration);
             self.refresh_pids(&[pid]);
             elapsed_ms += sleep_duration.as_millis() as u64;
-            if identity_pinned {
-                if !process_group_is_running(pgid) {
-                    debug!("process group {pgid} terminated after {signal_name} ({elapsed_ms} ms)",);
-                    return Ok(true);
-                }
-                continue;
-            }
-            if let Some(expected) = expected_start_time
-                && self.start_time(pid) != Some(expected)
-            {
-                debug!("original process group {pgid} leader exited after {signal_name}");
-                return Ok(true);
-            }
             if self.is_terminated_or_zombie(sysinfo::Pid::from_u32(pid)) {
                 debug!("process group {pgid} terminated after {signal_name} ({elapsed_ms} ms)",);
-                return Ok(true);
-            }
-        }
-
-        if let Some(expected) = expected_start_time
-            && !identity_pinned
-        {
-            self.refresh_pids(&[pid]);
-            if self.start_time(pid) != Some(expected) {
-                debug!("original process group {pgid} leader exited before SIGKILL");
                 return Ok(true);
             }
         }
@@ -330,6 +287,87 @@ impl Procs {
         }
 
         // Brief wait for SIGKILL to take effect
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        Ok(true)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn kill_process_group_with_pidfds(
+        &self,
+        pid: u32,
+        expected_start_time: u64,
+        stop_signal: i32,
+        stop_timeout: Option<std::time::Duration>,
+    ) -> Result<bool> {
+        let leader = match open_pidfd(pid) {
+            Ok(pidfd) => pidfd,
+            Err(err) => {
+                warn!("cannot securely identify process group {pid}: {err}");
+                return Ok(false);
+            }
+        };
+        if !self.start_time_matches(pid, expected_start_time) {
+            debug!("process group {pid} leader identity changed before signaling");
+            return Ok(false);
+        }
+
+        let mut members = vec![(pid, leader)];
+        extend_process_group_pidfds(pid as i32, &mut members);
+
+        // Candidate membership was read through numeric PIDs. Only use those
+        // handles if the validated leader remained alive for the full scan, so
+        // the numeric process-group ID could not have been recycled.
+        if !pidfd_is_running(&members[0].1) {
+            debug!("process group {pid} leader exited before signaling");
+            return Ok(false);
+        }
+
+        let signal_name = signal_name(stop_signal);
+        debug!(
+            "killing {} pinned process(es) in group {pid} with {signal_name}",
+            members.len()
+        );
+        signal_pidfds(&members, stop_signal, signal_name)?;
+
+        let stop_timeout = stop_timeout.unwrap_or_else(|| settings().supervisor_stop_timeout());
+        let fast_ms = 10u64;
+        let slow_ms = 50u64;
+        let total_ms = stop_timeout.as_millis().max(1) as u64;
+        let fast_count = ((total_ms / fast_ms) as usize).min(10);
+        let fast_total_ms = fast_ms * fast_count as u64;
+        let remaining_ms = total_ms.saturating_sub(fast_total_ms);
+        let slow_count = (remaining_ms / slow_ms) as usize;
+        let fast_checks =
+            std::iter::repeat_n(std::time::Duration::from_millis(fast_ms), fast_count);
+        let slow_checks =
+            std::iter::repeat_n(std::time::Duration::from_millis(slow_ms), slow_count);
+        let mut elapsed_ms = 0u64;
+
+        for sleep_duration in fast_checks.chain(slow_checks) {
+            std::thread::sleep(sleep_duration);
+            elapsed_ms += sleep_duration.as_millis() as u64;
+            if members.iter().all(|(_, fd)| !pidfd_is_running(fd)) {
+                debug!("process group {pid} terminated after {signal_name} ({elapsed_ms} ms)");
+                return Ok(true);
+            }
+        }
+
+        // At least one pinned member still anchors the original group, so it
+        // is safe to discover children that appeared during graceful shutdown.
+        let anchored_members = members.len();
+        extend_process_group_pidfds(pid as i32, &mut members);
+        if members[..anchored_members]
+            .iter()
+            .all(|(_, fd)| !pidfd_is_running(fd))
+        {
+            debug!("all pinned members of process group {pid} exited before escalation");
+            return Ok(true);
+        }
+        warn!(
+            "process group {pid} did not respond to {signal_name} after {}ms, sending SIGKILL",
+            stop_timeout.as_millis()
+        );
+        signal_pidfds(&members, libc::SIGKILL, "SIGKILL")?;
         std::thread::sleep(std::time::Duration::from_millis(100));
         Ok(true)
     }
@@ -812,12 +850,88 @@ fn open_pidfd(pid: u32) -> std::io::Result<OwnedFd> {
     Ok(unsafe { OwnedFd::from_raw_fd(fd as i32) })
 }
 
-#[cfg(unix)]
-fn process_group_is_running(pgid: i32) -> bool {
-    if unsafe { libc::killpg(pgid, 0) } == 0 {
+#[cfg(target_os = "linux")]
+fn pidfd_is_running(pidfd: &OwnedFd) -> bool {
+    let mut pollfd = libc::pollfd {
+        fd: pidfd.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let result = unsafe { libc::poll(&mut pollfd, 1, 0) };
+    if result < 0 {
+        warn!(
+            "failed to poll pidfd {}: {}",
+            pidfd.as_raw_fd(),
+            std::io::Error::last_os_error()
+        );
         return true;
     }
-    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+    result == 0
+}
+
+#[cfg(target_os = "linux")]
+fn signal_pidfds(members: &[(u32, OwnedFd)], signal: i32, signal_name: &str) -> Result<()> {
+    for (pid, pidfd) in members {
+        if !pidfd_is_running(pidfd) {
+            continue;
+        }
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                pidfd.as_raw_fd(),
+                signal,
+                std::ptr::null::<libc::siginfo_t>(),
+                0,
+            )
+        };
+        if result == -1 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::ESRCH) {
+                continue;
+            }
+            return Err(miette::miette!(
+                "failed to send {signal_name} to pinned process {pid}: {err}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn extend_process_group_pidfds(pgid: i32, members: &mut Vec<(u32, OwnedFd)>) {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if members.iter().any(|(known_pid, _)| *known_pid == pid) {
+            continue;
+        }
+        let Ok(pidfd) = open_pidfd(pid) else {
+            continue;
+        };
+        if linux_process_group(pid) == Some(pgid) {
+            members.push((pid, pidfd));
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_group(pid: u32) -> Option<i32> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let command_end = stat.rfind(')')?;
+    // Fields after the command start at field 3: state, ppid, then pgrp.
+    stat.get(command_end + 1..)?
+        .split_whitespace()
+        .nth(2)?
+        .parse()
+        .ok()
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -913,7 +1027,7 @@ mod format_tests {
             .start_time(pid)
             .expect("current process should have a start time");
 
-        assert!(!procs.start_time_matches(pid, actual.saturating_add(1)));
+        assert_ne!(procs.start_time(pid), Some(actual.saturating_add(1)));
     }
 
     #[test]

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -326,8 +326,14 @@ impl Procs {
         // so the pinned set is complete and the PGID cannot be recycled.
         loop {
             let known_members = members.len();
-            extend_process_group_pidfds(pid as i32, &mut members);
-            if members.len() == known_members {
+            let added = match extend_process_group_pidfds(pid as i32, &mut members) {
+                Ok(added) => added,
+                Err(err) => {
+                    let _ = signal_pidfds(&members, libc::SIGCONT, "SIGCONT");
+                    return Err(err);
+                }
+            };
+            if added == 0 {
                 break;
             }
             if let Err(err) = stop_pidfds(&members[known_members..]) {
@@ -828,6 +834,17 @@ fn open_pidfd(pid: u32) -> std::io::Result<OwnedFd> {
 
 #[cfg(target_os = "linux")]
 fn pidfd_is_running(pidfd: &OwnedFd) -> bool {
+    match try_pidfd_is_running(pidfd) {
+        Ok(running) => running,
+        Err(err) => {
+            warn!("failed to poll pidfd {}: {err}", pidfd.as_raw_fd());
+            true
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn try_pidfd_is_running(pidfd: &OwnedFd) -> std::io::Result<bool> {
     let mut pollfd = libc::pollfd {
         fd: pidfd.as_raw_fd(),
         events: libc::POLLIN,
@@ -835,14 +852,9 @@ fn pidfd_is_running(pidfd: &OwnedFd) -> bool {
     };
     let result = unsafe { libc::poll(&mut pollfd, 1, 0) };
     if result < 0 {
-        warn!(
-            "failed to poll pidfd {}: {}",
-            pidfd.as_raw_fd(),
-            std::io::Error::last_os_error()
-        );
-        return true;
+        return Err(std::io::Error::last_os_error());
     }
-    result == 0
+    Ok(result == 0)
 }
 
 #[cfg(target_os = "linux")]
@@ -890,11 +902,14 @@ fn stop_pidfds(members: &[(u32, OwnedFd)]) -> Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-fn extend_process_group_pidfds(pgid: i32, members: &mut Vec<(u32, OwnedFd)>) {
-    let Ok(entries) = std::fs::read_dir("/proc") else {
-        return;
-    };
-    for entry in entries.flatten() {
+fn extend_process_group_pidfds(
+    pgid: i32,
+    members: &mut Vec<(u32, OwnedFd)>,
+) -> std::io::Result<usize> {
+    let entries = std::fs::read_dir("/proc")?;
+    let mut added = 0;
+    for entry in entries {
+        let entry = entry?;
         let Some(pid) = entry
             .file_name()
             .to_str()
@@ -902,28 +917,47 @@ fn extend_process_group_pidfds(pgid: i32, members: &mut Vec<(u32, OwnedFd)>) {
         else {
             continue;
         };
-        if members.iter().any(|(known_pid, _)| *known_pid == pid) {
-            continue;
-        }
-        let Ok(pidfd) = open_pidfd(pid) else {
+        let Some(observed_identity) = linux_process_identity(pid) else {
             continue;
         };
-        if linux_process_group(pid) == Some(pgid) {
-            members.push((pid, pidfd));
+        if observed_identity.0 != pgid {
+            continue;
         }
+        let mut already_pinned = false;
+        for (known_pid, pidfd) in members.iter() {
+            if *known_pid == pid && try_pidfd_is_running(pidfd)? {
+                already_pinned = true;
+                break;
+            }
+        }
+        if already_pinned {
+            continue;
+        }
+
+        let pidfd = match open_pidfd(pid) {
+            Ok(pidfd) => pidfd,
+            Err(err) if err.raw_os_error() == Some(libc::ESRCH) => continue,
+            Err(err) => return Err(err),
+        };
+        if linux_process_identity(pid) != Some(observed_identity) {
+            return Err(std::io::Error::other(format!(
+                "process {pid} identity changed while pinning group {pgid}"
+            )));
+        }
+        members.push((pid, pidfd));
+        added += 1;
     }
+    Ok(added)
 }
 
 #[cfg(target_os = "linux")]
-fn linux_process_group(pid: u32) -> Option<i32> {
+fn linux_process_identity(pid: u32) -> Option<(i32, u64)> {
     let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
     let command_end = stat.rfind(')')?;
-    // Fields after the command start at field 3: state, ppid, then pgrp.
-    stat.get(command_end + 1..)?
-        .split_whitespace()
-        .nth(2)?
-        .parse()
-        .ok()
+    let fields: Vec<_> = stat.get(command_end + 1..)?.split_whitespace().collect();
+    // Fields after the command start at field 3. pgrp is field 5 and the
+    // scheduler-tick start token is field 22.
+    Some((fields.get(2)?.parse().ok()?, fields.get(19)?.parse().ok()?))
 }
 
 #[cfg(target_os = "linux")]

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -297,7 +297,7 @@ impl Procs {
         pid: u32,
         expected_start_time: u64,
         _stop_signal: i32,
-        _stop_timeout: Option<std::time::Duration>,
+        stop_timeout: Option<std::time::Duration>,
     ) -> Result<bool> {
         let leader = match open_pidfd(pid) {
             Ok(pidfd) => pidfd,
@@ -352,8 +352,21 @@ impl Procs {
             let _ = signal_pidfds(&members, libc::SIGCONT, "SIGCONT");
             return Err(err);
         }
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        Ok(true)
+
+        let exit_timeout = stop_timeout.unwrap_or_else(|| settings().supervisor_stop_timeout());
+        let checks = ((exit_timeout.as_millis().max(1) + 49) / 50) as usize;
+        for _ in 0..checks {
+            if members.iter().all(|(_, pidfd)| !pidfd_is_running(pidfd)) {
+                return Ok(true);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        if members.iter().all(|(_, pidfd)| !pidfd_is_running(pidfd)) {
+            return Ok(true);
+        }
+
+        warn!("one or more pinned processes in orphan group {pid} remained alive after SIGKILL");
+        Ok(false)
     }
 
     #[cfg(not(unix))]

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -330,7 +330,7 @@ impl Procs {
                 Ok(added) => added,
                 Err(err) => {
                     let _ = signal_pidfds(&members, libc::SIGCONT, "SIGCONT");
-                    return Err(err);
+                    return Err(err.into());
                 }
             };
             if added == 0 {

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -344,12 +344,11 @@ impl Supervisor {
             // the TCP readiness probe would immediately succeed and pitchfork
             // would falsely consider the daemon ready — routing proxy traffic to
             // the wrong process.
-            if let Some(port) = opts.ready_port.as_ref().and_then(|p| p.as_port()) {
-                if port > 0 {
-                    if let Some((pid, process)) = detect_port_conflict(port).await {
-                        return Ok(IpcResponse::PortConflict { port, process, pid });
-                    }
-                }
+            if let Some(port) = opts.ready_port.as_ref().and_then(|p| p.as_port())
+                && port > 0
+                && let Some((pid, process)) = detect_port_conflict(port).await
+            {
+                return Ok(IpcResponse::PortConflict { port, process, pid });
             }
             (
                 Vec::new(),
@@ -1855,11 +1854,12 @@ async fn check_ports_available(
         }
 
         // Port is in use
-        if bump_offset == 0 && !auto_bump {
-            if let Some(port) = conflicting_port {
-                let (pid, process) = identify_port_owner(port).await;
-                return Err(PortError::InUse { port, process, pid }.into());
-            }
+        if bump_offset == 0
+            && !auto_bump
+            && let Some(port) = conflicting_port
+        {
+            let (pid, process) = identify_port_owner(port).await;
+            return Err(PortError::InUse { port, process, pid }.into());
         }
     }
 
@@ -1986,10 +1986,10 @@ fn detect_and_store_active_port(id: DaemonId, pid: u32) {
 
                 // Prefer the configured expected_port if the process is actually
                 // listening on it; otherwise fall back to the first port found.
-                if let Some(ep) = expected_port {
-                    if process_ports.contains(&ep) {
-                        return Some(ep);
-                    }
+                if let Some(ep) = expected_port
+                    && process_ports.contains(&ep)
+                {
+                    return Some(ep);
                 }
 
                 // No expected_port match — return the first port in the list.

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1302,6 +1302,13 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
         );
 
         if !matches {
+            if daemon.start_time.is_some() && current_start_time.is_none() {
+                warn!(
+                    "could not verify start time for live pid {pid} recorded for daemon {}; retaining running state",
+                    daemon.id,
+                );
+                continue;
+            }
             warn!(
                 "pid {pid} recorded for daemon {} belongs to a different process now (PID recycled); resetting state without killing",
                 daemon.id,
@@ -1312,10 +1319,9 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
 
         let Some(expected_start_time) = current_start_time else {
             warn!(
-                "could not read start time for pid {pid} recorded for daemon {}; resetting state without killing",
+                "could not read start time for live pid {pid} recorded for daemon {}; retaining running state",
                 daemon.id,
             );
-            reset_daemon_state(supervisor, &daemon.id).await;
             continue;
         };
 

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1239,10 +1239,14 @@ fn chmod_safe_subtrees(state_dir: &std::path::Path) {
 /// PID is still alive and its current identity matches the recorded start time
 /// (or the recorded title for older state files), it is assumed to be an orphan
 /// from the previous supervisor session and is killed. The daemon's state is
-/// then reset to `Stopped` with no PID.
+/// then reset to `Stopped` with no PID. If a matching live process cannot be
+/// terminated securely, its running state is retained to prevent a duplicate
+/// instance from being started.
 ///
 /// Missing or mismatched identity data fails closed so a PID recycled by an
-/// unrelated process is never killed.
+/// unrelated process is never killed. On Unix platforms without durable
+/// process handles, orphan termination also fails closed because the PID/PGID
+/// cannot be pinned between identity validation and signaling.
 ///
 /// This is gated by the `supervisor.cleanup_orphans` setting (default: true).
 async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
@@ -1318,7 +1322,7 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
         info!("terminating orphaned daemon {} (pid {pid})", daemon.id);
 
         let stop_cfg = daemon.stop_signal.unwrap_or_default();
-        let _ = PROCS
+        let termination_result = PROCS
             .kill_process_group_if_start_time_matches_async(
                 pid,
                 expected_start_time,
@@ -1326,6 +1330,24 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
                 stop_cfg.timeout,
             )
             .await;
+
+        if !matches!(termination_result, Ok(true)) {
+            PROCS.refresh_pids(&[pid]);
+            if PROCS.is_running(pid) && PROCS.start_time(pid) == Some(expected_start_time) {
+                match termination_result {
+                    Ok(false) => warn!(
+                        "could not securely terminate orphaned daemon {} (pid {pid}); retaining running state",
+                        daemon.id
+                    ),
+                    Err(err) => warn!(
+                        "failed to terminate orphaned daemon {} (pid {pid}): {err}; retaining running state",
+                        daemon.id
+                    ),
+                    Ok(true) => unreachable!(),
+                }
+                continue;
+            }
+        }
 
         reset_daemon_state(supervisor, &daemon.id).await;
     }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -537,10 +537,10 @@ impl Supervisor {
                 ticker.tick().await; // first tick is immediate
                 loop {
                     ticker.tick().await;
-                    if let Some(cancel) = monitor_cancel.as_ref() {
-                        if cancel.is_cancelled() {
-                            break;
-                        }
+                    if let Some(cancel) = monitor_cancel.as_ref()
+                        && cancel.is_cancelled()
+                    {
+                        break;
                     }
                     if let Some(new_ip) =
                         crate::proxy::lan_ip::detect_lan_ip_if_changed(last_ip).await
@@ -622,10 +622,10 @@ impl Supervisor {
                     }
                 }
                 let state = SUPERVISOR.state_file.lock().await;
-                if state.is_dirty() {
-                    if let Err(e) = state.write() {
-                        warn!("failed to flush state file: {e}");
-                    }
+                if state.is_dirty()
+                    && let Err(e) = state.write()
+                {
+                    warn!("failed to flush state file: {e}");
                 }
             }
             debug!("state flush task exiting");
@@ -634,10 +634,10 @@ impl Supervisor {
 
     pub(crate) async fn flush_state(&self) {
         let state = self.state_file.lock().await;
-        if state.is_dirty() {
-            if let Err(e) = state.write() {
-                warn!("failed to flush state file: {e}");
-            }
+        if state.is_dirty()
+            && let Err(e) = state.write()
+        {
+            warn!("failed to flush state file: {e}");
         }
     }
 
@@ -1009,10 +1009,10 @@ impl Supervisor {
         // in-memory-only changes are lost.
         {
             let state = self.state_file.lock().await;
-            if state.is_dirty() {
-                if let Err(e) = state.write() {
-                    warn!("failed to flush state file during shutdown: {e}");
-                }
+            if state.is_dirty()
+                && let Err(e) = state.write()
+            {
+                warn!("failed to flush state file during shutdown: {e}");
             }
         }
 
@@ -1182,12 +1182,11 @@ fn chown_recursive(dir: &std::path::Path, uid: u32, gid: u32, skip_proxy: bool) 
         let path = entry.path();
         if path.is_dir() {
             // Skip proxy/ at the top level of the state directory
-            if skip_proxy {
-                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    if name == "proxy" {
-                        continue;
-                    }
-                }
+            if skip_proxy
+                && let Some(name) = path.file_name().and_then(|n| n.to_str())
+                && name == "proxy"
+            {
+                continue;
             }
             chown_recursive(&path, uid, gid, false);
         } else {
@@ -1269,56 +1268,44 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
         candidates.len()
     );
 
+    // Populate the process cache for all candidate PIDs in one pass so the
+    // identity checks below (start_time/title) see live data. Without this
+    // the cache is empty at supervisor startup and every lookup returns None,
+    // which would defeat the recycled-PID safety check entirely.
+    let pids: Vec<u32> = candidates.iter().filter_map(|d| d.pid).collect();
+    PROCS.refresh_pids(&pids);
+
     for daemon in candidates {
         let Some(pid) = daemon.pid else { continue };
 
         if !PROCS.is_running(pid) {
             // PID already dead — just reset its state
-            let _ = supervisor
-                .upsert_daemon(
-                    UpsertDaemonOpts::builder(daemon.id.clone())
-                        .set(|o| {
-                            o.pid = None;
-                            o.status = DaemonStatus::Stopped;
-                            o.active_port = None;
-                        })
-                        .build(),
-                )
-                .await;
+            reset_daemon_state(supervisor, &daemon.id).await;
             continue;
         }
 
-        // Safety check: verify the process name matches what we recorded.
-        // This avoids accidentally killing an unrelated process if the PID
-        // was recycled by the kernel between state-file writes.
-        let current_title = PROCS.title(pid);
-        let matches = match (&current_title, &daemon.title) {
-            (Some(current), Some(expected)) => current == expected,
-            // If we don't have a recorded title, fall back to allowing the kill
-            // (this is a degraded but functional state — the process was probably
-            // started before title tracking was added, or the state was reset).
-            _ => true,
+        // Safety check: verify the live process really is the daemon we
+        // recorded, not an unrelated process that received a recycled PID.
+        // The kernel start time is a stable identity for the lifetime of a
+        // process; fall back to comparing the process name for state files
+        // written by older versions that didn't record start_time.
+        let matches = match (daemon.start_time, PROCS.start_time(pid)) {
+            (Some(recorded), Some(current)) => recorded == current,
+            _ => match (PROCS.title(pid), &daemon.title) {
+                (Some(current), Some(expected)) => current == *expected,
+                // No recorded identity at all (the process was started before
+                // identity tracking was added, or the state was reset) —
+                // degraded but functional: allow the kill.
+                _ => true,
+            },
         };
 
         if !matches {
             warn!(
-                "pid {pid} for daemon {} has changed name (expected '{}', found '{}'); skipping orphan cleanup",
+                "pid {pid} recorded for daemon {} belongs to a different process now (PID recycled); resetting state without killing",
                 daemon.id,
-                daemon.title.as_deref().unwrap_or("?"),
-                current_title.as_deref().unwrap_or("?")
             );
-            // Still reset state so we don't track a stale PID
-            let _ = supervisor
-                .upsert_daemon(
-                    UpsertDaemonOpts::builder(daemon.id.clone())
-                        .set(|o| {
-                            o.pid = None;
-                            o.status = DaemonStatus::Stopped;
-                            o.active_port = None;
-                        })
-                        .build(),
-                )
-                .await;
+            reset_daemon_state(supervisor, &daemon.id).await;
             continue;
         }
 
@@ -1329,18 +1316,24 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
             .kill_process_group_async(pid, stop_cfg.signal.into(), stop_cfg.timeout)
             .await;
 
-        let _ = supervisor
-            .upsert_daemon(
-                UpsertDaemonOpts::builder(daemon.id.clone())
-                    .set(|o| {
-                        o.pid = None;
-                        o.status = DaemonStatus::Stopped;
-                        o.active_port = None;
-                    })
-                    .build(),
-            )
-            .await;
+        reset_daemon_state(supervisor, &daemon.id).await;
     }
+}
+
+/// Clear a daemon's runtime state (pid, status, active port) after its
+/// process is gone or no longer ours to manage.
+async fn reset_daemon_state(supervisor: &Supervisor, id: &DaemonId) {
+    let _ = supervisor
+        .upsert_daemon(
+            UpsertDaemonOpts::builder(id.clone())
+                .set(|o| {
+                    o.pid = None;
+                    o.status = DaemonStatus::Stopped;
+                    o.active_port = None;
+                })
+                .build(),
+        )
+        .await;
 }
 
 /// Recursively chmod: directories → 0o755, files → 0o644.

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1337,20 +1337,20 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
             )
             .await;
 
-        if !matches!(termination_result, Ok(true)) {
-            PROCS.refresh_pids(&[pid]);
-            if PROCS.is_running(pid) && PROCS.start_time(pid) == Some(expected_start_time) {
-                match termination_result {
-                    Ok(false) => warn!(
-                        "could not securely terminate orphaned daemon {} (pid {pid}); retaining running state",
-                        daemon.id
-                    ),
-                    Err(err) => warn!(
-                        "failed to terminate orphaned daemon {} (pid {pid}): {err}; retaining running state",
-                        daemon.id
-                    ),
-                    Ok(true) => unreachable!(),
-                }
+        match termination_result {
+            Ok(true) => {}
+            Ok(false) => {
+                warn!(
+                    "could not securely terminate orphaned daemon {} (pid {pid}); retaining running state",
+                    daemon.id
+                );
+                continue;
+            }
+            Err(err) => {
+                warn!(
+                    "failed to terminate orphaned daemon {} (pid {pid}): {err}; retaining running state",
+                    daemon.id
+                );
                 continue;
             }
         }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1235,13 +1235,14 @@ fn chmod_safe_subtrees(state_dir: &std::path::Path) {
 /// On startup, kill any daemon processes left behind by a previous supervisor
 /// that was terminated unexpectedly (e.g. `kill -9`).
 ///
-/// This iterates the state file for daemon entries with a recorded PID.  If the
-/// PID is still alive and the process name matches the recorded `title`, it is
-/// assumed to be an orphan from the previous supervisor session and is killed.
-/// The daemon's state is then reset to `Stopped` with no PID.
+/// This iterates the state file for daemon entries with a recorded PID. If the
+/// PID is still alive and its current identity matches the recorded start time
+/// (or the recorded title for older state files), it is assumed to be an orphan
+/// from the previous supervisor session and is killed. The daemon's state is
+/// then reset to `Stopped` with no PID.
 ///
-/// The process-name check protects against the rare case where a PID has been
-/// recycled by an unrelated process since the state file was written.
+/// Missing or mismatched identity data fails closed so a PID recycled by an
+/// unrelated process is never killed.
 ///
 /// This is gated by the `supervisor.cleanup_orphans` setting (default: true).
 async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
@@ -1289,16 +1290,14 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
         // The kernel start time is a stable identity for the lifetime of a
         // process; fall back to comparing the process name for state files
         // written by older versions that didn't record start_time.
-        let matches = match (daemon.start_time, PROCS.start_time(pid)) {
-            (Some(recorded), Some(current)) => recorded == current,
-            _ => match (PROCS.title(pid), &daemon.title) {
-                (Some(current), Some(expected)) => current == *expected,
-                // No recorded identity at all (the process was started before
-                // identity tracking was added, or the state was reset) —
-                // degraded but functional: allow the kill.
-                _ => true,
-            },
-        };
+        let current_start_time = PROCS.start_time(pid);
+        let current_title = PROCS.title(pid);
+        let matches = process_identity_matches(
+            daemon.start_time,
+            daemon.title.as_deref(),
+            current_start_time,
+            current_title.as_deref(),
+        );
 
         if !matches {
             warn!(
@@ -1317,6 +1316,25 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
             .await;
 
         reset_daemon_state(supervisor, &daemon.id).await;
+    }
+}
+
+/// Verify that live process identity matches the persisted daemon identity.
+///
+/// A recorded start time takes precedence over the legacy title field. Missing
+/// current identity data must never authorize terminating a process.
+fn process_identity_matches(
+    recorded_start_time: Option<u64>,
+    recorded_title: Option<&str>,
+    current_start_time: Option<u64>,
+    current_title: Option<&str>,
+) -> bool {
+    match recorded_start_time {
+        Some(recorded) => current_start_time == Some(recorded),
+        None => matches!(
+            (recorded_title, current_title),
+            (Some(recorded), Some(current)) if recorded == current
+        ),
     }
 }
 
@@ -1356,8 +1374,51 @@ fn chmod_recursive(dir: &std::path::Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::should_remove_liveness_session;
+    use super::{process_identity_matches, should_remove_liveness_session};
     use crate::state_file::ProjectSession;
+
+    #[test]
+    fn orphan_identity_does_not_match_when_current_identity_is_missing() {
+        assert!(!process_identity_matches(
+            Some(123),
+            Some("daemon"),
+            None,
+            None,
+        ));
+        assert!(!process_identity_matches(None, Some("daemon"), None, None,));
+    }
+
+    #[test]
+    fn orphan_identity_requires_recorded_start_time_when_available() {
+        assert!(process_identity_matches(
+            Some(123),
+            Some("old-title"),
+            Some(123),
+            Some("new-title"),
+        ));
+        assert!(!process_identity_matches(
+            Some(123),
+            Some("same-title"),
+            Some(456),
+            Some("same-title"),
+        ));
+    }
+
+    #[test]
+    fn orphan_identity_falls_back_to_title_for_legacy_state() {
+        assert!(process_identity_matches(
+            None,
+            Some("daemon"),
+            Some(123),
+            Some("daemon"),
+        ));
+        assert!(!process_identity_matches(
+            None,
+            Some("daemon"),
+            Some(123),
+            Some("unrelated"),
+        ));
+    }
 
     #[test]
     fn should_not_remove_when_state_title_differs_from_snapshot() {

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1269,15 +1269,13 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
         candidates.len()
     );
 
-    // Populate the process cache for all candidate PIDs in one pass so the
-    // identity checks below (start_time/title) see live data. Without this
-    // the cache is empty at supervisor startup and every lookup returns None,
-    // which would defeat the recycled-PID safety check entirely.
-    let pids: Vec<u32> = candidates.iter().filter_map(|d| d.pid).collect();
-    PROCS.refresh_pids(&pids);
-
     for daemon in candidates {
         let Some(pid) = daemon.pid else { continue };
+
+        // Refresh each candidate immediately before checking it. Processing an
+        // earlier orphan can await its stop timeout, during which this PID may
+        // exit and be recycled.
+        PROCS.refresh_pids(&[pid]);
 
         if !PROCS.is_running(pid) {
             // PID already dead — just reset its state
@@ -1308,11 +1306,25 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
             continue;
         }
 
+        let Some(expected_start_time) = current_start_time else {
+            warn!(
+                "could not read start time for pid {pid} recorded for daemon {}; resetting state without killing",
+                daemon.id,
+            );
+            reset_daemon_state(supervisor, &daemon.id).await;
+            continue;
+        };
+
         info!("terminating orphaned daemon {} (pid {pid})", daemon.id);
 
         let stop_cfg = daemon.stop_signal.unwrap_or_default();
         let _ = PROCS
-            .kill_process_group_async(pid, stop_cfg.signal.into(), stop_cfg.timeout)
+            .kill_process_group_if_start_time_matches_async(
+                pid,
+                expected_start_time,
+                stop_cfg.signal.into(),
+                stop_cfg.timeout,
+            )
             .await;
 
         reset_daemon_state(supervisor, &daemon.id).await;

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -178,7 +178,25 @@ impl Supervisor {
         let existing = state_file.daemons.get(&opts.id);
         let daemon = Daemon {
             id: opts.id.clone(),
-            title: opts.pid.and_then(|pid| PROCS.title(pid)),
+            // title/start_time identify the process for orphan cleanup after a
+            // supervisor crash. They are looked up from the process cache; if
+            // the cache has no entry (e.g. an upsert between refreshes) fall
+            // back to the existing values as long as the PID is unchanged, so
+            // the recorded identity is not wiped mid-lifetime.
+            title: opts.pid.and_then(|pid| {
+                PROCS.title(pid).or_else(|| {
+                    existing
+                        .filter(|d| d.pid == Some(pid))
+                        .and_then(|d| d.title.clone())
+                })
+            }),
+            start_time: opts.pid.and_then(|pid| {
+                PROCS.start_time(pid).or_else(|| {
+                    existing
+                        .filter(|d| d.pid == Some(pid))
+                        .and_then(|d| d.start_time)
+                })
+            }),
             pid: opts.pid,
             status: opts.status,
             shell_pid: opts.shell_pid,

--- a/src/supervisor/watchers.rs
+++ b/src/supervisor/watchers.rs
@@ -255,19 +255,19 @@ impl Supervisor {
             // Check memory limit (RSS) — immediate kill, no grace period.
             // Memory violations are not transient: once RSS exceeds the limit
             // the process is unlikely to release it without intervention.
-            if let Some(mem_limit) = daemon.memory_limit {
-                if stats.memory_bytes > mem_limit.0 {
-                    warn!(
-                        "daemon {} (pid {}) exceeded memory limit: {} > {}, stopping",
-                        daemon.id,
-                        pid,
-                        stats.memory_display(),
-                        mem_limit,
-                    );
-                    cpu_violation_counts.remove(&daemon.id);
-                    self.stop_for_resource_violation(&daemon.id, pid).await;
-                    continue; // Don't check CPU if we're already killing
-                }
+            if let Some(mem_limit) = daemon.memory_limit
+                && stats.memory_bytes > mem_limit.0
+            {
+                warn!(
+                    "daemon {} (pid {}) exceeded memory limit: {} > {}, stopping",
+                    daemon.id,
+                    pid,
+                    stats.memory_display(),
+                    mem_limit,
+                );
+                cpu_violation_counts.remove(&daemon.id);
+                self.stop_for_resource_violation(&daemon.id, pid).await;
+                continue; // Don't check CPU if we're already killing
             }
 
             // Check CPU limit (percentage) with consecutive-sample threshold.
@@ -624,12 +624,12 @@ impl Supervisor {
                             // immediate=false (default): anchor last_cron_triggered to now
                             // so the next scheduled time is picked up, without firing now.
                             let mut state_file = self.state_file.lock().await;
-                            if state_file.set_last_cron_triggered(&id, now) {
-                                if let Err(e) = state_file.write() {
-                                    error!(
-                                        "failed to persist last_cron_triggered for daemon {id}: {e}"
-                                    );
-                                }
+                            if state_file.set_last_cron_triggered(&id, now)
+                                && let Err(e) = state_file.write()
+                            {
+                                error!(
+                                    "failed to persist last_cron_triggered for daemon {id}: {e}"
+                                );
                             }
                             continue;
                         }
@@ -651,12 +651,10 @@ impl Supervisor {
                     // re-fire the cron job immediately.
                     {
                         let mut state_file = self.state_file.lock().await;
-                        if state_file.set_last_cron_triggered(&id, now) {
-                            if let Err(e) = state_file.write() {
-                                error!(
-                                    "failed to persist last_cron_triggered for daemon {id}: {e}"
-                                );
-                            }
+                        if state_file.set_last_cron_triggered(&id, now)
+                            && let Err(e) = state_file.write()
+                        {
+                            error!("failed to persist last_cron_triggered for daemon {id}: {e}");
                         }
                     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -362,24 +362,24 @@ pub fn render_daemon_templates(
         config.ready_http = Some(http);
     }
 
-    if let Some(ref ready_port) = config.ready_port {
-        if let Some(ref template) = ready_port.template {
-            let rendered = renderer.render(template)?;
-            let port = rendered
-                .trim()
-                .parse::<u16>()
-                .ok()
-                .filter(|&p| p > 0)
-                .ok_or_else(|| RenderError::InvalidPort {
-                    template: template.clone(),
-                    rendered: rendered.clone(),
-                })?;
-            config.ready_port = Some(crate::config_types::ReadyPort {
-                port: Some(port),
-                template: None,
-                timeout: ready_port.timeout,
-            });
-        }
+    if let Some(ref ready_port) = config.ready_port
+        && let Some(ref template) = ready_port.template
+    {
+        let rendered = renderer.render(template)?;
+        let port = rendered
+            .trim()
+            .parse::<u16>()
+            .ok()
+            .filter(|&p| p > 0)
+            .ok_or_else(|| RenderError::InvalidPort {
+                template: template.clone(),
+                rendered: rendered.clone(),
+            })?;
+        config.ready_port = Some(crate::config_types::ReadyPort {
+            port: Some(port),
+            template: None,
+            timeout: ready_port.timeout,
+        });
     }
 
     Ok(())

--- a/test/supervisor.bats
+++ b/test/supervisor.bats
@@ -123,6 +123,10 @@ EOF
   assert_success
   wait_for_status orphan_test running
 
+  local daemon_pid
+  daemon_pid="$(get_daemon_pid orphan_test)"
+  [[ -n "$daemon_pid" ]]
+
   local sup_pid
   sup_pid="$(get_supervisor_pid)"
   [[ -n "$sup_pid" ]]
@@ -131,6 +135,9 @@ EOF
   kill_pid "$sup_pid"
   sleep 1
 
+  # The daemon survives the crash as an orphan (reparented to init).
+  pid_alive "$daemon_pid"
+
   run pitchfork supervisor start
   assert_success
   sleep 3
@@ -138,6 +145,58 @@ EOF
   run pitchfork status orphan_test
   assert_success
   assert_output --partial "stopped"
+
+  # The orphan process itself must be terminated — a state entry that merely
+  # says "stopped" while the process lives on would allow silent duplicates.
+  run pid_alive "$daemon_pid"
+  assert_failure
+
+  # Starting again must yield exactly one fresh instance, not a duplicate.
+  run pitchfork start orphan_test
+  assert_success
+  wait_for_status orphan_test running
+
+  local new_pid
+  new_pid="$(get_daemon_pid orphan_test)"
+  [[ -n "$new_pid" ]]
+  [[ "$new_pid" != "$daemon_pid" ]]
+
+  pitchfork stop orphan_test
+}
+
+@test "orphan cleanup does not kill unrelated process with recycled PID" {
+  skip_on_windows "state file crafting relies on Unix signal semantics"
+
+  # An unrelated long-running process standing in for a recycled PID.
+  sleep 300 >/dev/null 2>&1 &
+  local bystander_pid=$!
+
+  # Stop the supervisor, then plant a state entry claiming a daemon owns the
+  # bystander's PID with a mismatching identity (different start time/title).
+  pitchfork supervisor stop 2>/dev/null || true
+  sleep 1
+  cat > "$PITCHFORK_STATE_DIR/state.toml" <<EOF
+[daemons."recycled/victim"]
+id = "recycled/victim"
+title = "definitely-not-sleep"
+pid = $bystander_pid
+start_time = 1
+status = "running"
+autostop = false
+EOF
+
+  run pitchfork supervisor start
+  assert_success
+  sleep 3
+
+  # The unrelated process must survive; only the stale state entry is reset.
+  pid_alive "$bystander_pid"
+
+  run pitchfork status recycled/victim
+  assert_success
+  assert_output --partial "stopped"
+
+  { kill -9 "$bystander_pid" && wait "$bystander_pid"; } 2>/dev/null || true
 }
 
 # ============================================================================

--- a/test/supervisor.bats
+++ b/test/supervisor.bats
@@ -109,6 +109,9 @@ get_supervisor_pid() {
 }
 
 @test "orphaned daemons are cleaned up on supervisor restart" {
+  if [[ "$(uname -s)" != "Linux" && "$(uname -s)" != MINGW* && "$(uname -s)" != MSYS* ]]; then
+    skip "secure process-group termination is unavailable on this Unix platform"
+  fi
 
   create_pitchfork_toml <<EOF
 [daemons.orphan_test]
@@ -162,6 +165,59 @@ EOF
   [[ "$new_pid" != "$daemon_pid" ]]
 
   pitchfork stop orphan_test
+}
+
+@test "orphan cleanup fails closed without durable process handles" {
+  if [[ "$(uname -s)" == "Linux" || "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
+    skip "only applies to non-Linux Unix platforms"
+  fi
+
+  create_pitchfork_toml <<EOF
+[daemons.orphan_test]
+run = "sleep 60"
+ready_delay = 1
+EOF
+
+  run pitchfork supervisor start
+  assert_success
+
+  run pitchfork start orphan_test
+  assert_success
+  wait_for_status orphan_test running
+
+  local daemon_pid
+  daemon_pid="$(get_daemon_pid orphan_test)"
+  [[ -n "$daemon_pid" ]]
+
+  local sup_pid
+  sup_pid="$(get_supervisor_pid)"
+  [[ -n "$sup_pid" ]]
+
+  kill_pid "$sup_pid"
+  sleep 1
+  pid_alive "$daemon_pid"
+
+  run pitchfork supervisor start
+  assert_success
+  sleep 3
+
+  # Both the orphan and its running state survive because the platform cannot
+  # pin its identity across killpg. Retaining state prevents duplicate starts.
+  pid_alive "$daemon_pid"
+
+  run pitchfork status orphan_test
+  assert_success
+  assert_output --partial "running"
+
+  run pitchfork start orphan_test
+  assert_success
+  assert_output --partial "already running"
+
+  local retained_pid
+  retained_pid="$(get_daemon_pid orphan_test)"
+  [[ "$retained_pid" == "$daemon_pid" ]]
+
+  kill_pid "$daemon_pid"
 }
 
 @test "orphan cleanup does not kill unrelated process with recycled PID" {

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -99,6 +99,18 @@ kill_pid() {
   fi
 }
 
+# Check whether a PID is alive, working on both Unix and Windows.
+# On Windows Git Bash, `kill -0` cannot probe native Windows processes,
+# so query tasklist instead.
+pid_alive() {
+  local pid="$1"
+  if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
+    tasklist //FI "PID eq $pid" 2>/dev/null | grep -q "[[:space:]]$pid[[:space:]]"
+  else
+    kill -0 "$pid" 2>/dev/null
+  fi
+}
+
 # Normalize a path for cross-platform comparison.
 # On Windows Git Bash, paths can appear in multiple formats:
 #   /tmp/...           (Git Bash virtual mount)


### PR DESCRIPTION
## Context

Investigating #631 (supervisor crash orphans daemons; restarted supervisor doesn't clean up and can start duplicates) turned up two things:

1. The reported bug was already fixed in v2.17.0 — #585 changed `Supervisor::new()` from `StateFile::new` (empty state) to `StateFile::read`, which is what let startup orphan cleanup see its candidates. But that one-liner landed inside a test-infrastructure PR with **no regression test protecting it**.
2. The PID-recycle safety check in `cleanup_orphaned_daemons` is **inert**: it compares `PROCS.title(pid)` against the recorded title, but the sysinfo process cache is never populated for candidate PIDs at startup (empty since the perf change in #576), so `title()` always returns `None` and the check falls through to "allow the kill". Verified empirically: a crafted state entry pointing at an unrelated live process with a mismatched title gets that process killed (process group and all).

Title comparison is also inherently unreliable even with a populated cache: the title is snapshotted once at spawn, so daemons that `exec` into another binary or set their own process title (nginx, postgres, node) legitimately mismatch — and a *working* title check would then skip the kill but reset state, leaking the orphan and recreating the duplicate-start bug through the other door.

## Changes

- **Record process identity at spawn**: `Daemon` gains `start_time` (kernel process start time via sysinfo, already used elsewhere in `procs.rs`). PID + start time is a stable identity for the lifetime of a process — a recycled PID always has a different start time. Old state files without the field fall back to the title check, which now actually works because…
- **Populate the process cache before identity checks**: `cleanup_orphaned_daemons` now does one `refresh_pids` pass over all candidate PIDs before the loop.
- **Never kill on identity mismatch**: a mismatch means the PID was recycled to an unrelated process — the daemon is already gone, so only the stale state entry is reset.
- **Don't wipe identity mid-lifetime**: `upsert_daemon` previously recomputed `title` from the cache on every pid-carrying upsert, setting it to `None` whenever the cache happened to be cold; `title`/`start_time` now fall back to the existing values when the PID is unchanged.
- **Regression tests** (bats):
  - Strengthened `orphaned daemons are cleaned up on supervisor restart`: now asserts the orphan **process** is actually terminated (the old assertion passed even when only state was reset) and that a subsequent `pitchfork start` yields exactly one fresh instance — this is the guardrail for the #585 fix.
  - New `orphan cleanup does not kill unrelated process with recycled PID`: plants a state entry pointing at an innocent bystander process with mismatched identity and asserts it survives.

## Follow-up

A stacked PR implements orphan **re-adoption** as the default policy (what the reporter asked for), with this PR's identity check deciding adoptability.

Fixes the remaining gaps from #631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how the supervisor signals process groups at startup; mistakes could leave orphans or, worse, affect the wrong process, though the design is explicitly fail-closed on weak platforms.
> 
> **Overview**
> **Orphan cleanup** now treats **PID + kernel `start_time`** as the primary identity: daemons persist `start_time` at spawn, `upsert_daemon` keeps `title`/`start_time` when the process cache is cold, and startup cleanup refreshes each candidate PID before checks.
> 
> On **identity mismatch** (recycled PID), state is cleared **without** killing the live process. Termination uses **`kill_process_group_if_start_time_matches_async`**: Linux pins the group via **pidfd** (freeze/scan/SIGKILL); Windows holds an open process handle through **taskkill**; other Unix platforms **refuse** identity-checked kills so running state is retained and duplicates are blocked.
> 
> **Docs/tests:** `supervisor.cleanup_orphans` docs describe platform behavior; bats assert real process termination on Linux/Windows, fail-closed on other Unix, and PID-recycle safety; **`pid_alive`** helper added for cross-platform tests. Minor **let-chain** refactors elsewhere; no behavior change there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a673f5bc423aa75a3bf4cb764077341943b099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orphaned daemon cleanup by verifying process identity with PID plus kernel start time to prevent termination after PID reuse.
  * Enhanced process-group shutdown by only proceeding when the expected start time matches (fail-closed when secure verification isn’t available).
  * Preserved and restored daemon identity data more reliably to reduce verification gaps during supervisor refreshes.
* **Tests**
  * Strengthened supervisor restart/orphan cleanup tests, including PID-recycling protection and fail-closed scenarios.
  * Added cross-platform PID liveness helper for end-to-end testing.
* **Documentation**
  * Updated configuration docs to describe the safer identity-checked orphan cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->