### PR TITLE
style: collapse nested if-lets for clippy 1.97

### DIFF
--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -141,10 +141,11 @@ impl ListCmd {
             return print_json(&entries);
         }
         for (key, info) in meta.iter() {
-            if let Some(ref group) = self.group {
-                if !key.starts_with(&format!("{group}.")) && key != group {
-                    continue;
-                }
+            if let Some(ref group) = self.group
+                && !key.starts_with(&format!("{group}."))
+                && key != group
+            {
+                continue;
             }
             let default = info.default_value.unwrap_or("(none)");
             let env_hint = info.env_var.map(|e| format!(" [{e}]")).unwrap_or_default();

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -603,10 +603,10 @@ impl<'de> Deserialize<'de> for ReadyPort {
                         "ready_port object must have either 'port' or 'template'",
                     ));
                 }
-                if let Some(port) = raw.port {
-                    if port == 0 {
-                        return Err(serde::de::Error::custom("port must be between 1 and 65535"));
-                    }
+                if let Some(port) = raw.port
+                    && port == 0
+                {
+                    return Err(serde::de::Error::custom("port must be between 1 and 65535"));
                 }
                 let timeout = parse_timeout(&raw.timeout).map_err(serde::de::Error::custom)?;
                 Ok(ReadyPort {

--- a/src/env.rs
+++ b/src/env.rs
@@ -26,12 +26,11 @@ pub static HOME_DIR: Lazy<PathBuf> = Lazy::new(|| {
     // actually running as root). SUDO_USER can leak into non-sudo environments
     // (e.g. inherited env, containers) and would misdirect all state paths.
     #[cfg(unix)]
-    if nix::unistd::Uid::effective().is_root() {
-        if let Ok(sudo_user) = std::env::var("SUDO_USER") {
-            if let Some(home) = home_dir_for_user(&sudo_user) {
-                return home;
-            }
-        }
+    if nix::unistd::Uid::effective().is_root()
+        && let Ok(sudo_user) = std::env::var("SUDO_USER")
+        && let Some(home) = home_dir_for_user(&sudo_user)
+    {
+        return home;
     }
     dirs::home_dir().unwrap_or_else(|| {
         eprintln!("Warning: Could not determine home directory");

--- a/src/log_parse.rs
+++ b/src/log_parse.rs
@@ -236,10 +236,10 @@ fn unescape_logfmt_value(s: &str) -> String {
 /// (pino/syslog style). See `normalize_level_value` for the mapping.
 fn extract_level(obj: &Map<String, Value>) -> Option<String> {
     for key in &["level", "severity", "lvl", "PRIORITY", "@level"] {
-        if let Some(val) = obj.get(*key) {
-            if let Some(level) = normalize_level_value(val) {
-                return Some(level);
-            }
+        if let Some(val) = obj.get(*key)
+            && let Some(level) = normalize_level_value(val)
+        {
+            return Some(level);
         }
     }
     None

--- a/src/log_store/sqlite.rs
+++ b/src/log_store/sqlite.rs
@@ -230,10 +230,10 @@ impl SqliteLogStore {
                 // individual writeln! has touched the underlying pipe yet, so
                 // without this flush the failure would be lost and the entries
                 // deleted without ever being delivered to the hook.
-                if result.is_ok() {
-                    if let Err(e) = stdin.flush() {
-                        result = Err(miette::miette!("failed to flush archive hook stdin: {e}"));
-                    }
+                if result.is_ok()
+                    && let Err(e) = stdin.flush()
+                {
+                    result = Err(miette::miette!("failed to flush archive hook stdin: {e}"));
                 }
                 result
                 // BufWriter + ChildStdin drop here, closing stdin (EOF signal).
@@ -489,13 +489,13 @@ impl SqliteLogStore {
             total_migrated += self.insert_batch(daemon_id, &entries)?;
         }
 
-        if total_migrated > 0 {
-            if let Err(e) = std::fs::remove_file(&text_path) {
-                log::warn!(
-                    "failed to remove legacy log file after migration {}: {e}",
-                    text_path.display()
-                );
-            }
+        if total_migrated > 0
+            && let Err(e) = std::fs::remove_file(&text_path)
+        {
+            log::warn!(
+                "failed to remove legacy log file after migration {}: {e}",
+                text_path.display()
+            );
         }
 
         Ok(total_migrated)
@@ -763,10 +763,10 @@ impl SqliteLogStore {
             }
         }
 
-        if let Some(limit) = opts.limit {
-            if merged.len() > limit {
-                merged.truncate(limit);
-            }
+        if let Some(limit) = opts.limit
+            && merged.len() > limit
+        {
+            merged.truncate(limit);
         }
 
         Ok(merged)
@@ -886,12 +886,13 @@ impl LogStore for SqliteLogStore {
 
     fn query(&self, opts: &LogQuery) -> Result<Vec<LogEntry>> {
         // Delegate to parallel path for large single-daemon queries.
-        if Self::should_parallelize(opts) && self.path.as_os_str() != ":memory:" {
-            if let Ok(entries) = self.query_parallel(opts) {
-                return Ok(entries);
-            }
-            // Fall back to single-threaded on parallel failure.
+        if Self::should_parallelize(opts)
+            && self.path.as_os_str() != ":memory:"
+            && let Ok(entries) = self.query_parallel(opts)
+        {
+            return Ok(entries);
         }
+        // Fall back to single-threaded on parallel failure.
 
         // Single-threaded path.
         let conn = self.conn.lock().unwrap();

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -461,29 +461,29 @@ impl PitchforkToml {
         if let Some(entry) = global_slugs.get(user_id) {
             // Load the project's config from the slug's dir to find the daemon ID
             let daemon_name = entry.daemon.as_deref().unwrap_or(user_id);
-            if let Some(dir) = entry.resolve_dir() {
-                if let Ok(project_config) = Self::all_merged_from(&dir) {
-                    // Find daemon by short name in that project
-                    let matches: Vec<DaemonId> = project_config
-                        .daemons
-                        .keys()
-                        .filter(|id| id.name() == daemon_name)
-                        .cloned()
-                        .collect();
-                    match matches.as_slice() {
-                        [] => {}
-                        [id] => return Ok(vec![id.clone()]),
-                        _ => {
-                            let mut candidates: Vec<String> =
-                                matches.iter().map(|id| id.qualified()).collect();
-                            candidates.sort();
-                            return Err(miette::miette!(
-                                "slug '{}' maps to daemon '{}' which matches multiple daemons: {}",
-                                user_id,
-                                daemon_name,
-                                candidates.join(", ")
-                            ));
-                        }
+            if let Some(dir) = entry.resolve_dir()
+                && let Ok(project_config) = Self::all_merged_from(&dir)
+            {
+                // Find daemon by short name in that project
+                let matches: Vec<DaemonId> = project_config
+                    .daemons
+                    .keys()
+                    .filter(|id| id.name() == daemon_name)
+                    .cloned()
+                    .collect();
+                match matches.as_slice() {
+                    [] => {}
+                    [id] => return Ok(vec![id.clone()]),
+                    _ => {
+                        let mut candidates: Vec<String> =
+                            matches.iter().map(|id| id.qualified()).collect();
+                        candidates.sort();
+                        return Err(miette::miette!(
+                            "slug '{}' maps to daemon '{}' which matches multiple daemons: {}",
+                            user_id,
+                            daemon_name,
+                            candidates.join(", ")
+                        ));
                     }
                 }
             }
@@ -590,28 +590,28 @@ impl PitchforkToml {
         let global_slugs = Self::read_global_slugs();
         if let Some(entry) = global_slugs.get(user_id) {
             let daemon_name = entry.daemon.as_deref().unwrap_or(user_id);
-            if let Some(dir) = entry.resolve_dir() {
-                if let Ok(project_config) = Self::all_merged_from(&dir) {
-                    let matches: Vec<DaemonId> = project_config
-                        .daemons
-                        .keys()
-                        .filter(|id| id.name() == daemon_name)
-                        .cloned()
-                        .collect();
-                    match matches.as_slice() {
-                        [] => {}
-                        [id] => return Ok(id.clone()),
-                        _ => {
-                            let mut candidates: Vec<String> =
-                                matches.iter().map(|id| id.qualified()).collect();
-                            candidates.sort();
-                            return Err(miette::miette!(
-                                "slug '{}' maps to daemon '{}' which matches multiple daemons: {}",
-                                user_id,
-                                daemon_name,
-                                candidates.join(", ")
-                            ));
-                        }
+            if let Some(dir) = entry.resolve_dir()
+                && let Ok(project_config) = Self::all_merged_from(&dir)
+            {
+                let matches: Vec<DaemonId> = project_config
+                    .daemons
+                    .keys()
+                    .filter(|id| id.name() == daemon_name)
+                    .cloned()
+                    .collect();
+                match matches.as_slice() {
+                    [] => {}
+                    [id] => return Ok(id.clone()),
+                    _ => {
+                        let mut candidates: Vec<String> =
+                            matches.iter().map(|id| id.qualified()).collect();
+                        candidates.sort();
+                        return Err(miette::miette!(
+                            "slug '{}' maps to daemon '{}' which matches multiple daemons: {}",
+                            user_id,
+                            daemon_name,
+                            candidates.join(", ")
+                        ));
                     }
                 }
             }
@@ -1456,17 +1456,17 @@ impl PitchforkToml {
         // If caller provided a namespace that isn't yet registered,
         // auto-register it at the directory we can resolve.
         // Falls back to CWD if the slug dir cannot be resolved.
-        if let Some(ns) = namespace {
-            if !pt.namespaces.contains_key(ns) {
-                let dir = pt
-                    .slugs
-                    .get(slug)
-                    .and_then(|e| e.resolve_dir())
-                    .or_else(|| namespace.and_then(|_| env::CWD.as_path().canonicalize().ok()));
-                if let Some(ref d) = dir {
-                    pt.namespaces
-                        .insert(ns.to_string(), NamespaceEntry { dir: d.clone() });
-                }
+        if let Some(ns) = namespace
+            && !pt.namespaces.contains_key(ns)
+        {
+            let dir = pt
+                .slugs
+                .get(slug)
+                .and_then(|e| e.resolve_dir())
+                .or_else(|| namespace.and_then(|_| env::CWD.as_path().canonicalize().ok()));
+            if let Some(ref d) = dir {
+                pt.namespaces
+                    .insert(ns.to_string(), NamespaceEntry { dir: d.clone() });
             }
         }
 

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -344,12 +344,11 @@ impl Supervisor {
             // the TCP readiness probe would immediately succeed and pitchfork
             // would falsely consider the daemon ready — routing proxy traffic to
             // the wrong process.
-            if let Some(port) = opts.ready_port.as_ref().and_then(|p| p.as_port()) {
-                if port > 0 {
-                    if let Some((pid, process)) = detect_port_conflict(port).await {
-                        return Ok(IpcResponse::PortConflict { port, process, pid });
-                    }
-                }
+            if let Some(port) = opts.ready_port.as_ref().and_then(|p| p.as_port())
+                && port > 0
+                && let Some((pid, process)) = detect_port_conflict(port).await
+            {
+                return Ok(IpcResponse::PortConflict { port, process, pid });
             }
             (
                 Vec::new(),
@@ -1855,11 +1854,12 @@ async fn check_ports_available(
         }
 
         // Port is in use
-        if bump_offset == 0 && !auto_bump {
-            if let Some(port) = conflicting_port {
-                let (pid, process) = identify_port_owner(port).await;
-                return Err(PortError::InUse { port, process, pid }.into());
-            }
+        if bump_offset == 0
+            && !auto_bump
+            && let Some(port) = conflicting_port
+        {
+            let (pid, process) = identify_port_owner(port).await;
+            return Err(PortError::InUse { port, process, pid }.into());
         }
     }
 
@@ -1986,10 +1986,10 @@ fn detect_and_store_active_port(id: DaemonId, pid: u32) {
 
                 // Prefer the configured expected_port if the process is actually
                 // listening on it; otherwise fall back to the first port found.
-                if let Some(ep) = expected_port {
-                    if process_ports.contains(&ep) {
-                        return Some(ep);
-                    }
+                if let Some(ep) = expected_port
+                    && process_ports.contains(&ep)
+                {
+                    return Some(ep);
                 }
 
                 // No expected_port match — return the first port in the list.

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -537,10 +537,10 @@ impl Supervisor {
                 ticker.tick().await; // first tick is immediate
                 loop {
                     ticker.tick().await;
-                    if let Some(cancel) = monitor_cancel.as_ref() {
-                        if cancel.is_cancelled() {
-                            break;
-                        }
+                    if let Some(cancel) = monitor_cancel.as_ref()
+                        && cancel.is_cancelled()
+                    {
+                        break;
                     }
                     if let Some(new_ip) =
                         crate::proxy::lan_ip::detect_lan_ip_if_changed(last_ip).await
@@ -622,10 +622,10 @@ impl Supervisor {
                     }
                 }
                 let state = SUPERVISOR.state_file.lock().await;
-                if state.is_dirty() {
-                    if let Err(e) = state.write() {
-                        warn!("failed to flush state file: {e}");
-                    }
+                if state.is_dirty()
+                    && let Err(e) = state.write()
+                {
+                    warn!("failed to flush state file: {e}");
                 }
             }
             debug!("state flush task exiting");
@@ -634,10 +634,10 @@ impl Supervisor {
 
     pub(crate) async fn flush_state(&self) {
         let state = self.state_file.lock().await;
-        if state.is_dirty() {
-            if let Err(e) = state.write() {
-                warn!("failed to flush state file: {e}");
-            }
+        if state.is_dirty()
+            && let Err(e) = state.write()
+        {
+            warn!("failed to flush state file: {e}");
         }
     }
 
@@ -1009,10 +1009,10 @@ impl Supervisor {
         // in-memory-only changes are lost.
         {
             let state = self.state_file.lock().await;
-            if state.is_dirty() {
-                if let Err(e) = state.write() {
-                    warn!("failed to flush state file during shutdown: {e}");
-                }
+            if state.is_dirty()
+                && let Err(e) = state.write()
+            {
+                warn!("failed to flush state file during shutdown: {e}");
             }
         }
 
@@ -1182,12 +1182,11 @@ fn chown_recursive(dir: &std::path::Path, uid: u32, gid: u32, skip_proxy: bool) 
         let path = entry.path();
         if path.is_dir() {
             // Skip proxy/ at the top level of the state directory
-            if skip_proxy {
-                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    if name == "proxy" {
-                        continue;
-                    }
-                }
+            if skip_proxy
+                && let Some(name) = path.file_name().and_then(|n| n.to_str())
+                && name == "proxy"
+            {
+                continue;
             }
             chown_recursive(&path, uid, gid, false);
         } else {

--- a/src/supervisor/watchers.rs
+++ b/src/supervisor/watchers.rs
@@ -255,19 +255,19 @@ impl Supervisor {
             // Check memory limit (RSS) — immediate kill, no grace period.
             // Memory violations are not transient: once RSS exceeds the limit
             // the process is unlikely to release it without intervention.
-            if let Some(mem_limit) = daemon.memory_limit {
-                if stats.memory_bytes > mem_limit.0 {
-                    warn!(
-                        "daemon {} (pid {}) exceeded memory limit: {} > {}, stopping",
-                        daemon.id,
-                        pid,
-                        stats.memory_display(),
-                        mem_limit,
-                    );
-                    cpu_violation_counts.remove(&daemon.id);
-                    self.stop_for_resource_violation(&daemon.id, pid).await;
-                    continue; // Don't check CPU if we're already killing
-                }
+            if let Some(mem_limit) = daemon.memory_limit
+                && stats.memory_bytes > mem_limit.0
+            {
+                warn!(
+                    "daemon {} (pid {}) exceeded memory limit: {} > {}, stopping",
+                    daemon.id,
+                    pid,
+                    stats.memory_display(),
+                    mem_limit,
+                );
+                cpu_violation_counts.remove(&daemon.id);
+                self.stop_for_resource_violation(&daemon.id, pid).await;
+                continue; // Don't check CPU if we're already killing
             }
 
             // Check CPU limit (percentage) with consecutive-sample threshold.
@@ -624,12 +624,12 @@ impl Supervisor {
                             // immediate=false (default): anchor last_cron_triggered to now
                             // so the next scheduled time is picked up, without firing now.
                             let mut state_file = self.state_file.lock().await;
-                            if state_file.set_last_cron_triggered(&id, now) {
-                                if let Err(e) = state_file.write() {
-                                    error!(
-                                        "failed to persist last_cron_triggered for daemon {id}: {e}"
-                                    );
-                                }
+                            if state_file.set_last_cron_triggered(&id, now)
+                                && let Err(e) = state_file.write()
+                            {
+                                error!(
+                                    "failed to persist last_cron_triggered for daemon {id}: {e}"
+                                );
                             }
                             continue;
                         }
@@ -651,12 +651,10 @@ impl Supervisor {
                     // re-fire the cron job immediately.
                     {
                         let mut state_file = self.state_file.lock().await;
-                        if state_file.set_last_cron_triggered(&id, now) {
-                            if let Err(e) = state_file.write() {
-                                error!(
-                                    "failed to persist last_cron_triggered for daemon {id}: {e}"
-                                );
-                            }
+                        if state_file.set_last_cron_triggered(&id, now)
+                            && let Err(e) = state_file.write()
+                        {
+                            error!("failed to persist last_cron_triggered for daemon {id}: {e}");
                         }
                     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -362,24 +362,24 @@ pub fn render_daemon_templates(
         config.ready_http = Some(http);
     }
 
-    if let Some(ref ready_port) = config.ready_port {
-        if let Some(ref template) = ready_port.template {
-            let rendered = renderer.render(template)?;
-            let port = rendered
-                .trim()
-                .parse::<u16>()
-                .ok()
-                .filter(|&p| p > 0)
-                .ok_or_else(|| RenderError::InvalidPort {
-                    template: template.clone(),
-                    rendered: rendered.clone(),
-                })?;
-            config.ready_port = Some(crate::config_types::ReadyPort {
-                port: Some(port),
-                template: None,
-                timeout: ready_port.timeout,
-            });
-        }
+    if let Some(ref ready_port) = config.ready_port
+        && let Some(ref template) = ready_port.template
+    {
+        let rendered = renderer.render(template)?;
+        let port = rendered
+            .trim()
+            .parse::<u16>()
+            .ok()
+            .filter(|&p| p > 0)
+            .ok_or_else(|| RenderError::InvalidPort {
+                template: template.clone(),
+                rendered: rendered.clone(),
+            })?;
+        config.ready_port = Some(crate::config_types::ReadyPort {
+            port: Some(port),
+            template: None,
+            timeout: ready_port.timeout,
+        });
     }
 
     Ok(())


### PR DESCRIPTION
## What

Rust stable 1.97 extended `clippy::collapsible_if` to flag nested `if let` statements that can now be written as `let`-chains (`if let ... && let ... {}`). This applies `cargo clippy --fix` to collapse them across the codebase.

Files touched: `src/cli/settings.rs`, `src/config_types.rs`, `src/env.rs`, `src/log_parse.rs`, `src/log_store/sqlite.rs`, `src/pitchfork_toml.rs`, `src/supervisor/lifecycle.rs`, `src/supervisor/mod.rs`, `src/supervisor/watchers.rs`, `src/template.rs`.

## Why

CI's `hk` lint runs `cargo clippy --quiet` without `-D warnings`, so these warnings don't gate CI. But `CLAUDE.md` documents `cargo clippy --all-targets --all-features -- -D warnings` as the lint command, and that now fails under clippy 1.97. This restores a clean `-D warnings` run.

## How it was verified

- `cargo clippy --fix --allow-dirty --all-targets --all-features` to collapse the if-lets
- `cargo clippy --all-targets --all-features -- -D warnings` now passes clean
- `cargo fmt --all`
- `mise run ci-dev` (lint, build, docs, render all pass; no doc regeneration)

The change is purely syntactic — no behavior changes.

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical style refactor with no intended logic changes; risk is limited to rare let-chain evaluation-order edge cases, which these rewrites preserve.
> 
> **Overview**
> **Rust 1.97 / Clippy** now suggests collapsing nested `if let` checks into **let-chains**. This PR applies that pattern repo-wide (CLI settings filtering, config deserialization, `SUDO_USER` home resolution, log parsing, SQLite log store, TOML slug resolution, supervisor lifecycle/watchers, templates, etc.).
> 
> The edits are **syntax-only**: the same conditions run in the same order with the same early returns, branches, and side effects—only the control-flow shape changes.
> 
> **Why:** `cargo clippy --all-targets --all-features -- -D warnings` (documented in the project) was failing on the new `collapsible_if` lints; CI’s quieter clippy run did not catch them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 550908c3a251658b28b2db4b7809b30e2a49b0c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->