### PR TITLE
[RFC] fix(supervisor): prevent stale monitor state overwrites

### DIFF
--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -244,28 +244,6 @@ impl PitchforkServer {
         let ids = PitchforkToml::resolve_ids(&params.id)
             .map_err(|e| internal_err(format!("Failed to resolve daemon IDs: {e}")))?;
 
-        // Snapshot running daemons before stop to determine what was actually stopped
-        let running_before: std::collections::HashSet<_> = ipc
-            .get_running_daemons()
-            .await
-            .map_err(|e| internal_err(format!("Failed to query running daemons: {e}")))?
-            .into_iter()
-            .collect();
-
-        let actually_running: Vec<_> = ids
-            .iter()
-            .filter(|id| running_before.contains(id))
-            .cloned()
-            .collect();
-
-        if actually_running.is_empty() {
-            let names: Vec<String> = ids.iter().map(|id| id.qualified()).collect();
-            return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
-                "No daemons were running: {}",
-                names.join(", ")
-            ))]));
-        }
-
         let result = ipc
             .stop_daemons(&ids)
             .await
@@ -276,9 +254,9 @@ impl PitchforkServer {
                 "Some daemons failed to stop",
             )]))
         } else {
-            let names: Vec<String> = actually_running.iter().map(|id| id.qualified()).collect();
+            let names: Vec<String> = ids.iter().map(|id| id.qualified()).collect();
             Ok(CallToolResult::success(vec![ContentBlock::text(format!(
-                "Stopped: {}",
+                "Stop processed: {}",
                 names.join(", ")
             ))]))
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -209,6 +209,14 @@ pub struct RunOptions {
 }
 
 impl Daemon {
+    /// Whether the persisted daemon state is eligible for another retry.
+    pub(crate) fn needs_retry(&self) -> bool {
+        self.status.is_errored()
+            && self.pid.is_none()
+            && self.retry.count() > 0
+            && self.retry_count < self.retry.count()
+    }
+
     /// Build RunOptions from persisted daemon state.
     ///
     /// Carries over all configuration fields from the daemon state.

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -954,21 +954,21 @@ impl IpcClient {
             .map(|d| d.id.clone())
             .collect();
 
-        // Filter to only running daemons
-        let requested_ids: Vec<DaemonId> = ids
+        // Only active roots participate in dependency expansion. Explicitly
+        // requested inactive roots are forwarded separately below because one
+        // may be backing off between readiness retries with no current PID.
+        let active_requested_ids: Vec<DaemonId> = ids
             .iter()
-            .filter(|id| {
-                if !running_daemons.contains(*id) {
-                    warn!("Daemon {id} is not running");
-                    false
-                } else {
-                    true
-                }
-            })
+            .filter(|id| running_daemons.contains(*id))
+            .cloned()
+            .collect();
+        let inactive_requested_ids: Vec<DaemonId> = ids
+            .iter()
+            .filter(|id| !running_daemons.contains(*id))
             .cloned()
             .collect();
 
-        if requested_ids.is_empty() {
+        if ids.is_empty() {
             info!("No running daemons to stop");
             return Ok(StopResult { any_failed: false });
         }
@@ -976,22 +976,27 @@ impl IpcClient {
         let mut any_failed = false;
 
         // Use shared reverse dependency ordering
-        let stop_levels = compute_reverse_stop_order(&requested_ids);
+        let active_stop_levels: Vec<Vec<DaemonId>> =
+            compute_reverse_stop_order(&active_requested_ids)
+                .into_iter()
+                .map(|level| {
+                    level
+                        .into_iter()
+                        .filter(|id| running_daemons.contains(id))
+                        .collect()
+                })
+                .filter(|level: &Vec<DaemonId>| !level.is_empty())
+                .collect();
+        let mut stop_levels = Vec::new();
+        if !inactive_requested_ids.is_empty() {
+            stop_levels.push(inactive_requested_ids);
+        }
+        stop_levels.extend(active_stop_levels);
 
         for level in stop_levels {
-            // Filter to only running daemons in this level
-            let to_stop: Vec<DaemonId> = level
-                .into_iter()
-                .filter(|id| running_daemons.contains(id))
-                .collect();
-
-            if to_stop.is_empty() {
-                continue;
-            }
-
             // Stop all daemons in this level concurrently
             let mut tasks = Vec::new();
-            for id in to_stop {
+            for id in level {
                 let task = Self::spawn_stop_task(self.clone(), id);
                 tasks.push(task);
             }

--- a/src/state_file.rs
+++ b/src/state_file.rs
@@ -344,6 +344,21 @@ impl StateFile {
         self.record_daemon_terminal_state(id, pid, DaemonStatus::Stopped, last_exit_success)
     }
 
+    /// Record an explicit stop only if no process currently owns the daemon state.
+    pub fn record_daemon_stop_if_no_process(&mut self, id: &DaemonId) -> bool {
+        let Some(daemon) = self.daemons.get_mut(id) else {
+            return false;
+        };
+        if daemon.pid.is_some() || daemon.status.is_stopped() {
+            return false;
+        }
+
+        daemon.status = DaemonStatus::Stopped;
+        daemon.active_port = None;
+        self.mark_dirty();
+        true
+    }
+
     fn record_daemon_terminal_state(
         &mut self,
         id: &DaemonId,
@@ -735,6 +750,87 @@ mod tests {
         let daemon = state.daemons.get(&daemon_id).unwrap();
         assert_eq!(daemon.pid, None);
         assert!(matches!(&daemon.status, DaemonStatus::Errored(1)));
+        assert_eq!(daemon.last_exit_success, Some(false));
+    }
+
+    #[test]
+    fn record_daemon_stop_without_process_cancels_retry_eligibility() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: None,
+                status: DaemonStatus::Errored(7),
+                last_exit_success: Some(false),
+                retry: 2u32.into(),
+                retry_count: 0,
+                active_port: Some(3000),
+                ..Daemon::default()
+            },
+        );
+
+        assert!(state.record_daemon_stop_if_no_process(&daemon_id));
+        assert!(state.is_dirty());
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert_eq!(daemon.pid, None);
+        assert!(matches!(&daemon.status, DaemonStatus::Stopped));
+        assert_eq!(daemon.last_exit_success, Some(false));
+        assert_eq!(daemon.retry_count, 0);
+        assert_eq!(daemon.active_port, None);
+        assert!(!daemon.needs_retry());
+    }
+
+    #[test]
+    fn record_daemon_stop_without_process_preserves_current_owner() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: Some(200),
+                status: DaemonStatus::Running,
+                last_exit_success: Some(true),
+                retry_count: 1,
+                active_port: Some(3000),
+                ..Daemon::default()
+            },
+        );
+
+        assert!(!state.record_daemon_stop_if_no_process(&daemon_id));
+        assert!(!state.is_dirty());
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert_eq!(daemon.pid, Some(200));
+        assert!(daemon.status.is_running());
+        assert_eq!(daemon.last_exit_success, Some(true));
+        assert_eq!(daemon.retry_count, 1);
+        assert_eq!(daemon.active_port, Some(3000));
+    }
+
+    #[test]
+    fn record_daemon_stop_without_process_ignores_already_stopped_daemon() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: None,
+                status: DaemonStatus::Stopped,
+                last_exit_success: Some(false),
+                ..Daemon::default()
+            },
+        );
+
+        assert!(!state.record_daemon_stop_if_no_process(&daemon_id));
+        assert!(!state.is_dirty());
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert!(daemon.status.is_stopped());
         assert_eq!(daemon.last_exit_success, Some(false));
     }
 

--- a/src/state_file.rs
+++ b/src/state_file.rs
@@ -283,6 +283,25 @@ impl StateFile {
         }
     }
 
+    /// Update a daemon's status only while the state still belongs to that PID.
+    pub fn set_daemon_status_if_owned(
+        &mut self,
+        id: &DaemonId,
+        pid: u32,
+        status: DaemonStatus,
+    ) -> bool {
+        let Some(daemon) = self.daemons.get_mut(id) else {
+            return false;
+        };
+        if daemon.pid != Some(pid) {
+            return false;
+        }
+
+        daemon.status = status;
+        self.mark_dirty();
+        true
+    }
+
     /// Record a daemon process exit only if the state still belongs to that PID.
     ///
     /// A replacement process may be started before the old process monitor
@@ -295,6 +314,29 @@ impl StateFile {
         status: DaemonStatus,
         last_exit_success: bool,
     ) -> bool {
+        self.record_daemon_terminal_state(id, pid, status, Some(last_exit_success))
+    }
+
+    /// Record an explicit stop only if the state still belongs to that PID.
+    ///
+    /// `last_exit_success` is optional because the already-dead branch cannot
+    /// infer a new outcome and must preserve the existing historical result.
+    pub fn record_daemon_stop(
+        &mut self,
+        id: &DaemonId,
+        pid: u32,
+        last_exit_success: Option<bool>,
+    ) -> bool {
+        self.record_daemon_terminal_state(id, pid, DaemonStatus::Stopped, last_exit_success)
+    }
+
+    fn record_daemon_terminal_state(
+        &mut self,
+        id: &DaemonId,
+        pid: u32,
+        status: DaemonStatus,
+        last_exit_success: Option<bool>,
+    ) -> bool {
         let Some(daemon) = self.daemons.get_mut(id) else {
             return false;
         };
@@ -304,7 +346,9 @@ impl StateFile {
 
         daemon.pid = None;
         daemon.status = status;
-        daemon.last_exit_success = Some(last_exit_success);
+        if let Some(last_exit_success) = last_exit_success {
+            daemon.last_exit_success = Some(last_exit_success);
+        }
         daemon.active_port = None;
         self.mark_dirty();
         true
@@ -602,6 +646,106 @@ mod tests {
         assert_eq!(daemon.pid, None);
         assert!(daemon.status.is_stopped());
         assert_eq!(daemon.last_exit_success, Some(true));
+    }
+
+    #[test]
+    fn record_daemon_stop_preserves_existing_exit_result() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: Some(100),
+                status: DaemonStatus::Errored(1),
+                last_exit_success: Some(false),
+                active_port: Some(4321),
+                ..Daemon::default()
+            },
+        );
+
+        assert!(state.record_daemon_stop(&daemon_id, 100, None));
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert_eq!(daemon.pid, None);
+        assert!(daemon.status.is_stopped());
+        assert_eq!(daemon.last_exit_success, Some(false));
+        assert_eq!(daemon.active_port, None);
+    }
+
+    #[test]
+    fn record_daemon_stop_does_not_overwrite_replacement_process() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: Some(200),
+                status: DaemonStatus::Running,
+                last_exit_success: None,
+                active_port: Some(4321),
+                ..Daemon::default()
+            },
+        );
+
+        assert!(!state.record_daemon_stop(&daemon_id, 100, Some(true)));
+        assert!(!state.is_dirty());
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert_eq!(daemon.pid, Some(200));
+        assert!(daemon.status.is_running());
+        assert_eq!(daemon.last_exit_success, None);
+        assert_eq!(daemon.active_port, Some(4321));
+    }
+
+    #[test]
+    fn record_daemon_stop_does_not_overwrite_monitor_result() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: None,
+                status: DaemonStatus::Errored(1),
+                last_exit_success: Some(false),
+                active_port: None,
+                ..Daemon::default()
+            },
+        );
+
+        assert!(!state.record_daemon_stop(&daemon_id, 100, None));
+        assert!(!state.is_dirty());
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert_eq!(daemon.pid, None);
+        assert!(matches!(&daemon.status, DaemonStatus::Errored(1)));
+        assert_eq!(daemon.last_exit_success, Some(false));
+    }
+
+    #[test]
+    fn set_daemon_status_if_owned_does_not_restore_cleared_process() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: None,
+                status: DaemonStatus::Errored(1),
+                last_exit_success: Some(false),
+                ..Daemon::default()
+            },
+        );
+
+        assert!(!state.set_daemon_status_if_owned(&daemon_id, 100, DaemonStatus::Running));
+        assert!(!state.is_dirty());
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert_eq!(daemon.pid, None);
+        assert!(matches!(&daemon.status, DaemonStatus::Errored(1)));
+        assert_eq!(daemon.last_exit_success, Some(false));
     }
 
     #[test]

