### PR TITLE
feat(supervisor): re-adopt orphaned daemons by default after a crash

### DIFF
--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -1032,7 +1032,7 @@
       "type": "object",
       "properties": {
         "cleanup_orphans": {
-          "description": "Kill orphaned daemon processes when supervisor starts",
+          "description": "Reconcile orphaned daemon processes when supervisor starts",
           "type": [
             "boolean",
             "null"
@@ -1076,6 +1076,13 @@
         },
         "log_flush_interval": {
           "description": "Daemon log buffer flush interval",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "orphan_policy": {
+          "description": "What to do with live orphaned daemons on supervisor startup: adopt or kill",
           "type": [
             "string",
             "null"

--- a/settings.toml
+++ b/settings.toml
@@ -753,27 +753,59 @@ Can also be enabled via the `--container` CLI flag on `pitchfork supervisor run`
 type = "Bool"
 env = "PITCHFORK_CLEANUP_ORPHANS"
 default = "true"
-description = "Kill orphaned daemon processes when supervisor starts"
+description = "Reconcile orphaned daemon processes when supervisor starts"
 docs = """
 When enabled, the supervisor scans the state file on startup for daemon
 processes left behind by a previous supervisor instance that was killed
-unexpectedly (for example, with `kill -9`). On supported platforms, matching
-live processes are terminated so the new supervisor starts with a clean slate.
+unexpectedly (for example, with `kill -9`) and reconciles them according
+to `supervisor.orphan_policy` (re-adopt by default, or terminate).
 
-Before terminating, the recorded process identity (PID plus kernel start
-time) is verified. Linux and Windows also pin that identity with a pidfd or
-open process handle while terminating, so a recycled PID cannot target an
-unrelated process. On Unix platforms without durable process handles, cleanup
-fails closed: the live process and its running state are retained rather than
-risk signaling a recycled process group or allowing a duplicate instance to
-start.
+Before acting, the recorded process identity (PID plus kernel start
+time) is verified so that a PID recycled by the OS to an unrelated process
+is never adopted or killed — in that case only the stale state entry is
+cleared. When terminating, Linux and Windows also pin that identity with a
+pidfd or open process handle, so a recycled PID cannot be signaled. If the
+identity cannot be verified or pinned, reconciliation fails closed: the
+live process and its running state are retained rather than risk acting on
+the wrong process or allowing a duplicate instance to start.
 
-This is recommended for local development where an unclean shutdown (IDE
-restart, system crash, etc.) would otherwise leave stale processes holding
-ports and consuming resources.
+Disabling this leaves orphaned processes and their state entries
+completely untouched. This is a legacy escape hatch; prefer
+`orphan_policy = "adopt"` (the default), which keeps daemons running
+across a supervisor crash while resuming supervision.
+"""
 
-Disable this on long-lived servers where you want daemons to survive a
-supervisor restart without interruption.
+[supervisor.orphan_policy]
+type = "String"
+env = "PITCHFORK_ORPHAN_POLICY"
+default = "adopt"
+description = "What to do with live orphaned daemons on supervisor startup: adopt or kill"
+docs = """
+When the supervisor starts and finds daemons in the state file whose
+processes are still alive from a previous supervisor instance that died
+uncleanly, this policy decides what happens (after the process identity
+is verified via PID plus kernel start time):
+
+- `adopt` (default): keep the process running and resume supervision.
+  The daemon keeps its state (status, ports, proxy routing) and is
+  monitored by polling. Since the process is no longer a child of the
+  supervisor, its stdout/stderr capture cannot be restored — log capture
+  resumes the next time the daemon restarts. Exit codes of adopted
+  daemons cannot be observed; an adopted daemon that dies unexpectedly
+  is marked `errored` with an unknown exit code, which makes it eligible
+  for its configured retries.
+- `kill`: terminate the orphaned process group so the new supervisor
+  starts with a clean slate, matching pre-adoption behavior.
+
+Daemons whose recorded PID is dead, or whose PID now belongs to a
+different process, have their state reset under either policy. If the
+process identity cannot be verified, reconciliation fails closed and
+retains the running state without adopting or killing.
+
+The same policy applies when the interval watcher finds a running daemon
+that has lost its monitor at runtime.
+
+This setting has no effect when `cleanup_orphans` is disabled.
 """
 
 

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -313,6 +313,19 @@ impl Supervisor {
         last_exit_success: Option<bool>,
     ) -> bool {
         let mut state_file = self.state_file.lock().await;
+        // A monitor entry appearing since the caller's snapshot means a live
+        // monitor now owns this daemon — including a successor that recycled
+        // the same numeric PID, which always registers before its Running
+        // state becomes visible. Its monitor handles its lifecycle.
+        if self
+            .monitored
+            .lock()
+            .expect("monitored lock poisoned")
+            .contains_key(id)
+        {
+            debug!("daemon {id} gained a monitor since the snapshot; skipping finalization");
+            return false;
+        }
         let Some(d) = state_file.daemons.get(id) else {
             return false;
         };

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -39,14 +39,19 @@ const POLL_INTERVAL: Duration = Duration::from_secs(2);
 enum PollOutcome {
     /// The adopted process exited (or its PID was recycled, which means the
     /// process exited unnoticed) while the daemon record still pointed at it.
-    ProcessDied,
-    /// `stop()` finished first: the record shows no PID and status `Stopped`.
-    /// State is already final, but the stop hooks still need to fire — the
-    /// regular child monitor fires them, `stop()` itself never does.
+    /// `was_stopping` snapshots whether `stop()` was in flight at the moment
+    /// death was observed, tying stop intent to the observation the way the
+    /// child monitor's pre-drain snapshot does.
+    ProcessDied { was_stopping: bool },
+    /// `stop()` finished first: the record shows no PID and status `Stopped`,
+    /// and every prior observation belonged to this monitor's PID (a foreign
+    /// PID would have broken out as `TakenOver` instead). State is already
+    /// final, but the stop hooks still need to fire — the regular child
+    /// monitor fires them, `stop()` itself never does.
     StoppedExternally,
     /// Another process took over the daemon record (e.g. a restart spawned a
-    /// fresh child with its own monitor) or the record was removed. State is
-    /// the successor's to manage; touch nothing.
+    /// fresh child with its own monitor) or the record was removed. State and
+    /// hooks are the successor's to manage; touch nothing.
     TakenOver,
 }
 
@@ -272,14 +277,19 @@ impl Supervisor {
 
         // Legacy records matched by title have no persisted start_time.
         // Re-upsert while the process cache is fresh so the identity fields
-        // are recorded for future scans and crashes.
+        // are recorded for future scans and crashes. active_port must be
+        // carried over explicitly: upsert_daemon intentionally never inherits
+        // it (a restarted process hasn't bound its port yet), but this
+        // process never stopped — wiping it would break proxy routing.
         if daemon.start_time.is_none() {
+            let active_port = daemon.active_port;
             let _ = self
                 .upsert_daemon(
                     UpsertDaemonOpts::builder(daemon.id.clone())
                         .set(|o| {
                             o.pid = Some(pid);
                             o.status = DaemonStatus::Running;
+                            o.active_port = active_port;
                         })
                         .build(),
                 )
@@ -311,13 +321,14 @@ impl Supervisor {
                     // that no longer matches means our process died and the
                     // OS recycled its PID: treat as death, and never touch
                     // the unrelated new process.
+                    let was_stopping = current.status.is_stopping();
                     PROCS.refresh_pids(&[pid]);
                     if !PROCS.is_running(pid) {
-                        break PollOutcome::ProcessDied;
+                        break PollOutcome::ProcessDied { was_stopping };
                     }
                     match PROCS.start_time(pid) {
                         Some(current_start_time) if current_start_time != expected_start_time => {
-                            break PollOutcome::ProcessDied;
+                            break PollOutcome::ProcessDied { was_stopping };
                         }
                         None => {
                             // Transient identity read failure: keep watching
@@ -329,9 +340,11 @@ impl Supervisor {
                         }
                         _ => {}
                     }
-                } else if current.status.is_stopping() {
-                    // stop() in flight — wait for it to finish so the exit
-                    // path below can fire the stop hooks.
+                } else if current.pid.is_none() && current.status.is_stopping() {
+                    // Transitional: a stop of our record is mid-flight — wait
+                    // for it to settle so the exit path can fire stop hooks.
+                    // (A Stopping record with a *different* PID is a successor
+                    // and falls through to TakenOver below.)
                 } else if current.pid.is_none() && current.status.is_stopped() {
                     break PollOutcome::StoppedExternally;
                 } else {
@@ -363,21 +376,32 @@ impl Supervisor {
             // Re-read state and verify this monitor still owns the record
             // before mutating anything. A restart can spawn a successor
             // between observing the death and reaching this point; its
-            // state (PID, status, active port) is not ours to touch.
+            // state (PID, status, active port) and hooks are not ours to
+            // touch — even if the successor is itself Stopping or Stopped,
+            // its own monitor handles that lifecycle. Ownership here means
+            // the record still names our PID, or was finalized with no PID
+            // at all (stop() observed our dead process and completed the
+            // transition itself).
             let current = SUPERVISOR.get_daemon(&id).await;
             let owns_pid = current.as_ref().is_some_and(|d| d.pid == Some(pid));
-            let is_stopping = current.as_ref().is_some_and(|d| d.status.is_stopping());
-            let stopped_cleared = current
-                .as_ref()
-                .is_some_and(|d| d.pid.is_none() && d.status.is_stopped());
-            if !owns_pid && !is_stopping && !stopped_cleared {
+            let finalized_ours = current.as_ref().is_some_and(|d| {
+                d.pid.is_none() && (d.status.is_stopped() || d.status.is_stopping())
+            });
+            if !owns_pid && !finalized_ours {
                 debug!("adopted daemon {id} has a successor; skipping exit handling");
                 return;
             }
 
-            // Exit codes of non-child processes cannot be observed.
-            let intentional =
-                is_stopping || stopped_cleared || matches!(outcome, PollOutcome::StoppedExternally);
+            // Exit codes of non-child processes cannot be observed. Stop
+            // intent comes from the snapshot taken when death was observed,
+            // or from the record having been finalized by stop() since.
+            let was_stopping = matches!(outcome, PollOutcome::ProcessDied { was_stopping: true });
+            let intentional = was_stopping
+                || finalized_ours
+                || matches!(outcome, PollOutcome::StoppedExternally)
+                || current
+                    .as_ref()
+                    .is_some_and(|d| d.status.is_stopping() || d.status.is_stopped());
             let (exit_code, exit_reason) = if intentional {
                 (-1, "stop")
             } else {
@@ -385,8 +409,9 @@ impl Supervisor {
             };
             info!("adopted daemon {id} (pid {pid}) exited ({exit_reason}, exit status unknown)");
 
-            // Update state unless stop() already finalized it.
-            if (owns_pid || is_stopping) && !stopped_cleared {
+            // Update state unless stop() already finalized it. Gated strictly
+            // on owning the PID so a successor's record is never written to.
+            if owns_pid {
                 {
                     let mut state_file = SUPERVISOR.state_file.lock().await;
                     state_file.clear_active_port(&id);

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -69,6 +69,10 @@ pub(crate) struct MonitoredGuard {
 }
 
 impl MonitoredGuard {
+    /// Unconditionally claim the daemon's registry entry, displacing any
+    /// previous monitor. Used by `run_once` when spawning a child: a fresh
+    /// process legitimately supersedes whatever monitor came before, and the
+    /// overwrite is what lets stale monitors detect the succession.
     pub(crate) fn register(id: DaemonId, pid: u32) -> Self {
         SUPERVISOR
             .monitored
@@ -76,6 +80,23 @@ impl MonitoredGuard {
             .expect("monitored lock poisoned")
             .insert(id.clone(), pid);
         Self { id, pid }
+    }
+
+    /// Claim the daemon's registry entry only if no monitor currently holds
+    /// it. Used by adoption, which must never displace a live monitor: this
+    /// check-and-insert is atomic under the registry lock, making it the
+    /// authoritative gate against two concurrent reconciliation passes
+    /// adopting the same process twice.
+    pub(crate) fn try_register(id: DaemonId, pid: u32) -> Option<Self> {
+        let mut monitored = SUPERVISOR
+            .monitored
+            .lock()
+            .expect("monitored lock poisoned");
+        if monitored.contains_key(&id) {
+            return None;
+        }
+        monitored.insert(id.clone(), pid);
+        Some(Self { id, pid })
     }
 }
 
@@ -273,6 +294,17 @@ impl Supervisor {
     /// poll monitor takes over for the `child.wait()` monitor that died with
     /// the previous supervisor.
     pub(crate) async fn adopt_daemon(&self, daemon: &Daemon, pid: u32, expected_start_time: u64) {
+        // Claim the registry entry BEFORE any await so two concurrent
+        // reconciliation passes (or startup scan + interval tick) cannot
+        // both adopt the same process and spawn duplicate poll monitors.
+        // The earlier is_monitored checks are advisory; this is the gate.
+        let Some(guard) = MonitoredGuard::try_register(daemon.id.clone(), pid) else {
+            debug!(
+                "daemon {} (pid {pid}) is already monitored; skipping duplicate adoption",
+                daemon.id
+            );
+            return;
+        };
         info!("re-adopting orphaned daemon {} (pid {pid})", daemon.id);
 
         // Legacy records matched by title have no persisted start_time.
@@ -295,8 +327,6 @@ impl Supervisor {
                 )
                 .await;
         }
-
-        let guard = MonitoredGuard::register(daemon.id.clone(), pid);
         let id = daemon.id.clone();
         let daemon_dir = daemon
             .dir

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -312,6 +312,17 @@ impl Supervisor {
             let outcome = loop {
                 time::sleep(POLL_INTERVAL).await;
 
+                // The monitored registry doubles as a generation marker:
+                // run_once overwrites this daemon's entry synchronously
+                // before any successor spawns, and each monitor's guard only
+                // removes its own value. If the entry no longer names our
+                // PID, a successor existed at some point — even one that
+                // already ran its full lifecycle between our polls — and its
+                // monitor owns the record's transitions and hooks.
+                if !SUPERVISOR.is_monitored(&id, pid) {
+                    break PollOutcome::TakenOver;
+                }
+
                 let Some(current) = SUPERVISOR.get_daemon(&id).await else {
                     break PollOutcome::TakenOver;
                 };
@@ -382,6 +393,16 @@ impl Supervisor {
             // the record still names our PID, or was finalized with no PID
             // at all (stop() observed our dead process and completed the
             // transition itself).
+            // Re-check the generation marker: a PID-less stopped record only
+            // belongs to this monitor if no successor ever registered over
+            // our entry. Without this, a successor's complete start+stop
+            // between two polls would be misattributed to our process and
+            // its stop hooks fired twice.
+            if !SUPERVISOR.is_monitored(&id, pid) {
+                debug!("adopted daemon {id} was superseded; skipping exit handling");
+                return;
+            }
+
             let current = SUPERVISOR.get_daemon(&id).await;
             let owns_pid = current.as_ref().is_some_and(|d| d.pid == Some(pid));
             let finalized_ours = current.as_ref().is_some_and(|d| {

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -1,0 +1,440 @@
+//! Re-adoption of orphaned daemons
+//!
+//! When the supervisor dies uncleanly (e.g. `kill -9`), its daemon child
+//! processes survive, re-parented to init. On restart, daemons whose recorded
+//! identity (PID + kernel start time) still matches a live process can be
+//! re-adopted: their state is kept and supervision resumes.
+//!
+//! An adopted process is no longer a child of the supervisor, so `wait()`
+//! based monitoring is impossible — a poll monitor watches liveness instead,
+//! anchored to the verified start time so a recycled PID is never mistaken
+//! for the daemon. Two consequences follow, both documented in the
+//! `orphan_policy` setting:
+//!
+//! - stdout/stderr capture cannot be restored (the pipes died with the old
+//!   supervisor); log capture resumes on the daemon's next restart
+//! - exit codes cannot be observed; an adopted daemon that dies unexpectedly
+//!   is marked `Errored(-1)` ("unknown exit code"), making it eligible for
+//!   its configured retries
+
+use super::Supervisor;
+use super::hooks::{HookType, fire_hook};
+use crate::daemon::Daemon;
+use crate::daemon_id::DaemonId;
+use crate::daemon_status::DaemonStatus;
+use crate::procs::PROCS;
+use crate::settings::settings;
+use crate::supervisor::SUPERVISOR;
+use crate::supervisor::state::UpsertDaemonOpts;
+use std::sync::atomic;
+use std::time::Duration;
+use tokio::time;
+
+/// How often the poll monitor checks that an adopted process is still alive.
+/// Chosen to roughly match the responsiveness of `child.wait()` monitoring
+/// without adding measurable load.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Why the poll monitor stopped watching an adopted process.
+enum PollOutcome {
+    /// The adopted process exited (or its PID was recycled, which means the
+    /// process exited unnoticed) while the daemon record still pointed at it.
+    ProcessDied,
+    /// `stop()` finished first: the record shows no PID and status `Stopped`.
+    /// State is already final, but the stop hooks still need to fire — the
+    /// regular child monitor fires them, `stop()` itself never does.
+    StoppedExternally,
+    /// Another process took over the daemon record (e.g. a restart spawned a
+    /// fresh child with its own monitor) or the record was removed. State is
+    /// the successor's to manage; touch nothing.
+    TakenOver,
+}
+
+/// RAII registration of a daemon in the supervisor's `monitored` map.
+///
+/// Created *synchronously* before the monitoring task is spawned so there is
+/// no window in which a supervised daemon looks unmonitored to the orphan
+/// reconciler. Dropped by the monitoring task when it finishes; the entry is
+/// only removed if it still refers to this guard's PID, so a monitor that
+/// outlives a restart (e.g. during the post-exit drain) cannot unregister
+/// its successor.
+pub(crate) struct MonitoredGuard {
+    id: DaemonId,
+    pid: u32,
+}
+
+impl MonitoredGuard {
+    pub(crate) fn register(id: DaemonId, pid: u32) -> Self {
+        SUPERVISOR
+            .monitored
+            .lock()
+            .expect("monitored lock poisoned")
+            .insert(id.clone(), pid);
+        Self { id, pid }
+    }
+}
+
+impl Drop for MonitoredGuard {
+    fn drop(&mut self) {
+        let mut monitored = SUPERVISOR
+            .monitored
+            .lock()
+            .expect("monitored lock poisoned");
+        if monitored.get(&self.id) == Some(&self.pid) {
+            monitored.remove(&self.id);
+        }
+    }
+}
+
+impl Supervisor {
+    /// Whether `id` currently has a live monitoring task watching `pid`.
+    pub(crate) fn is_monitored(&self, id: &DaemonId, pid: u32) -> bool {
+        self.monitored
+            .lock()
+            .expect("monitored lock poisoned")
+            .get(id)
+            == Some(&pid)
+    }
+
+    /// Interval-watcher reconciliation: find state-`running` daemons that no
+    /// live monitoring task is watching and bring state and reality back in
+    /// line. This covers windows the startup scan cannot see (e.g. a state
+    /// file restored from backup, or an orphan that appeared after startup).
+    ///
+    /// Mirrors the startup scan's fail-closed identity handling, then applies
+    /// `supervisor.orphan_policy` exactly like startup does:
+    ///
+    /// - dead PID → mark `Errored(-1)` so retry/cron/autostop logic behaves
+    /// - recycled PID → the daemon died unnoticed; mark `Errored(-1)`
+    /// - unverifiable identity → retain running state, touch nothing
+    /// - live and verified → adopt, or terminate under the `kill` policy
+    pub(crate) async fn reconcile_unmonitored_daemons(&self) {
+        if !settings().supervisor.cleanup_orphans {
+            return;
+        }
+
+        let candidates: Vec<Daemon> = {
+            let state = self.state_file.lock().await;
+            state
+                .daemons
+                .values()
+                .filter(|d| {
+                    d.id != DaemonId::pitchfork()
+                        && d.status.is_running()
+                        && d.pid.is_some_and(|pid| !self.is_monitored(&d.id, pid))
+                })
+                .cloned()
+                .collect()
+        };
+
+        if candidates.is_empty() {
+            return;
+        }
+
+        let policy = super::orphan_policy();
+
+        for daemon in candidates {
+            let Some(pid) = daemon.pid else { continue };
+            // Re-check under current state: a monitor may have registered
+            // between the snapshot and now.
+            if self.is_monitored(&daemon.id, pid) {
+                continue;
+            }
+
+            // Refresh each candidate immediately before checking it, matching
+            // the startup scan: processing an earlier candidate can await a
+            // stop timeout, during which this PID may exit and be recycled.
+            PROCS.refresh_pids(&[pid]);
+
+            if !PROCS.is_running(pid) {
+                // The monitor that would have observed this exit died with a
+                // previous supervisor; the exit status is unobservable.
+                warn!(
+                    "daemon {} (pid {pid}) died while unmonitored; marking errored",
+                    daemon.id
+                );
+                self.mark_unmonitored_death(&daemon.id).await;
+                continue;
+            }
+
+            let current_start_time = PROCS.start_time(pid);
+            let current_title = PROCS.title(pid);
+            let matches = super::process_identity_matches(
+                daemon.start_time,
+                daemon.title.as_deref(),
+                current_start_time,
+                current_title.as_deref(),
+            );
+
+            if !matches {
+                if daemon.start_time.is_some() && current_start_time.is_none() {
+                    warn!(
+                        "could not verify start time for live pid {pid} recorded for daemon {}; retaining running state",
+                        daemon.id,
+                    );
+                    continue;
+                }
+                // The PID belongs to a different process now, which means the
+                // daemon itself died unnoticed. Never touch the new process.
+                warn!(
+                    "pid {pid} recorded for daemon {} belongs to a different process now (PID recycled); marking errored",
+                    daemon.id,
+                );
+                self.mark_unmonitored_death(&daemon.id).await;
+                continue;
+            }
+
+            let Some(expected_start_time) = current_start_time else {
+                warn!(
+                    "could not read start time for live pid {pid} recorded for daemon {}; retaining running state",
+                    daemon.id,
+                );
+                continue;
+            };
+
+            if policy == "adopt" {
+                self.adopt_daemon(&daemon, pid, expected_start_time).await;
+                continue;
+            }
+
+            // `kill` policy applies on the interval path too — otherwise an
+            // unmonitored live daemon found at runtime would stay running
+            // unsupervised even though startup would have terminated it.
+            info!(
+                "terminating unmonitored orphaned daemon {} (pid {pid})",
+                daemon.id
+            );
+            let stop_cfg = daemon.stop_signal.unwrap_or_default();
+            match PROCS
+                .kill_process_group_if_start_time_matches_async(
+                    pid,
+                    expected_start_time,
+                    stop_cfg.signal.into(),
+                    stop_cfg.timeout,
+                )
+                .await
+            {
+                Ok(true) => {
+                    let _ = self
+                        .upsert_daemon(
+                            UpsertDaemonOpts::builder(daemon.id.clone())
+                                .set(|o| {
+                                    o.pid = None;
+                                    o.status = DaemonStatus::Stopped;
+                                    o.active_port = None;
+                                })
+                                .build(),
+                        )
+                        .await;
+                }
+                Ok(false) => {
+                    warn!(
+                        "could not securely terminate unmonitored orphaned daemon {} (pid {pid}); retaining running state",
+                        daemon.id
+                    );
+                }
+                Err(err) => {
+                    warn!(
+                        "failed to terminate unmonitored orphaned daemon {} (pid {pid}): {err}; retaining running state",
+                        daemon.id
+                    );
+                }
+            }
+        }
+    }
+
+    /// Mark a daemon whose process died (or was recycled) while unmonitored.
+    /// No hooks fire — the monitor that would have observed the exit died
+    /// with a previous supervisor, mirroring the startup scan's handling.
+    async fn mark_unmonitored_death(&self, id: &DaemonId) {
+        let _ = self
+            .upsert_daemon(
+                UpsertDaemonOpts::builder(id.clone())
+                    .set(|o| {
+                        o.pid = None;
+                        o.status = DaemonStatus::Errored(-1);
+                        o.last_exit_success = Some(false);
+                        o.active_port = None;
+                    })
+                    .build(),
+            )
+            .await;
+    }
+
+    /// Resume supervision of a live orphaned daemon process whose identity
+    /// has been verified against `expected_start_time`.
+    ///
+    /// The daemon's state (status, ports, proxy routing) is kept as-is; a
+    /// poll monitor takes over for the `child.wait()` monitor that died with
+    /// the previous supervisor.
+    pub(crate) async fn adopt_daemon(&self, daemon: &Daemon, pid: u32, expected_start_time: u64) {
+        info!("re-adopting orphaned daemon {} (pid {pid})", daemon.id);
+
+        // Legacy records matched by title have no persisted start_time.
+        // Re-upsert while the process cache is fresh so the identity fields
+        // are recorded for future scans and crashes.
+        if daemon.start_time.is_none() {
+            let _ = self
+                .upsert_daemon(
+                    UpsertDaemonOpts::builder(daemon.id.clone())
+                        .set(|o| {
+                            o.pid = Some(pid);
+                            o.status = DaemonStatus::Running;
+                        })
+                        .build(),
+                )
+                .await;
+        }
+
+        let guard = MonitoredGuard::register(daemon.id.clone(), pid);
+        let id = daemon.id.clone();
+        let daemon_dir = daemon
+            .dir
+            .clone()
+            .unwrap_or_else(|| crate::env::CWD.clone());
+        let hook_env = daemon.env.clone();
+        let hook_retry = daemon.retry;
+        let hook_retry_count = daemon.retry_count;
+
+        tokio::spawn(async move {
+            let _guard = guard;
+
+            let outcome = loop {
+                time::sleep(POLL_INTERVAL).await;
+
+                let Some(current) = SUPERVISOR.get_daemon(&id).await else {
+                    break PollOutcome::TakenOver;
+                };
+
+                if current.pid == Some(pid) {
+                    // Still ours — check liveness and identity. A start time
+                    // that no longer matches means our process died and the
+                    // OS recycled its PID: treat as death, and never touch
+                    // the unrelated new process.
+                    PROCS.refresh_pids(&[pid]);
+                    if !PROCS.is_running(pid) {
+                        break PollOutcome::ProcessDied;
+                    }
+                    match PROCS.start_time(pid) {
+                        Some(current_start_time) if current_start_time != expected_start_time => {
+                            break PollOutcome::ProcessDied;
+                        }
+                        None => {
+                            // Transient identity read failure: keep watching
+                            // on liveness alone. Treating this as death could
+                            // start a duplicate next to a live process.
+                            debug!(
+                                "could not read start time for adopted daemon {id} (pid {pid}); continuing on liveness only"
+                            );
+                        }
+                        _ => {}
+                    }
+                } else if current.status.is_stopping() {
+                    // stop() in flight — wait for it to finish so the exit
+                    // path below can fire the stop hooks.
+                } else if current.pid.is_none() && current.status.is_stopped() {
+                    break PollOutcome::StoppedExternally;
+                } else {
+                    break PollOutcome::TakenOver;
+                }
+            };
+
+            if matches!(outcome, PollOutcome::TakenOver) {
+                debug!("adopted daemon {id} was taken over or removed; poll monitor exiting");
+                return;
+            }
+
+            // Mirror the child monitor's exit path, minus everything that
+            // requires the (long-gone) stdio pipes.
+            SUPERVISOR
+                .active_monitors
+                .fetch_add(1, atomic::Ordering::Release);
+            struct MonitorGuard;
+            impl Drop for MonitorGuard {
+                fn drop(&mut self) {
+                    SUPERVISOR
+                        .active_monitors
+                        .fetch_sub(1, atomic::Ordering::Release);
+                    SUPERVISOR.monitor_done.notify_waiters();
+                }
+            }
+            let _monitor_guard = MonitorGuard;
+
+            // Re-read state and verify this monitor still owns the record
+            // before mutating anything. A restart can spawn a successor
+            // between observing the death and reaching this point; its
+            // state (PID, status, active port) is not ours to touch.
+            let current = SUPERVISOR.get_daemon(&id).await;
+            let owns_pid = current.as_ref().is_some_and(|d| d.pid == Some(pid));
+            let is_stopping = current.as_ref().is_some_and(|d| d.status.is_stopping());
+            let stopped_cleared = current
+                .as_ref()
+                .is_some_and(|d| d.pid.is_none() && d.status.is_stopped());
+            if !owns_pid && !is_stopping && !stopped_cleared {
+                debug!("adopted daemon {id} has a successor; skipping exit handling");
+                return;
+            }
+
+            // Exit codes of non-child processes cannot be observed.
+            let intentional =
+                is_stopping || stopped_cleared || matches!(outcome, PollOutcome::StoppedExternally);
+            let (exit_code, exit_reason) = if intentional {
+                (-1, "stop")
+            } else {
+                (-1, "fail")
+            };
+            info!("adopted daemon {id} (pid {pid}) exited ({exit_reason}, exit status unknown)");
+
+            // Update state unless stop() already finalized it.
+            if (owns_pid || is_stopping) && !stopped_cleared {
+                {
+                    let mut state_file = SUPERVISOR.state_file.lock().await;
+                    state_file.clear_active_port(&id);
+                }
+                let new_status = match exit_reason {
+                    "stop" => DaemonStatus::Stopped,
+                    _ => DaemonStatus::Errored(exit_code),
+                };
+                let last_exit_success = exit_reason == "stop";
+                if let Err(e) = SUPERVISOR
+                    .upsert_daemon(
+                        UpsertDaemonOpts::builder(id.clone())
+                            .set(|o| {
+                                o.pid = None;
+                                o.status = new_status;
+                                o.last_exit_success = Some(last_exit_success);
+                            })
+                            .build(),
+                    )
+                    .await
+                {
+                    error!("failed to update state for adopted daemon {id}: {e}");
+                }
+            }
+
+            let hook_extra_env = vec![
+                ("PITCHFORK_EXIT_CODE".to_string(), exit_code.to_string()),
+                ("PITCHFORK_EXIT_REASON".to_string(), exit_reason.to_string()),
+            ];
+            let hooks_to_fire: Vec<HookType> = match exit_reason {
+                "stop" => vec![HookType::OnStop, HookType::OnExit],
+                // "fail": fire on_fail + on_exit only when retries are exhausted
+                _ if hook_retry_count >= hook_retry.count() => {
+                    vec![HookType::OnFail, HookType::OnExit]
+                }
+                _ => vec![],
+            };
+            for hook_type in hooks_to_fire {
+                fire_hook(
+                    hook_type,
+                    id.clone(),
+                    daemon_dir.clone(),
+                    hook_retry_count,
+                    hook_env.clone(),
+                    hook_extra_env.clone(),
+                )
+                .await;
+            }
+        });
+    }
+}

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -55,31 +55,47 @@ enum PollOutcome {
     TakenOver,
 }
 
+/// Monotonic token distinguishing individual monitor registrations. PIDs are
+/// not sufficient: the OS can recycle a dead daemon's PID for its own
+/// successor, and two guards carrying the same (id, pid) pair would then be
+/// indistinguishable — the stale one could unregister the live one.
+static NEXT_MONITOR_TOKEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+/// A registration in the supervisor's `monitored` map: which PID is being
+/// watched and by which registration (token).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct MonitorEntry {
+    pub(crate) pid: u32,
+    pub(crate) token: u64,
+}
+
 /// RAII registration of a daemon in the supervisor's `monitored` map.
 ///
 /// Created *synchronously* before the monitoring task is spawned so there is
 /// no window in which a supervised daemon looks unmonitored to the orphan
 /// reconciler. Dropped by the monitoring task when it finishes; the entry is
-/// only removed if it still refers to this guard's PID, so a monitor that
+/// only removed if it still carries this guard's token, so a monitor that
 /// outlives a restart (e.g. during the post-exit drain) cannot unregister
-/// its successor.
+/// its successor — even a successor that recycled the same numeric PID.
 pub(crate) struct MonitoredGuard {
     id: DaemonId,
-    pid: u32,
+    token: u64,
 }
 
 impl MonitoredGuard {
     /// Unconditionally claim the daemon's registry entry, displacing any
     /// previous monitor. Used by `run_once` when spawning a child: a fresh
     /// process legitimately supersedes whatever monitor came before, and the
-    /// overwrite is what lets stale monitors detect the succession.
+    /// overwrite (new token) is what lets stale monitors detect the
+    /// succession.
     pub(crate) fn register(id: DaemonId, pid: u32) -> Self {
+        let token = NEXT_MONITOR_TOKEN.fetch_add(1, atomic::Ordering::Relaxed);
         SUPERVISOR
             .monitored
             .lock()
             .expect("monitored lock poisoned")
-            .insert(id.clone(), pid);
-        Self { id, pid }
+            .insert(id.clone(), MonitorEntry { pid, token });
+        Self { id, token }
     }
 
     /// Claim the daemon's registry entry only if no monitor currently holds
@@ -95,8 +111,15 @@ impl MonitoredGuard {
         if monitored.contains_key(&id) {
             return None;
         }
-        monitored.insert(id.clone(), pid);
-        Some(Self { id, pid })
+        let token = NEXT_MONITOR_TOKEN.fetch_add(1, atomic::Ordering::Relaxed);
+        monitored.insert(id.clone(), MonitorEntry { pid, token });
+        Some(Self { id, token })
+    }
+
+    /// The unique token of this registration, compared by monitors to detect
+    /// having been superseded.
+    pub(crate) fn token(&self) -> u64 {
+        self.token
     }
 }
 
@@ -106,7 +129,7 @@ impl Drop for MonitoredGuard {
             .monitored
             .lock()
             .expect("monitored lock poisoned");
-        if monitored.get(&self.id) == Some(&self.pid) {
+        if monitored.get(&self.id).map(|e| e.token) == Some(self.token) {
             monitored.remove(&self.id);
         }
     }
@@ -119,7 +142,18 @@ impl Supervisor {
             .lock()
             .expect("monitored lock poisoned")
             .get(id)
-            == Some(&pid)
+            .is_some_and(|e| e.pid == pid)
+    }
+
+    /// Whether the registry entry for `id` still belongs to the registration
+    /// identified by `token`. Unlike `is_monitored` this cannot be confused
+    /// by a successor that recycled the same numeric PID.
+    fn monitor_token_valid(&self, id: &DaemonId, token: u64) -> bool {
+        self.monitored
+            .lock()
+            .expect("monitored lock poisoned")
+            .get(id)
+            .is_some_and(|e| e.token == token)
     }
 
     /// Interval-watcher reconciliation: find state-`running` daemons that no
@@ -179,7 +213,8 @@ impl Supervisor {
                     "daemon {} (pid {pid}) died while unmonitored; marking errored",
                     daemon.id
                 );
-                self.mark_unmonitored_death(&daemon.id).await;
+                self.finalize_if_pid(&daemon.id, pid, DaemonStatus::Errored(-1), Some(false))
+                    .await;
                 continue;
             }
 
@@ -206,7 +241,8 @@ impl Supervisor {
                     "pid {pid} recorded for daemon {} belongs to a different process now (PID recycled); marking errored",
                     daemon.id,
                 );
-                self.mark_unmonitored_death(&daemon.id).await;
+                self.finalize_if_pid(&daemon.id, pid, DaemonStatus::Errored(-1), Some(false))
+                    .await;
                 continue;
             }
 
@@ -241,16 +277,7 @@ impl Supervisor {
                 .await
             {
                 Ok(true) => {
-                    let _ = self
-                        .upsert_daemon(
-                            UpsertDaemonOpts::builder(daemon.id.clone())
-                                .set(|o| {
-                                    o.pid = None;
-                                    o.status = DaemonStatus::Stopped;
-                                    o.active_port = None;
-                                })
-                                .build(),
-                        )
+                    self.finalize_if_pid(&daemon.id, pid, DaemonStatus::Stopped, None)
                         .await;
                 }
                 Ok(false) => {
@@ -269,22 +296,42 @@ impl Supervisor {
         }
     }
 
-    /// Mark a daemon whose process died (or was recycled) while unmonitored.
-    /// No hooks fire — the monitor that would have observed the exit died
-    /// with a previous supervisor, mirroring the startup scan's handling.
-    async fn mark_unmonitored_death(&self, id: &DaemonId) {
-        let _ = self
-            .upsert_daemon(
-                UpsertDaemonOpts::builder(id.clone())
-                    .set(|o| {
-                        o.pid = None;
-                        o.status = DaemonStatus::Errored(-1);
-                        o.last_exit_success = Some(false);
-                        o.active_port = None;
-                    })
-                    .build(),
-            )
-            .await;
+    /// Finalize a daemon's terminal state only if its record still names
+    /// `pid`. The ownership re-check and the mutation share one state-lock
+    /// critical section, so a successor installed after the caller's
+    /// snapshot is never overwritten — its upsert serializes after ours and
+    /// the in-lock check stands down. No hooks fire from these transitions —
+    /// the monitor that would have observed the exit died with a previous
+    /// supervisor, mirroring the startup scan's handling.
+    ///
+    /// Returns whether the write happened.
+    async fn finalize_if_pid(
+        &self,
+        id: &DaemonId,
+        pid: u32,
+        status: DaemonStatus,
+        last_exit_success: Option<bool>,
+    ) -> bool {
+        let mut state_file = self.state_file.lock().await;
+        let Some(d) = state_file.daemons.get(id) else {
+            return false;
+        };
+        if d.pid != Some(pid) {
+            debug!("daemon {id} was claimed by a successor; skipping finalization");
+            return false;
+        }
+        let mut d = d.clone();
+        d.pid = None;
+        d.title = None;
+        d.start_time = None;
+        d.status = status;
+        if let Some(les) = last_exit_success {
+            d.last_exit_success = Some(les);
+        }
+        d.active_port = None;
+        state_file.clear_active_port(id);
+        state_file.insert_daemon(id, d);
+        true
     }
 
     /// Resume supervision of a live orphaned daemon process whose identity
@@ -337,6 +384,7 @@ impl Supervisor {
         let hook_retry_count = daemon.retry_count;
 
         tokio::spawn(async move {
+            let token = guard.token();
             let _guard = guard;
 
             let outcome = loop {
@@ -345,11 +393,12 @@ impl Supervisor {
                 // The monitored registry doubles as a generation marker:
                 // run_once overwrites this daemon's entry synchronously
                 // before any successor spawns, and each monitor's guard only
-                // removes its own value. If the entry no longer names our
-                // PID, a successor existed at some point — even one that
-                // already ran its full lifecycle between our polls — and its
+                // removes its own registration. If the entry no longer
+                // carries our token, a successor existed at some point —
+                // even one that already ran its full lifecycle between our
+                // polls, or one that recycled our numeric PID — and its
                 // monitor owns the record's transitions and hooks.
-                if !SUPERVISOR.is_monitored(&id, pid) {
+                if !SUPERVISOR.monitor_token_valid(&id, token) {
                     break PollOutcome::TakenOver;
                 }
 
@@ -428,7 +477,7 @@ impl Supervisor {
             // our entry. Without this, a successor's complete start+stop
             // between two polls would be misattributed to our process and
             // its stop hooks fired twice.
-            if !SUPERVISOR.is_monitored(&id, pid) {
+            if !SUPERVISOR.monitor_token_valid(&id, token) {
                 debug!("adopted daemon {id} was superseded; skipping exit handling");
                 return;
             }
@@ -473,7 +522,7 @@ impl Supervisor {
                 };
                 let last_exit_success = exit_reason == "stop";
                 let mut state_file = SUPERVISOR.state_file.lock().await;
-                let still_ours = SUPERVISOR.is_monitored(&id, pid)
+                let still_ours = SUPERVISOR.monitor_token_valid(&id, token)
                     && state_file
                         .daemons
                         .get(&id)

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -430,31 +430,40 @@ impl Supervisor {
             };
             info!("adopted daemon {id} (pid {pid}) exited ({exit_reason}, exit status unknown)");
 
-            // Update state unless stop() already finalized it. Gated strictly
-            // on owning the PID so a successor's record is never written to.
+            // Update state unless stop() already finalized it. Ownership is
+            // re-validated inside the same state-lock critical section that
+            // performs the write, so a successor starting between the checks
+            // above and the mutation cannot have its record overwritten —
+            // its own upsert would be serialized after ours and we would see
+            // its PID here and stand down.
             if owns_pid {
-                {
-                    let mut state_file = SUPERVISOR.state_file.lock().await;
-                    state_file.clear_active_port(&id);
-                }
                 let new_status = match exit_reason {
                     "stop" => DaemonStatus::Stopped,
                     _ => DaemonStatus::Errored(exit_code),
                 };
                 let last_exit_success = exit_reason == "stop";
-                if let Err(e) = SUPERVISOR
-                    .upsert_daemon(
-                        UpsertDaemonOpts::builder(id.clone())
-                            .set(|o| {
-                                o.pid = None;
-                                o.status = new_status;
-                                o.last_exit_success = Some(last_exit_success);
-                            })
-                            .build(),
-                    )
-                    .await
-                {
-                    error!("failed to update state for adopted daemon {id}: {e}");
+                let mut state_file = SUPERVISOR.state_file.lock().await;
+                let still_ours = SUPERVISOR.is_monitored(&id, pid)
+                    && state_file
+                        .daemons
+                        .get(&id)
+                        .is_some_and(|d| d.pid == Some(pid));
+                if !still_ours {
+                    debug!(
+                        "adopted daemon {id} was claimed by a successor; skipping exit handling"
+                    );
+                    return;
+                }
+                state_file.clear_active_port(&id);
+                if let Some(d) = state_file.daemons.get(&id) {
+                    let mut d = d.clone();
+                    d.pid = None;
+                    d.title = None;
+                    d.start_time = None;
+                    d.status = new_status;
+                    d.last_exit_success = Some(last_exit_success);
+                    d.active_port = None;
+                    state_file.insert_daemon(&id, d);
                 }
             }
 

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -631,8 +631,14 @@ impl Supervisor {
             error!("Failed to capture stdout/stderr for daemon {id}");
         }
 
+        // Register the daemon as monitored BEFORE spawning the task so orphan
+        // reconciliation never observes a supervised daemon without a monitor
+        // entry. The guard is moved into the task and unregisters on exit.
+        let monitored_guard = super::adopt::MonitoredGuard::register(id.clone(), daemon_pid);
+
         tokio::spawn(async move {
             let id = id_clone;
+            let _monitored_guard = monitored_guard;
 
             // Merge all output sources (PTY master OR stdout+stderr) into a single channel.
             let (output_tx, mut output_rx) = tokio::sync::mpsc::channel::<String>(256);

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -547,6 +547,14 @@ impl Supervisor {
         };
         info!("started daemon {id} with pid {pid}");
         PROCS.refresh_pids(&[pid]);
+        // Register the daemon as monitored BEFORE persisting the Running
+        // state. The orphan reconciler treats any running, unmonitored PID
+        // as an orphan; if the state became visible first, a concurrent
+        // reconciliation pass could adopt — or under the kill policy,
+        // terminate — a daemon that was just legitimately started. The RAII
+        // guard unregisters on any early-error path below and is otherwise
+        // handed to the monitoring task.
+        let monitored_guard = super::adopt::MonitoredGuard::register(id.clone(), pid);
         let daemon = self
             .upsert_daemon(
                 UpsertDaemonOpts::from_run_options(&opts, DaemonStatus::Running)
@@ -631,13 +639,10 @@ impl Supervisor {
             error!("Failed to capture stdout/stderr for daemon {id}");
         }
 
-        // Register the daemon as monitored BEFORE spawning the task so orphan
-        // reconciliation never observes a supervised daemon without a monitor
-        // entry. The guard is moved into the task and unregisters on exit.
-        let monitored_guard = super::adopt::MonitoredGuard::register(id.clone(), daemon_pid);
-
         tokio::spawn(async move {
             let id = id_clone;
+            // Registered before the Running upsert above; unregisters when
+            // this monitoring task ends.
             let _monitored_guard = monitored_guard;
 
             // Merge all output sources (PTY master OR stdout+stderr) into a single channel.

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -3,11 +3,13 @@
 //! This module is split into focused submodules:
 //! - `state`: State access layer (get/set operations)
 //! - `lifecycle`: Daemon start/stop operations
+//! - `adopt`: Re-adoption of orphaned daemons after a supervisor crash
 //! - `autostop`: Autostop logic and boot daemon startup
 //! - `retry`: Retry logic with backoff
 //! - `watchers`: Background tasks (interval, cron, file watching)
 //! - `ipc_handlers`: IPC request dispatch
 
+mod adopt;
 mod autostop;
 mod hooks;
 mod ipc_handlers;
@@ -92,6 +94,11 @@ pub struct Supervisor {
     pub(crate) lan_monitor_task: Mutex<Option<JoinHandle<()>>>,
     /// Cancellation token for the background state flush task.
     pub(crate) flush_cancel: std::sync::Mutex<Option<tokio_util::sync::CancellationToken>>,
+    /// Daemons that currently have a live monitoring task (child `wait()`
+    /// monitor or adopted-orphan poll monitor), keyed to the PID being
+    /// monitored. Lets orphan reconciliation tell a supervised daemon from
+    /// one whose monitor died with a previous supervisor process.
+    pub(crate) monitored: std::sync::Mutex<HashMap<DaemonId, u32>>,
 }
 
 pub(crate) fn interval_duration() -> Duration {
@@ -260,6 +267,7 @@ impl Supervisor {
             mdns_publisher: Mutex::new(None),
             lan_monitor_task: Mutex::new(None),
             flush_cancel: std::sync::Mutex::new(None),
+            monitored: std::sync::Mutex::new(HashMap::new()),
         })
     }
 
@@ -738,6 +746,12 @@ impl Supervisor {
         for dir in dirs_to_leave {
             self.leave_dir(&dir).await?;
         }
+
+        // Catch state-`running` daemons that lost their monitor (e.g. the
+        // monitor died with a previous supervisor): mark dead ones errored
+        // and re-adopt live ones. Runs before check_retry so a daemon marked
+        // errored here is retried on this same tick.
+        self.reconcile_unmonitored_daemons().await;
 
         self.check_retry().await?;
         self.process_pending_autostops().await?;
@@ -1232,21 +1246,23 @@ fn chmod_safe_subtrees(state_dir: &std::path::Path) {
     }
 }
 
-/// On startup, kill any daemon processes left behind by a previous supervisor
+/// On startup, reconcile daemon processes left behind by a previous supervisor
 /// that was terminated unexpectedly (e.g. `kill -9`).
 ///
 /// This iterates the state file for daemon entries with a recorded PID. If the
 /// PID is still alive and its current identity matches the recorded start time
 /// (or the recorded title for older state files), it is assumed to be an orphan
-/// from the previous supervisor session and is killed. The daemon's state is
-/// then reset to `Stopped` with no PID. If a matching live process cannot be
-/// terminated securely, its running state is retained to prevent a duplicate
-/// instance from being started.
+/// from the previous supervisor session and `supervisor.orphan_policy` decides
+/// its fate: `adopt` (default) resumes supervision via a poll monitor and keeps
+/// the daemon's state intact; `kill` terminates it and resets its state to
+/// `Stopped` with no PID. If a matching live process cannot be terminated
+/// securely, its running state is retained to prevent a duplicate instance
+/// from being started.
 ///
 /// Missing or mismatched identity data fails closed so a PID recycled by an
-/// unrelated process is never killed. On Unix platforms without durable
-/// process handles, orphan termination also fails closed because the PID/PGID
-/// cannot be pinned between identity validation and signaling.
+/// unrelated process is never adopted or killed. On Unix platforms without
+/// durable process handles, orphan termination also fails closed because the
+/// PID/PGID cannot be pinned between identity validation and signaling.
 ///
 /// This is gated by the `supervisor.cleanup_orphans` setting (default: true).
 async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
@@ -1272,6 +1288,8 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
         "checking {} daemon(s) for orphaned processes",
         candidates.len()
     );
+
+    let policy = orphan_policy();
 
     for daemon in candidates {
         let Some(pid) = daemon.pid else { continue };
@@ -1317,6 +1335,9 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
             continue;
         }
 
+        // Both policies need a verified start time: killing revalidates it
+        // while pinned to the process, and adoption anchors its poll monitor
+        // to it so a later PID recycle is never mistaken for the daemon.
         let Some(expected_start_time) = current_start_time else {
             warn!(
                 "could not read start time for live pid {pid} recorded for daemon {}; retaining running state",
@@ -1324,6 +1345,16 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
             );
             continue;
         };
+
+        // Identity verified — the process really is our orphaned daemon.
+        // The policy decides whether supervision resumes or the slate is
+        // wiped clean.
+        if policy == "adopt" {
+            supervisor
+                .adopt_daemon(&daemon, pid, expected_start_time)
+                .await;
+            continue;
+        }
 
         info!("terminating orphaned daemon {} (pid {pid})", daemon.id);
 
@@ -1356,6 +1387,19 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
         }
 
         reset_daemon_state(supervisor, &daemon.id).await;
+    }
+}
+
+/// Effective `supervisor.orphan_policy`, warning on an unrecognized value
+/// (which falls back to the default of adopting).
+pub(crate) fn orphan_policy() -> String {
+    let policy = settings().supervisor.orphan_policy.clone();
+    match policy.as_str() {
+        "adopt" | "kill" => policy,
+        other => {
+            warn!("unknown supervisor.orphan_policy '{other}', defaulting to 'adopt'");
+            "adopt".to_string()
+        }
     }
 }
 

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -96,9 +96,10 @@ pub struct Supervisor {
     pub(crate) flush_cancel: std::sync::Mutex<Option<tokio_util::sync::CancellationToken>>,
     /// Daemons that currently have a live monitoring task (child `wait()`
     /// monitor or adopted-orphan poll monitor), keyed to the PID being
-    /// monitored. Lets orphan reconciliation tell a supervised daemon from
-    /// one whose monitor died with a previous supervisor process.
-    pub(crate) monitored: std::sync::Mutex<HashMap<DaemonId, u32>>,
+    /// monitored plus a unique registration token. Lets orphan
+    /// reconciliation tell a supervised daemon from one whose monitor died
+    /// with a previous supervisor process.
+    pub(crate) monitored: std::sync::Mutex<HashMap<DaemonId, adopt::MonitorEntry>>,
 }
 
 pub(crate) fn interval_duration() -> Duration {

--- a/test/supervisor.bats
+++ b/test/supervisor.bats
@@ -108,10 +108,12 @@ get_supervisor_pid() {
   kill_port 18998
 }
 
-@test "orphaned daemons are cleaned up on supervisor restart" {
+@test "orphan_policy=kill terminates orphaned daemons on supervisor restart" {
   if [[ "$(uname -s)" != "Linux" && "$(uname -s)" != MINGW* && "$(uname -s)" != MSYS* ]]; then
     skip "secure process-group termination is unavailable on this Unix platform"
   fi
+  # The default policy re-adopts orphans; this test pins the kill policy.
+  export PITCHFORK_ORPHAN_POLICY=kill
 
   create_pitchfork_toml <<EOF
 [daemons.orphan_test]
@@ -253,6 +255,131 @@ EOF
   assert_output --partial "stopped"
 
   { kill -9 "$bystander_pid" && wait "$bystander_pid"; } 2>/dev/null || true
+}
+
+@test "crashed supervisor re-adopts running daemon by default" {
+
+  create_pitchfork_toml <<EOF
+[daemons.adopt_test]
+run = "sleep 120"
+ready_delay = 1
+EOF
+
+  run pitchfork start adopt_test
+  assert_success
+  wait_for_status adopt_test running
+
+  local daemon_pid
+  daemon_pid="$(get_daemon_pid adopt_test)"
+  [[ -n "$daemon_pid" ]]
+
+  local sup_pid
+  sup_pid="$(get_supervisor_pid)"
+  [[ -n "$sup_pid" ]]
+
+  # SIGKILL the supervisor so its daemon child is left orphaned.
+  kill_pid "$sup_pid"
+  sleep 1
+  pid_alive "$daemon_pid"
+
+  run pitchfork supervisor start
+  assert_success
+  sleep 3
+
+  # The SAME process is still alive and supervised again — not killed,
+  # not restarted, not duplicated.
+  pid_alive "$daemon_pid"
+  wait_for_status adopt_test running
+  [[ "$(get_daemon_pid adopt_test)" == "$daemon_pid" ]]
+
+  run pitchfork start adopt_test
+  assert_output --partial "already running"
+
+  # Stopping an adopted daemon terminates the process and the poll
+  # monitor completes the stopped transition.
+  run pitchfork stop adopt_test
+  assert_success
+  wait_for_status adopt_test stopped
+  run pid_alive "$daemon_pid"
+  assert_failure
+}
+
+@test "adopted daemon death is detected and marked errored" {
+
+  create_pitchfork_toml <<EOF
+[daemons.adopt_exit]
+run = "sleep 120"
+ready_delay = 1
+EOF
+
+  run pitchfork start adopt_exit
+  assert_success
+  wait_for_status adopt_exit running
+
+  local daemon_pid
+  daemon_pid="$(get_daemon_pid adopt_exit)"
+  [[ -n "$daemon_pid" ]]
+
+  local sup_pid
+  sup_pid="$(get_supervisor_pid)"
+  [[ -n "$sup_pid" ]]
+
+  kill_pid "$sup_pid"
+  sleep 1
+
+  run pitchfork supervisor start
+  assert_success
+  sleep 3
+  wait_for_status adopt_exit running
+
+  # Kill the adopted process externally; the poll monitor cannot observe
+  # the exit status of a non-child, so the daemon is marked errored.
+  kill_pid "$daemon_pid"
+  wait_for_status adopt_exit errored 30
+}
+
+@test "stopping an adopted daemon fires on_stop and on_exit hooks" {
+  local stop_marker
+  stop_marker="$(to_shell_path "$TEST_TEMP_DIR/adopt_stop_marker")"
+  local exit_marker
+  exit_marker="$(to_shell_path "$TEST_TEMP_DIR/adopt_exit_marker")"
+
+  create_pitchfork_toml <<EOF
+[daemons.adopt_hooks]
+run = "sleep 120"
+ready_delay = 1
+
+[daemons.adopt_hooks.hooks]
+on_stop = "touch \"$stop_marker\""
+on_exit = "touch \"$exit_marker\""
+EOF
+
+  run pitchfork start adopt_hooks
+  assert_success
+  wait_for_status adopt_hooks running
+
+  local sup_pid
+  sup_pid="$(get_supervisor_pid)"
+  [[ -n "$sup_pid" ]]
+
+  kill_pid "$sup_pid"
+  sleep 1
+
+  run pitchfork supervisor start
+  assert_success
+  sleep 3
+  wait_for_status adopt_hooks running
+
+  # stop() finalizes state itself; the poll monitor must still fire the
+  # stop hooks even when it wakes up after the stop already completed.
+  run pitchfork stop adopt_hooks
+  assert_success
+  wait_for_status adopt_hooks stopped
+
+  wait_for_file "$stop_marker"
+  assert_file_exists "$stop_marker"
+  wait_for_file "$exit_marker"
+  assert_file_exists "$exit_marker"
 }
 
 # ============================================================================


### PR DESCRIPTION
## Context

Implements the re-adoption half of #631 (rebased onto main now that #632 is merged): the reporter asked that a restarted supervisor either re-adopt orphaned daemons or stop them before considering them startable. #632 made the kill path safe; this PR makes **re-adoption the default**, built on its fail-closed identity machinery.

## Behavior

On supervisor startup, for each state daemon whose recorded PID is alive and whose identity (PID + kernel start time) is verified:

- **`orphan_policy = "adopt"` (new default)**: the process keeps running and supervision resumes — state, resolved ports, and proxy routing stay intact. Since the process is no longer a child of the supervisor, `child.wait()` monitoring is impossible; a poll monitor (2s) takes over, anchored to the verified start time so a later PID recycle is never mistaken for the daemon. It mirrors the regular monitor's exit path: `stop` transitions to `stopped` and fires `on_stop`/`on_exit` (even when `stop()` finalizes the record before the poll monitor wakes); unexpected death marks `errored` with unknown exit code (exit codes of non-children are unobservable), feeding the existing retry machinery — a retried daemon respawns as a normal child again. Legacy title-matched records get their `start_time` persisted at adoption.
- **`orphan_policy = "kill"`**: pre-adoption behavior — the pinned, fail-closed termination from #632.
- Unverifiable identity retains running state untouched (fail closed, both policies); dead or recycled PIDs reset state. `cleanup_orphans = false` still skips orphan handling entirely (legacy escape hatch; docs updated to point at `orphan_policy`).

### Interval-watcher reconciliation

A new `monitored` registry (daemon → PID under a live monitor task) lets the 10s interval watcher catch state-`running` daemons that nothing is watching, applying the same fail-closed checks and orphan policy as the startup scan: dead or recycled PIDs are marked `errored(-1)` (previously a stale `running` record could persist forever when startup cleanup was skipped), live verified ones are adopted or terminated per policy. Registration happens synchronously before monitor spawn, with restart-overlap-safe RAII removal, so supervised daemons never appear unmonitored. The poll monitor re-verifies record ownership before mutating state, so a stale monitor can never clobber a successor process's state.

### Known limitation (follow-up planned)

Log capture cannot be restored for an adopted process — its stdout/stderr pipes died with the old supervisor. Output capture resumes on the daemon's next restart. A follow-up will explore re-attaching via `/proc/<pid>/fd` on Linux (reopening the surviving pipe inode recovers capture and up to 64KB of gap output), and possibly FIFO-based capture for a cross-platform fix; connected-socket approaches don't work here since a broken stream fd can't be re-pointed at a new listener.

## Tests

- `crashed supervisor re-adopts running daemon by default` — same PID survives crash+restart, still `running`, `start` refuses a duplicate, `stop` terminates the adopted process and completes the transition
- `adopted daemon death is detected and marked errored` — external kill of the adopted process is caught by the poll monitor
- `stopping an adopted daemon fires on_stop and on_exit hooks` — regression for the stop-hooks race found in review
- the kill test is pinned to `PITCHFORK_ORPHAN_POLICY=kill`; the recycled-PID bystander test is policy-independent and unchanged

Review feedback from Bugbot (stop hooks, kill policy on the interval path) and Greptile (successor-state clobbering, P1) is addressed in the current revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Supervisors can now reconcile orphaned daemon processes after restarting.
  - By default, verified orphaned daemons are re-adopted and continue running under supervision.
  - Added an option to terminate orphaned daemons instead.
  - Re-adopted daemons are monitored for termination and process identity changes.

- **Bug Fixes**
  - Improved handling when daemon monitoring is unexpectedly lost.
  - Unverifiable or mismatched processes now fail safely without being terminated.

- **Documentation**
  - Expanded configuration guidance for orphan verification, adoption, termination, and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core supervisor lifecycle around process identity, concurrent monitors, and startup/interval reconciliation; mistakes could kill wrong processes, duplicate daemons, or corrupt state/hooks.
> 
> **Overview**
> After an unclean supervisor exit, verified live daemon processes are **reconciled** instead of always being killed. New **`supervisor.orphan_policy`** defaults to **`adopt`**: keep the process, preserve state/ports/proxy routing, and resume supervision via a **2s poll monitor** (no restored stdio; unknown exit codes → `errored` and retries). **`kill`** preserves the prior terminate-on-restart behavior.
> 
> A **`monitored` registry** with tokenized **`MonitoredGuard`** registration (before `Running` state is written on normal starts) distinguishes supervised daemons from orphans. The **interval watcher** runs the same fail-closed identity checks and policy for unmonitored `running` records (dead/recycled → `errored(-1)`).
> 
> Docs/schema add **`orphan_policy`**; **`cleanup_orphans`** is described as reconciliation. Bats cover default adoption, adopted death/hooks, and pin the old kill test with **`PITCHFORK_ORPHAN_POLICY=kill`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fa361821db70d067c8cbb544d896b6ca3757b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->