### PR TITLE
docs: fix stale exec-prepending claim and other inaccuracies in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Pitchfork is a daemon supervisor CLI with a **client-server architecture**:
 ### Core Components
 
 1. **CLI (`src/cli/`)** - User-facing commands that communicate with the supervisor via IPC
-2. **Supervisor (`src/supervisor.rs`)** - Background daemon that manages all child processes
+2. **Supervisor (`src/supervisor/`)** - Background daemon that manages all child processes
 3. **IPC (`src/ipc/`)** - Unix domain socket communication using MessagePack serialization
 
 ### How It Works
@@ -54,27 +54,26 @@ Pitchfork is a daemon supervisor CLI with a **client-server architecture**:
 
 | File | Purpose |
 |------|---------|
-| `src/supervisor.rs` | Main supervisor logic, IPC handlers, background watchers |
+| `src/supervisor/` | Supervisor module: `lifecycle.rs` (start/stop daemons), `ipc_handlers.rs`, `watchers.rs` (background watchers), `retry.rs`, `autostop.rs`, `state.rs`, `hooks.rs`, `pty.rs` |
 | `src/ipc/` | Client/server IPC with MessagePack over Unix sockets |
 | `src/pitchfork_toml.rs` | Config file parsing and merging |
 | `src/state_file.rs` | Persistent state management |
 | `src/daemon.rs` | Daemon struct and state |
 | `src/cli/start.rs` | Main "start daemon" command logic |
 
-### Background Watchers (in supervisor)
+### Background Watchers (in `src/supervisor/watchers.rs`)
 
-- **Interval watcher (10s)**: Refresh process state, autostop, retry failed daemons
-- **Cron watcher (10s)**: Trigger scheduled tasks based on cron expressions
+- **Interval watcher**: Refresh process state, autostop, retry failed daemons (interval from `general.interval` setting, default 10s)
+- **Cron watcher**: Trigger scheduled tasks based on cron expressions (interval from `supervisor.cron_check_interval` setting, default 10s)
+- **File watcher**: Restart daemons when their watched files change (`daemon_file_watch`)
 
 ### Config Hierarchy
 
 Configs merge in order (later overrides earlier):
 1. `/etc/pitchfork/config.toml` (system - namespace: global)
 2. `~/.config/pitchfork/config.toml` (user - namespace: global)
-3. `.config/pitchfork.toml` files from filesystem root to current directory (project)
-4. `.config/pitchfork.local.toml` files from filesystem root to current directory (project)
-5. `pitchfork.toml` files from filesystem root to current directory (project)
-6. `pitchfork.local.toml` files from filesystem root to current directory (project)
+3. Project config files from filesystem root down to the current directory; within each directory:
+   `.config/pitchfork.toml` < `.config/pitchfork.local.toml` < `pitchfork.toml` < `pitchfork.local.toml`
 
 ### Data Sources
 
@@ -102,7 +101,7 @@ Configs merge in order (later overrides earlier):
 - **Error handling**: Use `miette::Result` for rich error messages
 - **Serialization**: Heavy use of serde with TOML for config/state, MessagePack for IPC
 - **File locking**: Always lock state file for concurrent access (`xx::fslock`)
-- **Daemon commands**: Prepend `exec` to eliminate shell process overhead
+- **Daemon commands**: Run via the shell verbatim; do NOT prepend `exec` — it breaks compound commands (e.g. `exec a && b` silently drops `b`). Users can add `exec` themselves in the run string for single commands
 - **Idiomatical Rust**: Prefer Idiomatical Rust patterns and idioms
 
 ## Conventional Commits


### PR DESCRIPTION
## What changed

Audit of CLAUDE.md (symlinked to AGENTS.md) against the current codebase; fixed four stale claims:

- **Daemon commands / exec**: the "Prepend `exec`" bullet contradicted the actual behavior — `exec` is deliberately NOT prepended anymore because it breaks compound commands (`exec a && b` silently drops `b`, see the comment in `src/supervisor/lifecycle.rs`). The bullet now documents that commands run via the shell verbatim and users may add `exec` themselves for single commands.
- **Supervisor module**: `src/supervisor.rs` was split into the `src/supervisor/` module; the Core Components and Key Files sections now reference the directory and its submodules (`lifecycle.rs`, `ipc_handlers.rs`, `watchers.rs`, `retry.rs`, `autostop.rs`, …).
- **Background watchers**: intervals are no longer hardcoded 10s — they come from the `general.interval` and `supervisor.cron_check_interval` settings (defaults 10s). Also added the missing file watcher (`daemon_file_watch`).
- **Config hierarchy**: the merge order was described as four separate file-type passes; it's actually per-directory from filesystem root to cwd, with `.config/pitchfork.toml` < `.config/pitchfork.local.toml` < `pitchfork.toml` < `pitchfork.local.toml` within each directory (`PitchforkToml::list_paths_from`).

## Why

CLAUDE.md guides AI-assisted contributions; the exec bullet in particular instructed the exact opposite of current behavior.

## Notes for reviewers

- Docs-only; the remaining claims (socket/state paths, mise tasks, codegen pipeline) were verified against the code and left unchanged.
- `mise run ci-dev` passed all tests (495 nextest + 287 bats). Its `lint-fix` step produced unrelated clippy let-chain rewrites in `src/`, which were intentionally excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> **AGENTS.md** is updated so contributor guidance matches the current codebase.
> 
> The supervisor is documented as **`src/supervisor/`** (with submodule roles) instead of a single **`supervisor.rs`**. Background watchers note configurable intervals via **`general.interval`** and **`supervisor.cron_check_interval`**, and call out the **file watcher** for **`daemon_file_watch`**.
> 
> Project config merge order is clarified: per directory from filesystem root to cwd, with the four filename variants ordered within each directory.
> 
> The **daemon commands** pattern is corrected: runs go through the shell **verbatim**; **`exec` must not be auto-prepended** (compound commands break); users may add **`exec`** in the run string when they want it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739b7c9232366951551d5c5c7e633880a7a09cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture guidance to reflect the supervisor’s modular structure.
  * Expanded supervisor file references and clarified project configuration precedence.
  * Corrected daemon command guidance to omit the `exec` prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->