--- a/src/state_file.rs
+++ b/src/state_file.rs
@@ -1,5 +1,6 @@
 use crate::daemon::Daemon;
 use crate::daemon_id::DaemonId;
+use crate::daemon_status::DaemonStatus;
 use crate::error::FileError;
 use crate::{Result, env};
 use once_cell::sync::Lazy;
@@ -282,16 +283,31 @@ impl StateFile {
         }
     }
 
-    /// Clear the active port for a daemon and mark the state dirty.
-    /// Returns true if the daemon was found and updated.
-    pub fn clear_active_port(&mut self, id: &DaemonId) -> bool {
-        if let Some(d) = self.daemons.get_mut(id) {
-            d.active_port = None;
-            self.mark_dirty();
-            true
-        } else {
-            false
+    /// Record a daemon process exit only if the state still belongs to that PID.
+    ///
+    /// A replacement process may be started before the old process monitor
+    /// finishes its exit path. Checking and updating under the same state lock
+    /// prevents the old monitor from overwriting the replacement's state.
+    pub fn record_daemon_exit(
+        &mut self,
+        id: &DaemonId,
+        pid: u32,
+        status: DaemonStatus,
+        last_exit_success: bool,
+    ) -> bool {
+        let Some(daemon) = self.daemons.get_mut(id) else {
+            return false;
+        };
+        if daemon.pid != Some(pid) {
+            return false;
         }
+
+        daemon.pid = None;
+        daemon.status = status;
+        daemon.last_exit_success = Some(last_exit_success);
+        daemon.active_port = None;
+        self.mark_dirty();
+        true
     }
 
     /// Update the last cron trigger time for a daemon and mark the state dirty.
@@ -508,6 +524,84 @@ mod tests {
             .get(&DaemonId::new("project", "test"))
             .unwrap();
         assert_eq!(daemon.user.as_deref(), Some("postgres"));
+    }
+
+    #[test]
+    fn record_daemon_exit_does_not_overwrite_replacement_process() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: Some(200),
+                status: DaemonStatus::Running,
+                last_exit_success: None,
+                active_port: Some(4321),
+                ..Daemon::default()
+            },
+        );
+
+        // The old PID 100 monitor completes after PID 200 has replaced it.
+        assert!(!state.is_dirty());
+        assert!(!state.record_daemon_exit(&daemon_id, 100, DaemonStatus::Stopped, true));
+        assert!(!state.is_dirty());
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert_eq!(daemon.pid, Some(200));
+        assert!(daemon.status.is_running());
+        assert_eq!(daemon.last_exit_success, None);
+        assert_eq!(daemon.active_port, Some(4321));
+    }
+
+    #[test]
+    fn record_daemon_exit_updates_matching_process() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: Some(100),
+                status: DaemonStatus::Stopping,
+                active_port: Some(4321),
+                ..Daemon::default()
+            },
+        );
+
+        assert!(!state.is_dirty());
+        assert!(state.record_daemon_exit(&daemon_id, 100, DaemonStatus::Stopped, true,));
+        assert!(state.is_dirty());
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert_eq!(daemon.pid, None);
+        assert!(daemon.status.is_stopped());
+        assert_eq!(daemon.last_exit_success, Some(true));
+        assert_eq!(daemon.active_port, None);
+    }
+
+    #[test]
+    fn record_daemon_exit_ignores_process_already_cleared_by_stop() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: None,
+                status: DaemonStatus::Stopped,
+                last_exit_success: Some(true),
+                ..Daemon::default()
+            },
+        );
+
+        assert!(!state.record_daemon_exit(&daemon_id, 100, DaemonStatus::Errored(1), false,));
+        assert!(!state.is_dirty());
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert_eq!(daemon.pid, None);
+        assert!(daemon.status.is_stopped());
+        assert_eq!(daemon.last_exit_success, Some(true));
     }
 
     #[test]

--- a/src/state_file.rs
+++ b/src/state_file.rs
@@ -244,6 +244,20 @@ impl StateFile {
         self.mark_dirty();
     }
 
+    /// Exhaust retries only while the daemon remains eligible for retry.
+    pub fn exhaust_daemon_retries_if_eligible(&mut self, id: &DaemonId) -> bool {
+        let Some(daemon) = self.daemons.get_mut(id) else {
+            return false;
+        };
+        if !daemon.needs_retry() {
+            return false;
+        }
+
+        daemon.retry_count = daemon.retry.count();
+        self.mark_dirty();
+        true
+    }
+
     /// Remove a daemon entry and mark the state dirty if the daemon existed.
     pub fn remove_daemon(&mut self, id: &DaemonId) {
         if self.daemons.remove(id).is_some() {
@@ -746,6 +760,58 @@ mod tests {
         assert_eq!(daemon.pid, None);
         assert!(matches!(&daemon.status, DaemonStatus::Errored(1)));
         assert_eq!(daemon.last_exit_success, Some(false));
+    }
+
+    #[test]
+    fn exhausting_retries_does_not_overwrite_a_replacement_process() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: Some(200),
+                status: DaemonStatus::Running,
+                retry: 2u32.into(),
+                retry_count: 0,
+                ..Daemon::default()
+            },
+        );
+
+        assert!(!state.exhaust_daemon_retries_if_eligible(&daemon_id));
+        assert!(!state.is_dirty());
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert_eq!(daemon.pid, Some(200));
+        assert!(matches!(&daemon.status, DaemonStatus::Running));
+        assert_eq!(daemon.retry_count, 0);
+    }
+
+    #[test]
+    fn exhausting_retries_updates_only_retry_count() {
+        let mut state = StateFile::new(PathBuf::from("/tmp/test.toml"));
+        let daemon_id = DaemonId::new("project", "worker");
+        state.daemons.insert(
+            daemon_id.clone(),
+            Daemon {
+                id: daemon_id.clone(),
+                pid: None,
+                status: DaemonStatus::Errored(7),
+                last_exit_success: Some(false),
+                retry: 2u32.into(),
+                retry_count: 0,
+                ..Daemon::default()
+            },
+        );
+
+        assert!(state.exhaust_daemon_retries_if_eligible(&daemon_id));
+        assert!(state.is_dirty());
+
+        let daemon = state.daemons.get(&daemon_id).unwrap();
+        assert_eq!(daemon.pid, None);
+        assert!(matches!(&daemon.status, DaemonStatus::Errored(7)));
+        assert_eq!(daemon.last_exit_success, Some(false));
+        assert_eq!(daemon.retry_count, 2);
     }
 
     #[test]

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -1699,15 +1699,15 @@ impl Supervisor {
                 trace!("killing pid: {pid}");
                 if PROCS.is_running(pid) {
                     // First set status to Stopping (preserve PID for monitoring task)
-                    self.upsert_daemon(
-                        UpsertDaemonOpts::builder(id.clone())
-                            .set(|o| {
-                                o.pid = Some(pid);
-                                o.status = DaemonStatus::Stopping;
-                            })
-                            .build(),
-                    )
-                    .await?;
+                    if !self
+                        .set_daemon_status_if_owned(id, pid, DaemonStatus::Stopping)
+                        .await
+                    {
+                        debug!(
+                            "stop request for daemon {id} pid {pid} ignored because the state no longer belongs to that process"
+                        );
+                        return Ok(IpcResponse::DaemonWasNotRunning);
+                    }
 
                     // Kill the entire process group atomically (daemon PID == PGID
                     // because we called setsid() at spawn time)
@@ -1722,15 +1722,14 @@ impl Supervisor {
                         if PROCS.is_running(pid) {
                             // Process still running after kill attempt - set back to Running
                             debug!("failed to stop pid {pid}: process still running after kill");
-                            self.upsert_daemon(
-                                UpsertDaemonOpts::builder(id.clone())
-                                    .set(|o| {
-                                        o.pid = Some(pid); // Preserve PID to avoid orphaning the process
-                                        o.status = DaemonStatus::Running;
-                                    })
-                                    .build(),
-                            )
-                            .await?;
+                            if !self
+                                .set_daemon_status_if_owned(id, pid, DaemonStatus::Running)
+                                .await
+                            {
+                                debug!(
+                                    "failed-stop recovery for daemon {id} pid {pid} ignored because the state no longer belongs to that process"
+                                );
+                            }
                             return Ok(IpcResponse::DaemonStopFailed {
                                 error: format!(
                                     "process {pid} still running after kill attempt: {e}"
@@ -1743,16 +1742,15 @@ impl Supervisor {
                     // Note: kill_async uses SIGTERM -> wait ~3s -> SIGKILL strategy,
                     // and also detects zombie processes, so by the time it returns,
                     // the process should be fully terminated.
-                    self.upsert_daemon(
-                        UpsertDaemonOpts::builder(id.clone())
-                            .set(|o| {
-                                o.pid = None;
-                                o.status = DaemonStatus::Stopped;
-                                o.last_exit_success = Some(true);
-                            })
-                            .build(),
-                    )
-                    .await?;
+                    if self.record_daemon_stop(id, pid, Some(true)).await {
+                        info!(
+                            "recorded explicit stop for daemon {id} pid {pid} with a successful exit result"
+                        );
+                    } else {
+                        debug!(
+                            "stop result for daemon {id} pid {pid} ignored because the state no longer belongs to that process"
+                        );
+                    }
                 } else {
                     debug!("pid {pid} not running, process may have exited unexpectedly");
                     // Process already dead — transition to Stopped so the
@@ -1760,15 +1758,15 @@ impl Supervisor {
                     // scheduling new attempts. This is important for an
                     // explicit `pitchfork stop` on an Errored daemon: the
                     // user wants to abort retries.
-                    self.upsert_daemon(
-                        UpsertDaemonOpts::builder(id.clone())
-                            .set(|o| {
-                                o.pid = None;
-                                o.status = DaemonStatus::Stopped;
-                            })
-                            .build(),
-                    )
-                    .await?;
+                    if self.record_daemon_stop(id, pid, None).await {
+                        info!(
+                            "recorded explicit stop for already-dead daemon {id} pid {pid}, preserving its previous exit result"
+                        );
+                    } else {
+                        debug!(
+                            "stop result for daemon {id} pid {pid} ignored because the state no longer belongs to that process"
+                        );
+                    }
                     return Ok(IpcResponse::DaemonWasNotRunning);
                 }
                 Ok(IpcResponse::Ok)

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -3,7 +3,9 @@
 //! Contains the core `run()`, `run_once()`, and `stop()` methods for daemon process management.
 
 use super::hooks::{self, HookType, fire_hook};
-use super::{DaemonLifecycle, DaemonLifecycleState, SUPERVISOR, Supervisor};
+use super::{
+    DaemonLifecycle, DaemonLifecycleState, ReadinessRetryActivity, SUPERVISOR, Supervisor,
+};
 use crate::daemon::RunOptions;
 use crate::daemon_id::DaemonId;
 use crate::daemon_status::DaemonStatus;
@@ -242,6 +244,26 @@ impl Supervisor {
         Arc::clone(&lifecycle.transition).lock_owned().await
     }
 
+    async fn register_active_readiness_retry(
+        lifecycle: &DaemonLifecycle,
+    ) -> Arc<ReadinessRetryActivity> {
+        let mut lifecycle_guard = Self::lifecycle_guard(lifecycle).await;
+        let activity = Arc::new(ReadinessRetryActivity::new(lifecycle_guard.generation));
+        lifecycle_guard
+            .active_readiness_retries
+            .retain(|retry| retry.strong_count() > 0);
+        lifecycle_guard
+            .active_readiness_retries
+            .push(Arc::downgrade(&activity));
+        activity
+    }
+
+    pub(super) async fn has_readiness_retry_for_current_generation(&self, id: &DaemonId) -> bool {
+        let lifecycle = self.daemon_lifecycle(id).await;
+        let mut lifecycle_guard = Self::lifecycle_guard(&lifecycle).await;
+        lifecycle_guard.has_readiness_retry_for_current_generation()
+    }
+
     fn retry_superseded_response(id: &DaemonId) -> IpcResponse {
         IpcResponse::DaemonFailed {
             error: format!("retry for daemon {id} was superseded by a newer lifecycle request"),
@@ -257,6 +279,7 @@ impl Supervisor {
         lifecycle: &Arc<DaemonLifecycle>,
         opts: RunOptions,
         retry: Option<RetryToken>,
+        retry_activity: Option<&ReadinessRetryActivity>,
     ) -> Result<LifecycleRunAttempt> {
         let mut lifecycle_guard = Self::lifecycle_guard(lifecycle).await;
         let id = &opts.id;
@@ -326,6 +349,9 @@ impl Supervisor {
         if !began_new_lifecycle {
             generation = Self::advance_lifecycle_generation(&mut lifecycle_guard);
         }
+        if let Some(retry_activity) = retry_activity {
+            retry_activity.set_generation(generation);
+        }
 
         Ok(LifecycleRunAttempt::new(
             self.run_once(opts, lifecycle_guard).await?,
@@ -349,6 +375,10 @@ impl Supervisor {
 
         // If wait_ready is true and retry is configured, implement retry loop
         if opts.wait_ready && opts.retry.count() > 0 {
+            // Keep the background retry watcher from starting an independent
+            // attempt while this request owns readiness retries. The weak
+            // registration disappears automatically if the request is cancelled.
+            let _active_readiness_retry = Self::register_active_readiness_retry(&lifecycle).await;
             // Use saturating_add to avoid overflow when retry = u32::MAX (infinite)
             let max_attempts = opts.retry.count().saturating_add(1);
             let mut retry = None;
@@ -357,7 +387,12 @@ impl Supervisor {
                 retry_opts.retry_count = attempt;
                 retry_opts.cmd = cmd.clone();
                 let result = self
-                    .run_once_serialized(&lifecycle, retry_opts, retry)
+                    .run_once_serialized(
+                        &lifecycle,
+                        retry_opts,
+                        retry,
+                        Some(&_active_readiness_retry),
+                    )
                     .await?;
 
                 match result.response {
@@ -410,7 +445,7 @@ impl Supervisor {
 
         // No retry or wait_ready is false
         Ok(self
-            .run_once_serialized(&lifecycle, opts, None)
+            .run_once_serialized(&lifecycle, opts, None, None)
             .await?
             .response)
     }

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -4,7 +4,8 @@
 
 use super::hooks::{self, HookType, fire_hook};
 use super::{
-    DaemonLifecycle, DaemonLifecycleState, ReadinessRetryActivity, SUPERVISOR, Supervisor,
+    BackgroundRetryStarted, DaemonLifecycle, DaemonLifecycleState, ReadinessRetryActivity,
+    SUPERVISOR, Supervisor,
 };
 use crate::daemon::RunOptions;
 use crate::daemon_id::DaemonId;
@@ -258,12 +259,6 @@ impl Supervisor {
         activity
     }
 
-    pub(super) async fn has_readiness_retry_for_current_generation(&self, id: &DaemonId) -> bool {
-        let lifecycle = self.daemon_lifecycle(id).await;
-        let mut lifecycle_guard = Self::lifecycle_guard(&lifecycle).await;
-        lifecycle_guard.has_readiness_retry_for_current_generation()
-    }
-
     fn retry_superseded_response(id: &DaemonId) -> IpcResponse {
         IpcResponse::DaemonFailed {
             error: format!("retry for daemon {id} was superseded by a newer lifecycle request"),
@@ -272,6 +267,13 @@ impl Supervisor {
 
     async fn stop_before_replacement(&self, id: &DaemonId) -> Result<Option<IpcResponse>> {
         Ok(blocking_stop_response(self.stop_inner(id).await?))
+    }
+
+    async fn clear_pending_autostop(&self, id: &DaemonId) {
+        let mut pending = self.pending_autostops.lock().await;
+        if pending.remove(id).is_some() {
+            info!("cleared pending autostop for {id} (daemon starting)");
+        }
     }
 
     async fn run_once_serialized(
@@ -359,19 +361,75 @@ impl Supervisor {
         ))
     }
 
+    pub(super) async fn try_start_background_retry(
+        &self,
+        id: &DaemonId,
+    ) -> Result<Option<BackgroundRetryStarted>> {
+        let lifecycle = self.daemon_lifecycle(id).await;
+        let mut lifecycle_guard = Self::lifecycle_guard(&lifecycle).await;
+
+        if lifecycle_guard.has_readiness_retry_for_current_generation() {
+            debug!(
+                "skipping background retry for daemon {id} while a start request owns readiness retries"
+            );
+            return Ok(None);
+        }
+
+        let mut state_file = self.state_file.lock().await;
+        let Some(daemon) = state_file
+            .daemons
+            .get(id)
+            .filter(|daemon| daemon.needs_retry())
+            .cloned()
+        else {
+            debug!("skipping background retry for daemon {id} after lifecycle re-check");
+            return Ok(None);
+        };
+
+        let Some(cmd) = daemon.cmd.clone() else {
+            warn!("no run command found in state for daemon {id}, cannot retry");
+            state_file.exhaust_daemon_retries_if_eligible(id);
+            return Ok(None);
+        };
+        drop(state_file);
+
+        let mut opts = daemon.to_run_options(cmd);
+        opts.retry_count = daemon.retry_count + 1;
+        Self::advance_lifecycle_generation(&mut lifecycle_guard);
+        self.clear_pending_autostop(id).await;
+        let dir = daemon.dir.clone().unwrap_or_else(|| env::CWD.clone());
+        fire_hook(
+            HookType::OnRetry,
+            id.clone(),
+            dir,
+            opts.retry_count,
+            daemon.env.clone(),
+            vec![],
+        )
+        .await;
+        let attempt = self.run_once(opts, lifecycle_guard).await?;
+        if attempt.pid.is_none() {
+            warn!(
+                "background retry for daemon {id} did not start: {:?}",
+                attempt.response
+            );
+            return Ok(None);
+        }
+
+        Ok(Some(BackgroundRetryStarted {
+            attempt: daemon.retry_count + 1,
+            limit: daemon.retry.count(),
+        }))
+    }
+
     /// Run a daemon, handling retries if configured
     pub async fn run(&self, opts: RunOptions) -> Result<IpcResponse> {
         let id = &opts.id;
         let cmd = opts.cmd.clone();
         let lifecycle = self.daemon_lifecycle(id).await;
 
-        // Clear any pending autostop for this daemon since it's being started
-        {
-            let mut pending = self.pending_autostops.lock().await;
-            if pending.remove(id).is_some() {
-                info!("cleared pending autostop for {id} (daemon starting)");
-            }
-        }
+        // Clear any pending autostop for this daemon since it's being started.
+        self.clear_pending_autostop(id).await;
 
         // If wait_ready is true and retry is configured, implement retry loop
         if opts.wait_ready && opts.retry.count() > 0 {
@@ -2437,6 +2495,7 @@ fn build_pitchfork_url(slug: &Option<String>, s: &crate::settings::Settings) -> 
 #[cfg(test)]
 mod lifecycle_response_tests {
     use super::*;
+    use crate::daemon::Daemon;
 
     #[test]
     fn only_successful_or_already_stopped_responses_allow_replacement() {
@@ -2462,6 +2521,42 @@ mod lifecycle_response_tests {
             unexpected,
             Some(IpcResponse::Error(error)) if error == "denied"
         ));
+    }
+
+    #[tokio::test]
+    async fn background_retry_yields_to_foreground_readiness_owner() {
+        let supervisor = Supervisor::new().unwrap();
+        let id = DaemonId::new("test", "background-retry-marker");
+        {
+            let mut state_file = supervisor.state_file.lock().await;
+            state_file.insert_daemon(
+                &id,
+                Daemon {
+                    id: id.clone(),
+                    pid: None,
+                    status: DaemonStatus::Errored(1),
+                    cmd: Some(vec!["true".to_string()]),
+                    retry: 2u32.into(),
+                    retry_count: 0,
+                    ..Daemon::default()
+                },
+            );
+        }
+
+        let lifecycle = supervisor.daemon_lifecycle(&id).await;
+        let _foreground_retry = Supervisor::register_active_readiness_retry(&lifecycle).await;
+
+        assert!(
+            supervisor
+                .try_start_background_retry(&id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let state_file = supervisor.state_file.lock().await;
+        let daemon = state_file.daemons.get(&id).unwrap();
+        assert_eq!(daemon.pid, None);
+        assert_eq!(daemon.retry_count, 0);
     }
 }
 

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -27,12 +27,43 @@ use std::sync::{Arc, atomic};
 use std::time::Duration;
 use tokio::io::AsyncBufReadExt;
 use tokio::select;
-use tokio::sync::oneshot;
+use tokio::sync::{OwnedMutexGuard, oneshot};
 use tokio::time;
 
 /// Cache for compiled regex patterns to avoid recompilation on daemon restarts
 static REGEX_CACHE: Lazy<std::sync::Mutex<HashMap<String, Regex>>> =
     Lazy::new(|| std::sync::Mutex::new(HashMap::new()));
+
+struct RunAttempt {
+    response: IpcResponse,
+    pid: Option<u32>,
+}
+
+impl RunAttempt {
+    fn before_spawn(response: IpcResponse) -> Self {
+        Self {
+            response,
+            pid: None,
+        }
+    }
+
+    fn started(response: IpcResponse, pid: u32) -> Self {
+        Self {
+            response,
+            pid: Some(pid),
+        }
+    }
+}
+
+fn blocking_stop_response(response: IpcResponse) -> Option<IpcResponse> {
+    match response {
+        IpcResponse::Ok
+        | IpcResponse::DaemonWasNotRunning
+        | IpcResponse::DaemonNotRunning
+        | IpcResponse::DaemonNotFound => None,
+        response => Some(response),
+    }
+}
 
 #[cfg(unix)]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -168,6 +199,66 @@ fn any_ready_check_remaining(
 }
 
 impl Supervisor {
+    async fn daemon_lifecycle_guard(&self, id: &DaemonId) -> OwnedMutexGuard<()> {
+        let lock = {
+            let mut locks = self.daemon_lifecycle_locks.lock().await;
+            locks.retain(|_, lock| lock.strong_count() > 0);
+            if let Some(lock) = locks.get(id).and_then(std::sync::Weak::upgrade) {
+                lock
+            } else {
+                let lock = Arc::new(tokio::sync::Mutex::new(()));
+                locks.insert(id.clone(), Arc::downgrade(&lock));
+                lock
+            }
+        };
+        lock.lock_owned().await
+    }
+
+    async fn stop_before_replacement(&self, id: &DaemonId) -> Result<Option<IpcResponse>> {
+        Ok(blocking_stop_response(self.stop_inner(id).await?))
+    }
+
+    async fn run_once_serialized(
+        &self,
+        opts: RunOptions,
+        retry_owner: Option<u32>,
+    ) -> Result<RunAttempt> {
+        let lifecycle_guard = self.daemon_lifecycle_guard(&opts.id).await;
+        let id = &opts.id;
+
+        if let Some(daemon) = self.get_daemon(id).await
+            && let Some(pid) = daemon.pid
+            && !daemon.status.is_stopped()
+        {
+            if let Some(retry_owner) = retry_owner {
+                if pid == retry_owner {
+                    // Readiness failure is reported before graceful shutdown
+                    // necessarily completes. Finish stopping this exact attempt
+                    // before replacing it, even if its PID is still live.
+                    if let Some(response) = self.stop_before_replacement(id).await? {
+                        return Ok(RunAttempt::before_spawn(response));
+                    }
+                    info!("run: retry stop completed for daemon {id} pid {pid}");
+                } else {
+                    warn!(
+                        "daemon {id} was replaced while waiting to retry (old pid {retry_owner}, current pid {pid})"
+                    );
+                    return Ok(RunAttempt::before_spawn(IpcResponse::DaemonAlreadyRunning));
+                }
+            } else if opts.force {
+                if let Some(response) = self.stop_before_replacement(id).await? {
+                    return Ok(RunAttempt::before_spawn(response));
+                }
+                info!("run: stop completed for daemon {id}");
+            } else {
+                warn!("daemon {id} already running with pid {pid}");
+                return Ok(RunAttempt::before_spawn(IpcResponse::DaemonAlreadyRunning));
+            }
+        }
+
+        self.run_once(opts, lifecycle_guard).await
+    }
+
     /// Run a daemon, handling retries if configured
     pub async fn run(&self, opts: RunOptions) -> Result<IpcResponse> {
         let id = &opts.id;
@@ -181,40 +272,23 @@ impl Supervisor {
             }
         }
 
-        let daemon = self.get_daemon(id).await;
-        if let Some(daemon) = daemon {
-            // Stopping state is treated as "not running" - the monitoring task will clean it up
-            // Only check for Running state with a valid PID
-            if !daemon.status.is_stopping()
-                && !daemon.status.is_stopped()
-                && let Some(pid) = daemon.pid
-            {
-                if opts.force {
-                    self.stop(id).await?;
-                    info!("run: stop completed for daemon {id}");
-                } else {
-                    warn!("daemon {id} already running with pid {pid}");
-                    return Ok(IpcResponse::DaemonAlreadyRunning);
-                }
-            }
-        }
-
         // If wait_ready is true and retry is configured, implement retry loop
         if opts.wait_ready && opts.retry.count() > 0 {
             // Use saturating_add to avoid overflow when retry = u32::MAX (infinite)
             let max_attempts = opts.retry.count().saturating_add(1);
+            let mut retry_owner = None;
             for attempt in 0..max_attempts {
                 let mut retry_opts = opts.clone();
                 retry_opts.retry_count = attempt;
                 retry_opts.cmd = cmd.clone();
+                let result = self.run_once_serialized(retry_opts, retry_owner).await?;
 
-                let result = self.run_once(retry_opts).await?;
-
-                match result {
+                match result.response {
                     IpcResponse::DaemonReady { daemon } => {
                         return Ok(IpcResponse::DaemonReady { daemon });
                     }
                     IpcResponse::DaemonFailedWithCode { exit_code } => {
+                        retry_owner = result.pid;
                         if attempt < opts.retry.count() {
                             let backoff_secs = 2u64.saturating_pow(attempt).min(3600);
                             info!(
@@ -245,11 +319,15 @@ impl Supervisor {
         }
 
         // No retry or wait_ready is false
-        self.run_once(opts).await
+        Ok(self.run_once_serialized(opts, None).await?.response)
     }
 
     /// Run a daemon once (single attempt)
-    pub(crate) async fn run_once(&self, opts: RunOptions) -> Result<IpcResponse> {
+    async fn run_once(
+        &self,
+        opts: RunOptions,
+        lifecycle_guard: OwnedMutexGuard<()>,
+    ) -> Result<RunAttempt> {
         let id = &opts.id;
         let original_cmd = opts.cmd.clone(); // Save original command for persistence
 
@@ -316,26 +394,28 @@ impl Supervisor {
                     if let Some(port_error) = e.downcast_ref::<PortError>() {
                         match port_error {
                             PortError::InUse { port, process, pid } => {
-                                return Ok(IpcResponse::PortConflict {
+                                return Ok(RunAttempt::before_spawn(IpcResponse::PortConflict {
                                     port: *port,
                                     process: process.clone(),
                                     pid: *pid,
-                                });
+                                }));
                             }
                             PortError::NoAvailablePort {
                                 start_port,
                                 attempts,
                             } => {
-                                return Ok(IpcResponse::NoAvailablePort {
-                                    start_port: *start_port,
-                                    attempts: *attempts,
-                                });
+                                return Ok(RunAttempt::before_spawn(
+                                    IpcResponse::NoAvailablePort {
+                                        start_port: *start_port,
+                                        attempts: *attempts,
+                                    },
+                                ));
                             }
                         }
                     }
-                    return Ok(IpcResponse::DaemonFailed {
+                    return Ok(RunAttempt::before_spawn(IpcResponse::DaemonFailed {
                         error: e.to_string(),
-                    });
+                    }));
                 }
             }
         } else {
@@ -347,7 +427,11 @@ impl Supervisor {
             if let Some(port) = opts.ready_port.as_ref().and_then(|p| p.as_port()) {
                 if port > 0 {
                     if let Some((pid, process)) = detect_port_conflict(port).await {
-                        return Ok(IpcResponse::PortConflict { port, process, pid });
+                        return Ok(RunAttempt::before_spawn(IpcResponse::PortConflict {
+                            port,
+                            process,
+                            pid,
+                        }));
                     }
                 }
             }
@@ -364,14 +448,14 @@ impl Supervisor {
         let shell_parts = match shell_words::split(&shell_setting) {
             Ok(parts) if !parts.is_empty() => parts,
             Ok(_) => {
-                return Ok(IpcResponse::DaemonFailed {
+                return Ok(RunAttempt::before_spawn(IpcResponse::DaemonFailed {
                     error: "general.shell setting is empty".to_string(),
-                });
+                }));
             }
             Err(e) => {
-                return Ok(IpcResponse::DaemonFailed {
+                return Ok(RunAttempt::before_spawn(IpcResponse::DaemonFailed {
                     error: format!("failed to parse general.shell setting {shell_setting:?}: {e}"),
-                });
+                }));
             }
         };
         let (shell_program, shell_args) = shell_parts.split_first().unwrap();
@@ -412,9 +496,9 @@ impl Supervisor {
         let run_identity = match resolve_effective_run_identity(opts.user.as_deref()) {
             Ok(identity) => identity,
             Err(e) => {
-                return Ok(IpcResponse::DaemonFailed {
+                return Ok(RunAttempt::before_spawn(IpcResponse::DaemonFailed {
                     error: e.to_string(),
-                });
+                }));
             }
         };
         info!("run: spawning daemon {id} with {program} {args:?}");
@@ -541,9 +625,9 @@ impl Supervisor {
             Some(p) => p,
             None => {
                 warn!("Daemon {id} exited before PID could be captured");
-                return Ok(IpcResponse::DaemonFailed {
+                return Ok(RunAttempt::before_spawn(IpcResponse::DaemonFailed {
                     error: "Process exited immediately".to_string(),
-                });
+                }));
             }
         };
         info!("started daemon {id} with pid {pid}");
@@ -1328,12 +1412,6 @@ impl Supervisor {
                 let _ = handle.await;
             }
 
-            // Clear active_port since the process is no longer running
-            {
-                let mut state_file = SUPERVISOR.state_file.lock().await;
-                state_file.clear_active_port(&id);
-            }
-
             // Get the final exit status
             let exit_status = if let Some(status) = exit_status {
                 status
@@ -1409,12 +1487,10 @@ impl Supervisor {
                 (Err(_), false) => (-1, "fail"),
             };
 
-            // Update daemon state unless stop() already did it (won the race),
-            // OR the daemon was intentionally stopped before the drain
-            // (pre_drain_is_stopping). In the latter case, start() may have
-            // upserted Running during the 5s drain, and we must NOT overwrite
-            // it with Stopped — that would undo the restart.
-            if !already_stopped && !pre_drain_is_stopping {
+            // Update daemon state unless stop() already did it. PID ownership is
+            // checked atomically with the update so a late monitor can never
+            // overwrite a replacement process started during exit cleanup.
+            if !already_stopped {
                 if let Ok(status) = &exit_status {
                     info!("daemon {id} exited with status {status}");
                 }
@@ -1425,19 +1501,18 @@ impl Supervisor {
                     ),
                     _ => (DaemonStatus::Errored(exit_code), false),
                 };
-                if let Err(e) = SUPERVISOR
-                    .upsert_daemon(
-                        UpsertDaemonOpts::builder(id.clone())
-                            .set(|o| {
-                                o.pid = None;
-                                o.status = new_status;
-                                o.last_exit_success = Some(last_exit_success);
-                            })
-                            .build(),
-                    )
+                let new_status_display = new_status.to_string();
+                if SUPERVISOR
+                    .record_daemon_exit(&id, pid, new_status, last_exit_success)
                     .await
                 {
-                    error!("Failed to update daemon state for {id}: {e}");
+                    info!(
+                        "recorded daemon {id} exit from pid {pid} with status {new_status_display}"
+                    );
+                } else {
+                    debug!(
+                        "daemon {id} exit from pid {pid} ignored because the state no longer belongs to that process"
+                    );
                 }
             }
 
@@ -1471,29 +1546,51 @@ impl Supervisor {
             }
         });
 
+        // The process is registered and its monitor is installed. Other
+        // lifecycle commands may now safely act on this daemon while this
+        // request continues waiting for readiness.
+        drop(lifecycle_guard);
+
         // If wait_ready is true, wait for readiness notification
         if let Some(ready_rx) = ready_rx {
             match ready_rx.await {
                 Ok(Ok(())) => {
                     info!("daemon {id} is ready");
-                    Ok(IpcResponse::DaemonReady { daemon })
+                    Ok(RunAttempt::started(
+                        IpcResponse::DaemonReady { daemon },
+                        pid,
+                    ))
                 }
                 Ok(Err(exit_code)) => {
                     error!("daemon {id} failed before becoming ready");
-                    Ok(IpcResponse::DaemonFailedWithCode { exit_code })
+                    Ok(RunAttempt::started(
+                        IpcResponse::DaemonFailedWithCode { exit_code },
+                        pid,
+                    ))
                 }
                 Err(_) => {
                     error!("readiness channel closed unexpectedly for daemon {id}");
-                    Ok(IpcResponse::DaemonStart { daemon })
+                    Ok(RunAttempt::started(
+                        IpcResponse::DaemonStart { daemon },
+                        pid,
+                    ))
                 }
             }
         } else {
-            Ok(IpcResponse::DaemonStart { daemon })
+            Ok(RunAttempt::started(
+                IpcResponse::DaemonStart { daemon },
+                pid,
+            ))
         }
     }
 
     /// Stop a running daemon
     pub async fn stop(&self, id: &DaemonId) -> Result<IpcResponse> {
+        let _lifecycle_guard = self.daemon_lifecycle_guard(id).await;
+        self.stop_inner(id).await
+    }
+
+    async fn stop_inner(&self, id: &DaemonId) -> Result<IpcResponse> {
         let pitchfork_id = DaemonId::pitchfork();
         if *id == pitchfork_id {
             return Ok(IpcResponse::Error(
@@ -2207,6 +2304,37 @@ fn build_pitchfork_url(slug: &Option<String>, s: &crate::settings::Settings) -> 
     let lan_enabled = s.proxy.lan || !s.proxy.lan_ip.is_empty();
     let tld = if lan_enabled { "local" } else { &s.proxy.tld };
     Some(format!("{scheme}://{slug}.{tld}{port_suffix}",))
+}
+
+#[cfg(test)]
+mod lifecycle_response_tests {
+    use super::*;
+
+    #[test]
+    fn only_successful_or_already_stopped_responses_allow_replacement() {
+        for response in [
+            IpcResponse::Ok,
+            IpcResponse::DaemonWasNotRunning,
+            IpcResponse::DaemonNotRunning,
+            IpcResponse::DaemonNotFound,
+        ] {
+            assert!(blocking_stop_response(response).is_none());
+        }
+
+        let failed = blocking_stop_response(IpcResponse::DaemonStopFailed {
+            error: "still running".to_string(),
+        });
+        assert!(matches!(
+            failed,
+            Some(IpcResponse::DaemonStopFailed { error }) if error == "still running"
+        ));
+
+        let unexpected = blocking_stop_response(IpcResponse::Error("denied".to_string()));
+        assert!(matches!(
+            unexpected,
+            Some(IpcResponse::Error(error)) if error == "denied"
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -3,7 +3,7 @@
 //! Contains the core `run()`, `run_once()`, and `stop()` methods for daemon process management.
 
 use super::hooks::{self, HookType, fire_hook};
-use super::{SUPERVISOR, Supervisor};
+use super::{DaemonLifecycle, DaemonLifecycleState, SUPERVISOR, Supervisor};
 use crate::daemon::RunOptions;
 use crate::daemon_id::DaemonId;
 use crate::daemon_status::DaemonStatus;
@@ -53,6 +53,28 @@ impl RunAttempt {
             pid: Some(pid),
         }
     }
+}
+
+struct LifecycleRunAttempt {
+    response: IpcResponse,
+    pid: Option<u32>,
+    generation: u64,
+}
+
+impl LifecycleRunAttempt {
+    fn new(attempt: RunAttempt, generation: u64) -> Self {
+        Self {
+            response: attempt.response,
+            pid: attempt.pid,
+            generation,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RetryToken {
+    pid: u32,
+    generation: u64,
 }
 
 fn blocking_stop_response(response: IpcResponse) -> Option<IpcResponse> {
@@ -199,19 +221,31 @@ fn any_ready_check_remaining(
 }
 
 impl Supervisor {
-    async fn daemon_lifecycle_guard(&self, id: &DaemonId) -> OwnedMutexGuard<()> {
-        let lock = {
-            let mut locks = self.daemon_lifecycle_locks.lock().await;
-            locks.retain(|_, lock| lock.strong_count() > 0);
-            if let Some(lock) = locks.get(id).and_then(std::sync::Weak::upgrade) {
-                lock
-            } else {
-                let lock = Arc::new(tokio::sync::Mutex::new(()));
-                locks.insert(id.clone(), Arc::downgrade(&lock));
-                lock
-            }
-        };
-        lock.lock_owned().await
+    async fn daemon_lifecycle(&self, id: &DaemonId) -> Arc<DaemonLifecycle> {
+        let mut lifecycles = self.daemon_lifecycles.lock().await;
+        lifecycles.retain(|_, lifecycle| lifecycle.strong_count() > 0);
+        if let Some(lifecycle) = lifecycles.get(id).and_then(std::sync::Weak::upgrade) {
+            lifecycle
+        } else {
+            let lifecycle = Arc::new(DaemonLifecycle::new());
+            lifecycles.insert(id.clone(), Arc::downgrade(&lifecycle));
+            lifecycle
+        }
+    }
+
+    fn advance_lifecycle_generation(lifecycle: &mut DaemonLifecycleState) -> u64 {
+        lifecycle.generation = lifecycle.generation.wrapping_add(1);
+        lifecycle.generation
+    }
+
+    async fn lifecycle_guard(lifecycle: &DaemonLifecycle) -> OwnedMutexGuard<DaemonLifecycleState> {
+        Arc::clone(&lifecycle.transition).lock_owned().await
+    }
+
+    fn retry_superseded_response(id: &DaemonId) -> IpcResponse {
+        IpcResponse::DaemonFailed {
+            error: format!("retry for daemon {id} was superseded by a newer lifecycle request"),
+        }
     }
 
     async fn stop_before_replacement(&self, id: &DaemonId) -> Result<Option<IpcResponse>> {
@@ -220,49 +254,90 @@ impl Supervisor {
 
     async fn run_once_serialized(
         &self,
+        lifecycle: &Arc<DaemonLifecycle>,
         opts: RunOptions,
-        retry_owner: Option<u32>,
-    ) -> Result<RunAttempt> {
-        let lifecycle_guard = self.daemon_lifecycle_guard(&opts.id).await;
+        retry: Option<RetryToken>,
+    ) -> Result<LifecycleRunAttempt> {
+        let mut lifecycle_guard = Self::lifecycle_guard(lifecycle).await;
         let id = &opts.id;
+        let current_generation = lifecycle_guard.generation;
+
+        if let Some(retry) = retry
+            && current_generation != retry.generation
+        {
+            warn!(
+                "daemon {id} retry generation {} was superseded by lifecycle generation {current_generation}",
+                retry.generation
+            );
+            return Ok(LifecycleRunAttempt::new(
+                RunAttempt::before_spawn(Self::retry_superseded_response(id)),
+                current_generation,
+            ));
+        }
+
+        let mut generation = retry.map_or(current_generation, |retry| retry.generation);
+        let mut began_new_lifecycle = retry.is_some();
 
         if let Some(daemon) = self.get_daemon(id).await
             && let Some(pid) = daemon.pid
             && !daemon.status.is_stopped()
         {
-            if let Some(retry_owner) = retry_owner {
-                if pid == retry_owner {
+            if let Some(retry) = retry {
+                if pid == retry.pid {
                     // Readiness failure is reported before graceful shutdown
                     // necessarily completes. Finish stopping this exact attempt
                     // before replacing it, even if its PID is still live.
                     if let Some(response) = self.stop_before_replacement(id).await? {
-                        return Ok(RunAttempt::before_spawn(response));
+                        return Ok(LifecycleRunAttempt::new(
+                            RunAttempt::before_spawn(response),
+                            generation,
+                        ));
                     }
                     info!("run: retry stop completed for daemon {id} pid {pid}");
                 } else {
                     warn!(
-                        "daemon {id} was replaced while waiting to retry (old pid {retry_owner}, current pid {pid})"
+                        "daemon {id} was replaced while waiting to retry (old pid {}, current pid {pid})",
+                        retry.pid
                     );
-                    return Ok(RunAttempt::before_spawn(IpcResponse::DaemonAlreadyRunning));
+                    return Ok(LifecycleRunAttempt::new(
+                        RunAttempt::before_spawn(Self::retry_superseded_response(id)),
+                        current_generation,
+                    ));
                 }
             } else if opts.force {
+                generation = Self::advance_lifecycle_generation(&mut lifecycle_guard);
+                began_new_lifecycle = true;
                 if let Some(response) = self.stop_before_replacement(id).await? {
-                    return Ok(RunAttempt::before_spawn(response));
+                    return Ok(LifecycleRunAttempt::new(
+                        RunAttempt::before_spawn(response),
+                        generation,
+                    ));
                 }
                 info!("run: stop completed for daemon {id}");
             } else {
                 warn!("daemon {id} already running with pid {pid}");
-                return Ok(RunAttempt::before_spawn(IpcResponse::DaemonAlreadyRunning));
+                return Ok(LifecycleRunAttempt::new(
+                    RunAttempt::before_spawn(IpcResponse::DaemonAlreadyRunning),
+                    current_generation,
+                ));
             }
         }
 
-        self.run_once(opts, lifecycle_guard).await
+        if !began_new_lifecycle {
+            generation = Self::advance_lifecycle_generation(&mut lifecycle_guard);
+        }
+
+        Ok(LifecycleRunAttempt::new(
+            self.run_once(opts, lifecycle_guard).await?,
+            generation,
+        ))
     }
 
     /// Run a daemon, handling retries if configured
     pub async fn run(&self, opts: RunOptions) -> Result<IpcResponse> {
         let id = &opts.id;
         let cmd = opts.cmd.clone();
+        let lifecycle = self.daemon_lifecycle(id).await;
 
         // Clear any pending autostop for this daemon since it's being started
         {
@@ -276,19 +351,34 @@ impl Supervisor {
         if opts.wait_ready && opts.retry.count() > 0 {
             // Use saturating_add to avoid overflow when retry = u32::MAX (infinite)
             let max_attempts = opts.retry.count().saturating_add(1);
-            let mut retry_owner = None;
+            let mut retry = None;
             for attempt in 0..max_attempts {
                 let mut retry_opts = opts.clone();
                 retry_opts.retry_count = attempt;
                 retry_opts.cmd = cmd.clone();
-                let result = self.run_once_serialized(retry_opts, retry_owner).await?;
+                let result = self
+                    .run_once_serialized(&lifecycle, retry_opts, retry)
+                    .await?;
 
                 match result.response {
                     IpcResponse::DaemonReady { daemon } => {
                         return Ok(IpcResponse::DaemonReady { daemon });
                     }
                     IpcResponse::DaemonFailedWithCode { exit_code } => {
-                        retry_owner = result.pid;
+                        let Some(pid) = result.pid else {
+                            error!(
+                                "daemon {id} failed after spawning but its PID was not retained"
+                            );
+                            return Ok(IpcResponse::DaemonFailed {
+                                error: format!(
+                                    "daemon {id} failed after spawning but its PID was not retained"
+                                ),
+                            });
+                        };
+                        retry = Some(RetryToken {
+                            pid,
+                            generation: result.generation,
+                        });
                         if attempt < opts.retry.count() {
                             let backoff_secs = 2u64.saturating_pow(attempt).min(3600);
                             info!(
@@ -319,14 +409,17 @@ impl Supervisor {
         }
 
         // No retry or wait_ready is false
-        Ok(self.run_once_serialized(opts, None).await?.response)
+        Ok(self
+            .run_once_serialized(&lifecycle, opts, None)
+            .await?
+            .response)
     }
 
     /// Run a daemon once (single attempt)
     async fn run_once(
         &self,
         opts: RunOptions,
-        lifecycle_guard: OwnedMutexGuard<()>,
+        lifecycle_guard: OwnedMutexGuard<DaemonLifecycleState>,
     ) -> Result<RunAttempt> {
         let id = &opts.id;
         let original_cmd = opts.cmd.clone(); // Save original command for persistence
@@ -1586,7 +1679,9 @@ impl Supervisor {
 
     /// Stop a running daemon
     pub async fn stop(&self, id: &DaemonId) -> Result<IpcResponse> {
-        let _lifecycle_guard = self.daemon_lifecycle_guard(id).await;
+        let lifecycle = self.daemon_lifecycle(id).await;
+        let mut lifecycle_guard = Self::lifecycle_guard(&lifecycle).await;
+        Self::advance_lifecycle_generation(&mut lifecycle_guard);
         self.stop_inner(id).await
     }
 

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -1865,7 +1865,15 @@ impl Supervisor {
                 Ok(IpcResponse::Ok)
             } else {
                 debug!("daemon {id} not running");
-                Ok(IpcResponse::DaemonNotRunning)
+                if self.record_daemon_stop_if_no_process(id).await {
+                    info!(
+                        "recorded explicit stop for daemon {id} without a current process, cancelling pending retries"
+                    );
+                    Ok(IpcResponse::Ok)
+                } else {
+                    debug!("stop result for daemon {id} without a PID made no state change");
+                    Ok(IpcResponse::DaemonNotRunning)
+                }
             }
         } else {
             debug!("daemon {id} not found");

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -72,6 +72,11 @@ pub(crate) struct DaemonLifecycleState {
     active_readiness_retries: Vec<Weak<ReadinessRetryActivity>>,
 }
 
+pub(crate) struct BackgroundRetryStarted {
+    attempt: u32,
+    limit: u32,
+}
+
 pub(crate) struct ReadinessRetryActivity {
     // Production loads and stores occur while the corresponding lifecycle
     // transition mutex is held. The atomic makes the Arc/Weak marker Sync;

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -38,9 +38,9 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::exit;
-use std::sync::Weak;
 use std::sync::atomic;
 use std::sync::atomic::{AtomicBool, AtomicU32};
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 #[cfg(unix)]
 use tokio::signal::unix::SignalKind;
@@ -63,15 +63,31 @@ pub(crate) static REAPED_STATUSES: Lazy<Mutex<HashMap<u32, i32>>> =
 // Re-export types needed by other modules
 pub(crate) use state::UpsertDaemonOpts;
 
+pub(crate) struct DaemonLifecycle {
+    transition: Arc<Mutex<DaemonLifecycleState>>,
+}
+
+pub(crate) struct DaemonLifecycleState {
+    generation: u64,
+}
+
+impl DaemonLifecycle {
+    fn new() -> Self {
+        Self {
+            transition: Arc::new(Mutex::new(DaemonLifecycleState { generation: 0 })),
+        }
+    }
+}
+
 pub struct Supervisor {
     pub(crate) state_file: Mutex<StateFile>,
     pub(crate) pending_notifications: Mutex<Vec<(log::LevelFilter, String)>>,
     pub(crate) last_refreshed_at: Mutex<time::Instant>,
     /// Map of daemon ID to scheduled autostop time
     pub(crate) pending_autostops: Mutex<HashMap<DaemonId, time::Instant>>,
-    /// Per-daemon locks serializing each check/stop/spawn lifecycle transition.
+    /// Per-daemon state serializing lifecycle transitions and invalidating stale retries.
     /// Weak references let unused daemon IDs fall out of the map on the next access.
-    pub(crate) daemon_lifecycle_locks: Mutex<HashMap<DaemonId, Weak<Mutex<()>>>>,
+    pub(crate) daemon_lifecycles: Mutex<HashMap<DaemonId, Weak<DaemonLifecycle>>>,
     /// Handle for graceful IPC server shutdown
     pub(crate) ipc_shutdown: Mutex<Option<IpcServerHandle>>,
     /// Tracks in-flight hook tasks so shutdown can wait for them to complete
@@ -255,7 +271,7 @@ impl Supervisor {
             last_refreshed_at: Mutex::new(time::Instant::now()),
             pending_notifications: Mutex::new(vec![]),
             pending_autostops: Mutex::new(HashMap::new()),
-            daemon_lifecycle_locks: Mutex::new(HashMap::new()),
+            daemon_lifecycles: Mutex::new(HashMap::new()),
             ipc_shutdown: Mutex::new(None),
             hook_tasks: Mutex::new(Vec::new()),
             active_monitors: AtomicU32::new(0),

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -38,6 +38,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::exit;
+use std::sync::Weak;
 use std::sync::atomic;
 use std::sync::atomic::{AtomicBool, AtomicU32};
 use std::time::Duration;
@@ -68,6 +69,9 @@ pub struct Supervisor {
     pub(crate) last_refreshed_at: Mutex<time::Instant>,
     /// Map of daemon ID to scheduled autostop time
     pub(crate) pending_autostops: Mutex<HashMap<DaemonId, time::Instant>>,
+    /// Per-daemon locks serializing each check/stop/spawn lifecycle transition.
+    /// Weak references let unused daemon IDs fall out of the map on the next access.
+    pub(crate) daemon_lifecycle_locks: Mutex<HashMap<DaemonId, Weak<Mutex<()>>>>,
     /// Handle for graceful IPC server shutdown
     pub(crate) ipc_shutdown: Mutex<Option<IpcServerHandle>>,
     /// Tracks in-flight hook tasks so shutdown can wait for them to complete
@@ -251,6 +255,7 @@ impl Supervisor {
             last_refreshed_at: Mutex::new(time::Instant::now()),
             pending_notifications: Mutex::new(vec![]),
             pending_autostops: Mutex::new(HashMap::new()),
+            daemon_lifecycle_locks: Mutex::new(HashMap::new()),
             ipc_shutdown: Mutex::new(None),
             hook_tasks: Mutex::new(Vec::new()),
             active_monitors: AtomicU32::new(0),

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -39,7 +39,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::exit;
 use std::sync::atomic;
-use std::sync::atomic::{AtomicBool, AtomicU32};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 #[cfg(unix)]
@@ -69,12 +69,51 @@ pub(crate) struct DaemonLifecycle {
 
 pub(crate) struct DaemonLifecycleState {
     generation: u64,
+    active_readiness_retries: Vec<Weak<ReadinessRetryActivity>>,
+}
+
+pub(crate) struct ReadinessRetryActivity {
+    // Production loads and stores occur while the corresponding lifecycle
+    // transition mutex is held. The atomic makes the Arc/Weak marker Sync;
+    // Relaxed ordering is sufficient because the lifecycle mutex orders access.
+    generation: AtomicU64,
+}
+
+impl DaemonLifecycleState {
+    fn has_readiness_retry_for_current_generation(&mut self) -> bool {
+        self.active_readiness_retries
+            .retain(|retry| retry.strong_count() > 0);
+        self.active_readiness_retries.iter().any(|retry| {
+            retry
+                .upgrade()
+                .is_some_and(|retry| retry.generation() == self.generation)
+        })
+    }
+}
+
+impl ReadinessRetryActivity {
+    fn new(generation: u64) -> Self {
+        Self {
+            generation: AtomicU64::new(generation),
+        }
+    }
+
+    fn generation(&self) -> u64 {
+        self.generation.load(atomic::Ordering::Relaxed)
+    }
+
+    fn set_generation(&self, generation: u64) {
+        self.generation.store(generation, atomic::Ordering::Relaxed);
+    }
 }
 
 impl DaemonLifecycle {
     fn new() -> Self {
         Self {
-            transition: Arc::new(Mutex::new(DaemonLifecycleState { generation: 0 })),
+            transition: Arc::new(Mutex::new(DaemonLifecycleState {
+                generation: 0,
+                active_readiness_retries: Vec::new(),
+            })),
         }
     }
 }
@@ -1384,8 +1423,27 @@ fn chmod_recursive(dir: &std::path::Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::should_remove_liveness_session;
+    use super::{DaemonLifecycleState, ReadinessRetryActivity, should_remove_liveness_session};
     use crate::state_file::ProjectSession;
+    use std::sync::Arc;
+
+    #[test]
+    fn superseded_readiness_retry_does_not_block_current_generation() {
+        let old_retry = Arc::new(ReadinessRetryActivity::new(1));
+        let mut lifecycle = DaemonLifecycleState {
+            generation: 2,
+            active_readiness_retries: vec![Arc::downgrade(&old_retry)],
+        };
+
+        assert!(!lifecycle.has_readiness_retry_for_current_generation());
+
+        old_retry.set_generation(2);
+        assert!(lifecycle.has_readiness_retry_for_current_generation());
+
+        drop(old_retry);
+        assert!(!lifecycle.has_readiness_retry_for_current_generation());
+        assert!(lifecycle.active_readiness_retries.is_empty());
+    }
 
     #[test]
     fn should_not_remove_when_state_title_differs_from_snapshot() {

--- a/src/supervisor/retry.rs
+++ b/src/supervisor/retry.rs
@@ -2,11 +2,9 @@
 //!
 //! Handles automatic retrying of failed daemons based on retry configuration.
 
-use super::Supervisor;
-use super::hooks::{HookType, fire_hook};
+use super::{BackgroundRetryStarted, Supervisor};
+use crate::Result;
 use crate::daemon_id::DaemonId;
-use crate::supervisor::state::UpsertDaemonOpts;
-use crate::{Result, env};
 
 impl Supervisor {
     /// Check for daemons that need retrying and attempt to restart them
@@ -17,79 +15,18 @@ impl Supervisor {
             state_file
                 .daemons
                 .iter()
-                .filter(|(_id, d)| {
-                    // Daemon is errored, not currently running, and has retries remaining
-                    d.status.is_errored()
-                        && d.pid.is_none()
-                        && d.retry.count() > 0
-                        && d.retry_count < d.retry.count()
-                })
+                .filter(|(_id, daemon)| daemon.needs_retry())
                 .map(|(id, _d)| id.clone())
                 .collect()
         };
 
         for id in ids_to_retry {
-            // Look up daemon when needed and re-verify retry criteria
-            // (state may have changed since we collected IDs)
-            let daemon = {
-                let state_file = self.state_file.lock().await;
-                match state_file.daemons.get(&id) {
-                    Some(d)
-                        if d.status.is_errored()
-                            && d.pid.is_none()
-                            && d.retry.count() > 0
-                            && d.retry_count < d.retry.count() =>
-                    {
-                        d.clone()
-                    }
-                    _ => continue, // Daemon was removed or no longer needs retry
+            match self.try_start_background_retry(&id).await {
+                Ok(Some(BackgroundRetryStarted { attempt, limit })) => {
+                    info!("started retry for daemon {id} ({attempt}/{limit} attempts)");
                 }
-            };
-            if self.has_readiness_retry_for_current_generation(&id).await {
-                debug!(
-                    "skipping background retry for daemon {id} while a start request owns readiness retries"
-                );
-                continue;
-            }
-            info!(
-                "retrying daemon {} ({}/{} attempts)",
-                id,
-                daemon.retry_count + 1,
-                daemon.retry.count()
-            );
-
-            // Use the persisted command from daemon state
-            let cmd = match daemon.cmd.clone() {
-                Some(cmd) => cmd,
-                None => {
-                    warn!("no run command found in state for daemon {id}, cannot retry");
-                    // Mark as exhausted to prevent infinite retry loop, preserving error status
-                    self.upsert_daemon(
-                        UpsertDaemonOpts::builder(id)
-                            .set(|o| {
-                                o.status = daemon.status.clone();
-                                o.retry_count = Some(daemon.retry.count());
-                            })
-                            .build(),
-                    )
-                    .await?;
-                    continue;
-                }
-            };
-            let dir = daemon.dir.clone().unwrap_or_else(|| env::CWD.clone());
-            fire_hook(
-                HookType::OnRetry,
-                id.clone(),
-                dir.clone(),
-                daemon.retry_count + 1,
-                daemon.env.clone(),
-                vec![],
-            )
-            .await;
-            let mut retry_opts = daemon.to_run_options(cmd);
-            retry_opts.retry_count = daemon.retry_count + 1;
-            if let Err(e) = self.run(retry_opts).await {
-                error!("failed to retry daemon {id}: {e}");
+                Ok(None) => {}
+                Err(error) => error!("failed to retry daemon {id}: {error}"),
             }
         }
 

--- a/src/supervisor/retry.rs
+++ b/src/supervisor/retry.rs
@@ -45,6 +45,12 @@ impl Supervisor {
                     _ => continue, // Daemon was removed or no longer needs retry
                 }
             };
+            if self.has_readiness_retry_for_current_generation(&id).await {
+                debug!(
+                    "skipping background retry for daemon {id} while a start request owns readiness retries"
+                );
+                continue;
+            }
             info!(
                 "retrying daemon {} ({}/{} attempts)",
                 id,

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -296,6 +296,20 @@ impl Supervisor {
         self.state_file.lock().await.daemons.get(id).cloned()
     }
 
+    /// Record an exit without allowing a stale monitor to overwrite a replacement process.
+    pub(crate) async fn record_daemon_exit(
+        &self,
+        id: &DaemonId,
+        pid: u32,
+        status: DaemonStatus,
+        last_exit_success: bool,
+    ) -> bool {
+        self.state_file
+            .lock()
+            .await
+            .record_daemon_exit(id, pid, status, last_exit_success)
+    }
+
     /// Get all active daemons (those with PIDs, excluding pitchfork itself)
     pub(crate) async fn active_daemons(&self) -> Vec<Daemon> {
         let pitchfork_id = DaemonId::pitchfork();

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -296,6 +296,19 @@ impl Supervisor {
         self.state_file.lock().await.daemons.get(id).cloned()
     }
 
+    /// Update status without allowing a stale lifecycle action to restore an old PID.
+    pub(crate) async fn set_daemon_status_if_owned(
+        &self,
+        id: &DaemonId,
+        pid: u32,
+        status: DaemonStatus,
+    ) -> bool {
+        self.state_file
+            .lock()
+            .await
+            .set_daemon_status_if_owned(id, pid, status)
+    }
+
     /// Record an exit without allowing a stale monitor to overwrite a replacement process.
     pub(crate) async fn record_daemon_exit(
         &self,
@@ -308,6 +321,19 @@ impl Supervisor {
             .lock()
             .await
             .record_daemon_exit(id, pid, status, last_exit_success)
+    }
+
+    /// Record an explicit stop without overwriting a terminal state from another owner.
+    pub(crate) async fn record_daemon_stop(
+        &self,
+        id: &DaemonId,
+        pid: u32,
+        last_exit_success: Option<bool>,
+    ) -> bool {
+        self.state_file
+            .lock()
+            .await
+            .record_daemon_stop(id, pid, last_exit_success)
     }
 
     /// Get all active daemons (those with PIDs, excluding pitchfork itself)

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -336,6 +336,14 @@ impl Supervisor {
             .record_daemon_stop(id, pid, last_exit_success)
     }
 
+    /// Record an explicit stop while no process owns the daemon state.
+    pub(crate) async fn record_daemon_stop_if_no_process(&self, id: &DaemonId) -> bool {
+        self.state_file
+            .lock()
+            .await
+            .record_daemon_stop_if_no_process(id)
+    }
+
     /// Get all active daemons (those with PIDs, excluding pitchfork itself)
     pub(crate) async fn active_daemons(&self) -> Vec<Daemon> {
         let pitchfork_id = DaemonId::pitchfork();

--- a/test/depends.bats
+++ b/test/depends.bats
@@ -273,6 +273,29 @@ EOF
   done
 }
 
+@test "stopping an inactive daemon does not stop its running dependency" {
+  create_pitchfork_toml <<EOF
+[daemons.db]
+run = "echo db started && sleep 30"
+ready_delay = 1
+
+[daemons.api]
+run = "echo api started && sleep 30"
+depends = ["db"]
+ready_delay = 1
+EOF
+
+  run pitchfork start db
+  assert_success
+  wait_for_status db running
+
+  run pitchfork stop api
+  assert_success
+
+  wait_for_status db running
+  pitchfork stop db
+}
+
 @test "stop --all succeeds when no daemons are running" {
   create_pitchfork_toml <<EOF
 [daemons.db]

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -282,6 +282,33 @@ EOF
   [[ "$count" -eq 2 ]]
 }
 
+@test "on_retry hook fires for a background retry" {
+  local marker
+  marker="$(to_shell_path "$TEST_TEMP_DIR/background_retry_marker")"
+
+  create_pitchfork_toml <<EOF
+[daemons.background_retry_hook]
+run = "sleep 1; exit 1"
+ready_delay = 0
+retry = 1
+
+[daemons.background_retry_hook.hooks]
+on_retry = "echo retry >> \"$marker\""
+EOF
+
+  run pitchfork start background_retry_hook
+  assert_success
+
+  for _ in $(seq 1 150); do
+    [[ -e "$marker" ]] && break
+    sleep 0.1
+  done
+  assert_file_exists "$marker"
+  local count
+  count=$(wc -l < "$marker" | tr -d ' ')
+  [[ "$count" -eq 1 ]]
+}
+
 # ===========================================================================
 # Lifecycle hooks – environment variables
 # ===========================================================================

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -304,6 +304,8 @@ EOF
     sleep 0.1
   done
   assert_file_exists "$marker"
+  # Let the retried process exit so a delayed duplicate hook would be visible.
+  sleep 2
   local count
   count=$(wc -l < "$marker" | tr -d ' ')
   [[ "$count" -eq 1 ]]

--- a/test/supervisor.bats
+++ b/test/supervisor.bats
@@ -261,6 +261,46 @@ EOF
   wait_for_logs retry_live_owner "attempt-1" 10
 }
 
+@test "stopping a superseding owner cancels an older retry" {
+  skip_on_windows "requires POSIX process groups and signal handling"
+
+  local ready_marker
+  ready_marker="$(to_shell_path "$TEST_TEMP_DIR/retry_superseded_ready")"
+
+  create_pitchfork_toml <<EOF
+[daemons.retry_superseded]
+run = "echo attempt-\$PITCHFORK_RETRY_COUNT; if [ -f '$ready_marker' ]; then echo replacement-ready; fi; sleep 60"
+ready_output = { pattern = "replacement-ready", timeout = "1s" }
+retry = 4
+EOF
+
+  pitchfork start retry_superseded >"$TEST_TEMP_DIR/older_start.log" 2>&1 &
+  local older_start=$!
+
+  # Attempt 3 enters an eight-second backoff before attempt 4. During that gap,
+  # install a newer owner and explicitly stop it, leaving no current PID that
+  # could otherwise tell the older retry it has been superseded.
+  wait_for_logs retry_superseded "attempt-3" 20
+  wait_for_status retry_superseded errored
+  touch "$ready_marker"
+
+  run pitchfork start retry_superseded
+  assert_success
+  wait_for_status retry_superseded running
+
+  run pitchfork stop retry_superseded
+  assert_success
+
+  local older_start_status=0
+  wait "$older_start" || older_start_status=$?
+  [[ "$older_start_status" -ne 0 ]]
+  wait_for_status retry_superseded stopped
+
+  run pitchfork logs retry_superseded --raw
+  assert_success
+  refute_output --partial "attempt-4"
+}
+
 @test "retry count persists across supervisor restart" {
   skip_on_windows "exponential backoff + state persistence timing is unreliable on Windows CI"
 

--- a/test/supervisor.bats
+++ b/test/supervisor.bats
@@ -185,6 +185,82 @@ EOF
   pitchfork stop hooktest
 }
 
+@test "concurrent restarts leave one tracked process" {
+  skip_on_windows "requires POSIX process groups and signal handling"
+
+  create_pitchfork_toml <<EOF
+[daemons.concurrent_restart]
+run = "trap 'sleep 1; exit 0' TERM; while true; do sleep 60; done"
+ready_delay = 0
+retry = 0
+EOF
+
+  run pitchfork start concurrent_restart
+  assert_success
+  wait_for_status concurrent_restart running
+
+  pitchfork restart concurrent_restart >"$TEST_TEMP_DIR/restart_1.log" 2>&1 &
+  local restart_1=$!
+  # The delayed TERM handler holds the first restart in Stopping long enough
+  # to deterministically overlap a second forced start.
+  wait_for_status concurrent_restart stopping
+  pitchfork restart concurrent_restart >"$TEST_TEMP_DIR/restart_2.log" 2>&1 &
+  local restart_2=$!
+
+  local restart_1_status=0
+  local restart_2_status=0
+  wait "$restart_1" || restart_1_status=$?
+  wait "$restart_2" || restart_2_status=$?
+  [[ "$restart_1_status" -eq 0 || "$restart_2_status" -eq 0 ]]
+  wait_for_status concurrent_restart running
+
+  local tracked_pid
+  tracked_pid="$(get_daemon_pid concurrent_restart)"
+  [[ -n "$tracked_pid" ]]
+  kill -0 "$tracked_pid"
+
+  # Supervisor logs each PID before a lifecycle request can release its lock,
+  # so this catches every spawned process even if it was stopped before its
+  # command body began executing.
+  local started_pids
+  started_pids="$TEST_TEMP_DIR/concurrent_restart_started_pids"
+  local supervisor_log="$PITCHFORK_LOGS_DIR/pitchfork/pitchfork.log"
+  [[ -f "$supervisor_log" ]]
+  grep 'started daemon .*/concurrent_restart with pid' "$supervisor_log" \
+    | sed -E 's/.* with pid ([0-9]+).*/\1/' \
+    | sort -u >"$started_pids"
+  [[ "$(wc -l <"$started_pids")" -ge 3 ]]
+
+  local started_pid
+  while IFS= read -r started_pid; do
+    if [[ "$started_pid" != "$tracked_pid" ]]; then
+      ! kill -0 "$started_pid" 2>/dev/null
+    fi
+  done <"$started_pids"
+
+  pitchfork stop concurrent_restart
+}
+
+@test "retry replaces its still-terminating failed attempt" {
+  skip_on_windows "requires POSIX process groups and signal handling"
+
+  create_pitchfork_toml <<EOF
+[daemons.retry_live_owner]
+run = "trap '' TERM; echo attempt-\$PITCHFORK_RETRY_COUNT; while true; do sleep 60; done"
+ready_output = { pattern = "READY", timeout = "100ms" }
+retry = 1
+stop_signal = { signal = "TERM", timeout = "2s" }
+EOF
+
+  run pitchfork start retry_live_owner
+  assert_failure
+
+  wait_for_logs retry_live_owner "attempt-0" 10
+  # The one-second retry backoff expires while attempt 0 still ignores TERM.
+  # The retry must recognize and finish stopping its own PID, then start again.
+  wait_for_logs retry_live_owner "attempt-1" 10
+}
+
 @test "retry count persists across supervisor restart" {
   skip_on_windows "exponential backoff + state persistence timing is unreliable on Windows CI"
 

--- a/test/supervisor.bats
+++ b/test/supervisor.bats
@@ -301,6 +301,33 @@ EOF
   refute_output --partial "attempt-4"
 }
 
+@test "explicit stop during retry backoff prevents resurrection" {
+  create_pitchfork_toml <<EOF
+[daemons.retry_stop_backoff]
+run = "echo attempt-\$PITCHFORK_RETRY_COUNT; sleep 60"
+ready_output = { pattern = "READY", timeout = "100ms" }
+retry = 4
+EOF
+
+  pitchfork start retry_stop_backoff >"$TEST_TEMP_DIR/retry_stop_backoff.log" 2>&1 &
+  local older_start=$!
+
+  wait_for_logs retry_stop_backoff "attempt-3" 20
+  wait_for_status retry_stop_backoff errored
+
+  run pitchfork stop retry_stop_backoff
+  assert_success
+
+  local older_start_status=0
+  wait "$older_start" || older_start_status=$?
+  [[ "$older_start_status" -ne 0 ]]
+  wait_for_status retry_stop_backoff stopped
+
+  run pitchfork logs retry_stop_backoff --raw
+  assert_success
+  refute_output --partial "attempt-4"
+}
+
 @test "retry count persists across supervisor restart" {
   skip_on_windows "exponential backoff + state persistence timing is unreliable on Windows CI"
 


### PR DESCRIPTION
## RFC status

This is a Draft PR intended to make the failure mode and one possible fix concrete for maintainer feedback. I am happy to change the design or combine the relevant pieces with ongoing supervisor work.

Related Discussion: https://github.com/jdx/pitchfork/discussions/634

## Problem

A forced restart can register a replacement daemon as running, then a late exit-state write from the old process monitor can overwrite it with `pid = None` and `stopped`.

The replacement remains alive but untracked. When it later exits, retry logic does not restart it because the supervisor already considers the daemon stopped.

The core invariant proposed here is:

> A process exit callback for PID P may mutate daemon state only while the current state still belongs to PID P.

This was observed in production on v2.17.0 during a cron `retrigger = "always"` restart. Current `main` narrows one timing window with a pre-drain stopping snapshot, but the final ownership check and state write are still separate operations.

## Root cause

There are two related races:

1. The monitor exit path reads state, drains output, and later upserts a terminal state without atomically confirming PID ownership.
2. Concurrent forced lifecycle requests can overlap check, stop, and spawn. A stop completion from one request can overwrite the owner installed by another request.

Readiness failure adds another ownership case: failure can be reported before graceful termination completes. A retry must replace its own still-live failed PID, but must not replace a different PID installed by a newer request.

## Proposed implementation

- Add an atomic `StateFile::record_daemon_exit` transition that updates status only when the stored PID matches the exiting PID.
- Move active-port clearing into that same ownership-gated transition.
- Serialize each daemon check/stop/spawn transition with a per-daemon lifecycle lock.
  - The lock map stores weak references and prunes unused entries.
  - The guard is released after the replacement is registered and its monitor is installed, before readiness waiting.
- Carry a `{ PID, lifecycle generation }` token through readiness retry decisions.
  - Same owner: finish stopping that attempt and retry.
  - Different PID or generation: treat the newer lifecycle request as superseding the old retry, even if the newer PID has since been explicitly stopped.
- Return a failed stop response without spawning another process.
- Gate explicit-stop terminal writes and failed-stop recovery by PID ownership.
- Treat an explicit stop as lifecycle cancellation during a PID-less readiness-retry backoff.
  - Record the stop only while no replacement PID owns the state.
  - Forward explicit CLI and MCP targets without expanding dependencies for inactive roots.
- Coordinate request-owned readiness retries with the periodic retry watcher.
  - The watcher checks readiness ownership, revalidates retry eligibility, schedules `on_retry`, and registers the replacement PID under one lifecycle guard.
  - Missing-command exhaustion mutates only a still-eligible errored daemon instead of performing a broad upsert.
- Log whether an exit was recorded or ignored because state belongs to another PID.

## Reproduction and regression coverage

### Exact stale monitor callback

1. Register replacement PID 200 as running with an active port.
2. Complete the old PID 100 exit transition.
3. Assert that PID 200, running status, exit metadata, and active port remain unchanged.

Companion tests cover a matching PID transitioning from stopping to stopped, an already-cleared PID ignoring a stale callback, and dirty-state behavior.

### Overlapping forced restarts

The end-to-end test:

1. Starts restart A.
2. Waits until the daemon is explicitly `stopping`.
3. Starts restart B.
4. Asserts the final tracked PID is alive.
5. Reads every PID synchronously recorded by supervisor start logs and asserts all non-current PIDs are dead.

### Still-terminating retry owner

Another end-to-end test makes readiness fail after 100 ms while the daemon ignores TERM for two seconds. The one-second retry backoff expires while the original PID is still alive; the test asserts that retry attempt 1 is nevertheless started.

### Superseded retry after explicit stop

A third end-to-end test lets an older readiness retry enter backoff, starts and explicitly stops a newer owner, then asserts the old request cannot resurrect the daemon after the current PID has been cleared.

### Explicit stop during retry backoff

The cancellation test waits until readiness attempt 3 enters its eight-second backoff, issues an explicit stop while there is no current PID, then asserts the daemon remains stopped and attempt 4 never starts. Companion coverage asserts an inactive requested daemon does not cause its running dependency to be stopped.

### Foreground/background retry ownership

State-level coverage keeps a foreground readiness-retry marker alive and asserts the periodic watcher neither starts a process nor mutates retry state. Companion tests cover safe missing-command exhaustion and confirm `on_retry` is scheduled exactly once for a successful background retry.

## Validation

- `cargo nextest run --all-features`: 525 passed
- `cargo clippy --all-targets --all-features --no-deps -- -D warnings -A clippy::collapsible_if`: passed
- Focused Bats tests:
  - `concurrent restarts leave one tracked process`: passed
  - `retry replaces its still-terminating failed attempt`: passed
  - `stopping a superseding owner cancels an older retry`: passed
  - `explicit stop during retry backoff prevents resurrection`: passed
  - `stopping an inactive daemon does not stop its running dependency`: passed
  - `retry with ready_output re-checks on each attempt`: passed
  - `on_retry hook fires for a background retry`: passed
- Iterative correctness, maintainability, and verification reviews: no remaining findings

A broader local Bats run encountered existing macOS `/var` versus `/private/var` path-equivalence assertion failures before reaching the full suite; the new focused tests pass independently.

## Related work

- https://github.com/jdx/pitchfork/discussions/631 describes supervisor-crash orphaning, which is a different failure mode.
- https://github.com/jdx/pitchfork/pull/620 covers nearby monitor-exit architecture and races. This RFC focuses on atomic PID ownership and serializing concurrent forced lifecycle transitions.

---

Authorship note: the investigation, reproduction, and implementation were assisted by OpenAI GPT-5.6 Sol with High reasoning effort. The changes and this RFC were reviewed by @brandon-julio-t.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made daemon terminal-state, status, and port handling PID-aware so stale exit/stop events can’t affect replacement processes.
  * Improved daemon lifecycle coordination to serialize start/stop and prevent outdated retries from taking ownership.
  * Added more reliable retry eligibility/exhaustion behavior, ensuring retries only progress when appropriate.
* **Tests**
  * Extended lifecycle/retry coverage for overlapping restarts, retry progression across attempts, and retry supersession.
  * Added coverage confirming the background retry `on_retry` hook fires exactly once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
