### PR TITLE
fix(supervisor): make unobserved daemon deaths retryable after a crash

### DIFF
--- a/src/cli/supervisor/stop.rs
+++ b/src/cli/supervisor/stop.rs
@@ -19,6 +19,17 @@ impl Stop {
         };
         match outcome {
             KillOrStopOutcome::Killed => {
+                // Record that this shutdown was deliberate. On Unix the
+                // supervisor handles the stop signal and removes its own entry
+                // in `close()`; Windows has no POSIX signals, so the process is
+                // force-terminated and never gets to. Without this the next
+                // supervisor would read the leftover entry as evidence of a
+                // crash and treat daemons it finds stopped as failures.
+                if let Ok(mut sf) = StateFile::read(&*env::PITCHFORK_STATE_FILE)
+                    && sf.daemons.remove(&DaemonId::pitchfork()).is_some()
+                {
+                    let _ = sf.write();
+                }
                 info!("Stopped pitchfork daemon with pid {pid}");
             }
             KillOrStopOutcome::AlreadyDead => {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -45,6 +45,13 @@ pub struct Daemon {
     /// from an unrelated process.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub start_time: Option<u64>,
+    /// System boot time (seconds since epoch) recorded at spawn. Lets orphan
+    /// reconciliation tell a daemon that died under a crashed supervisor
+    /// during this boot from one whose process died with the machine, which
+    /// need different terminal states. Unlike `start_time` this is a
+    /// wall-clock value comparable across processes and platforms.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub boot_time: Option<u64>,
     pub shell_pid: Option<u32>,
     pub status: DaemonStatus,
     pub dir: Option<PathBuf>,

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -67,6 +67,16 @@ impl Procs {
             .map(|p| p.name().to_string_lossy().to_string())
     }
 
+    /// Time the system booted, in seconds since the epoch.
+    ///
+    /// Constant for the lifetime of a boot, so recording it alongside a
+    /// daemon's PID makes it possible to tell later whether that record
+    /// belongs to the current boot. Note this is *not* comparable with
+    /// `start_time`, whose units are platform-specific.
+    pub fn boot_time(&self) -> u64 {
+        sysinfo::System::boot_time()
+    }
+
     /// High-resolution kernel start token for the process.
     ///
     /// Combined with the PID this forms a stable identity for the lifetime of a

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -210,8 +210,17 @@ impl Supervisor {
             if !PROCS.is_running(pid) {
                 // The monitor that would have observed this exit died with a
                 // previous supervisor; the exit status is unobservable.
-                let status =
-                    super::unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time);
+                // Any daemon this pass sees is Running with no live monitor,
+                // so whatever was watching it is gone and its exit went
+                // unobserved by definition. Records left by a *clean*
+                // shutdown cannot reach here: the startup scan already
+                // resolved those out of Running before this ever runs.
+                let status = super::unobserved_exit_status(
+                    &daemon.status,
+                    daemon.boot_time,
+                    boot_time,
+                    true,
+                );
                 warn!(
                     "daemon {} (pid {pid}) died while unmonitored; marking {status}",
                     daemon.id
@@ -239,8 +248,17 @@ impl Supervisor {
                 }
                 // The PID belongs to a different process now, which means the
                 // daemon itself died unnoticed. Never touch the new process.
-                let status =
-                    super::unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time);
+                // Any daemon this pass sees is Running with no live monitor,
+                // so whatever was watching it is gone and its exit went
+                // unobserved by definition. Records left by a *clean*
+                // shutdown cannot reach here: the startup scan already
+                // resolved those out of Running before this ever runs.
+                let status = super::unobserved_exit_status(
+                    &daemon.status,
+                    daemon.boot_time,
+                    boot_time,
+                    true,
+                );
                 warn!(
                     "pid {pid} recorded for daemon {} belongs to a different process now (PID recycled); marking {status}",
                     daemon.id,
@@ -306,9 +324,10 @@ impl Supervisor {
     /// the in-lock check stands down. No hooks fire from these transitions —
     /// the monitor that would have observed the exit died with a previous
     /// supervisor, mirroring the startup scan's handling. `last_exit_success`
-    /// is left untouched for the same reason: these exits were never
-    /// observed, and fabricating a result would corrupt the cron
-    /// `retrigger = "success" | "fail"` decisions that read it.
+    /// is cleared for the same reason: the run's outcome was never observed,
+    /// so neither fabricating a result nor keeping the previous run's (which
+    /// the cron `retrigger = "success" | "fail"` decisions would then read as
+    /// this run's) is correct.
     ///
     /// Returns whether the write happened.
     async fn finalize_if_pid(&self, id: &DaemonId, pid: u32, status: DaemonStatus) -> bool {
@@ -339,6 +358,7 @@ impl Supervisor {
         d.start_time = None;
         d.boot_time = None;
         d.status = status;
+        d.last_exit_success = None;
         d.active_port = None;
         state_file.clear_active_port(id);
         state_file.insert_daemon(id, d);

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -225,7 +225,8 @@ impl Supervisor {
                     "daemon {} (pid {pid}) died while unmonitored; marking {status}",
                     daemon.id
                 );
-                self.finalize_if_pid(&daemon.id, pid, status).await;
+                self.finalize_if_pid(&daemon.id, pid, status, super::ExitObservation::Unobserved)
+                    .await;
                 continue;
             }
 
@@ -263,7 +264,8 @@ impl Supervisor {
                     "pid {pid} recorded for daemon {} belongs to a different process now (PID recycled); marking {status}",
                     daemon.id,
                 );
-                self.finalize_if_pid(&daemon.id, pid, status).await;
+                self.finalize_if_pid(&daemon.id, pid, status, super::ExitObservation::Unobserved)
+                    .await;
                 continue;
             }
 
@@ -298,8 +300,13 @@ impl Supervisor {
                 .await
             {
                 Ok(true) => {
-                    self.finalize_if_pid(&daemon.id, pid, DaemonStatus::Stopped)
-                        .await;
+                    self.finalize_if_pid(
+                        &daemon.id,
+                        pid,
+                        DaemonStatus::Stopped,
+                        super::ExitObservation::Terminated,
+                    )
+                    .await;
                 }
                 Ok(false) => {
                     warn!(
@@ -323,14 +330,18 @@ impl Supervisor {
     /// snapshot is never overwritten — its upsert serializes after ours and
     /// the in-lock check stands down. No hooks fire from these transitions —
     /// the monitor that would have observed the exit died with a previous
-    /// supervisor, mirroring the startup scan's handling. `last_exit_success`
-    /// is cleared for the same reason: the run's outcome was never observed,
-    /// so neither fabricating a result nor keeping the previous run's (which
-    /// the cron `retrigger = "success" | "fail"` decisions would then read as
-    /// this run's) is correct.
+    /// supervisor, mirroring the startup scan's handling. `observation`
+    /// decides what happens to the recorded `last_exit_success`, exactly as in
+    /// the startup scan.
     ///
     /// Returns whether the write happened.
-    async fn finalize_if_pid(&self, id: &DaemonId, pid: u32, status: DaemonStatus) -> bool {
+    async fn finalize_if_pid(
+        &self,
+        id: &DaemonId,
+        pid: u32,
+        status: DaemonStatus,
+        observation: super::ExitObservation,
+    ) -> bool {
         let mut state_file = self.state_file.lock().await;
         // A monitor entry appearing since the caller's snapshot means a live
         // monitor now owns this daemon — including a successor that recycled
@@ -358,7 +369,7 @@ impl Supervisor {
         d.start_time = None;
         d.boot_time = None;
         d.status = status;
-        d.last_exit_success = None;
+        d.last_exit_success = observation.last_exit_success();
         d.active_port = None;
         state_file.clear_active_port(id);
         state_file.insert_daemon(id, d);

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -192,6 +192,7 @@ impl Supervisor {
         }
 
         let policy = super::orphan_policy();
+        let boot_time = PROCS.boot_time();
 
         for daemon in candidates {
             let Some(pid) = daemon.pid else { continue };
@@ -209,12 +210,13 @@ impl Supervisor {
             if !PROCS.is_running(pid) {
                 // The monitor that would have observed this exit died with a
                 // previous supervisor; the exit status is unobservable.
+                let status =
+                    super::unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time);
                 warn!(
-                    "daemon {} (pid {pid}) died while unmonitored; marking errored",
+                    "daemon {} (pid {pid}) died while unmonitored; marking {status}",
                     daemon.id
                 );
-                self.finalize_if_pid(&daemon.id, pid, DaemonStatus::Errored(-1), Some(false))
-                    .await;
+                self.finalize_if_pid(&daemon.id, pid, status).await;
                 continue;
             }
 
@@ -237,12 +239,13 @@ impl Supervisor {
                 }
                 // The PID belongs to a different process now, which means the
                 // daemon itself died unnoticed. Never touch the new process.
+                let status =
+                    super::unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time);
                 warn!(
-                    "pid {pid} recorded for daemon {} belongs to a different process now (PID recycled); marking errored",
+                    "pid {pid} recorded for daemon {} belongs to a different process now (PID recycled); marking {status}",
                     daemon.id,
                 );
-                self.finalize_if_pid(&daemon.id, pid, DaemonStatus::Errored(-1), Some(false))
-                    .await;
+                self.finalize_if_pid(&daemon.id, pid, status).await;
                 continue;
             }
 
@@ -277,7 +280,7 @@ impl Supervisor {
                 .await
             {
                 Ok(true) => {
-                    self.finalize_if_pid(&daemon.id, pid, DaemonStatus::Stopped, None)
+                    self.finalize_if_pid(&daemon.id, pid, DaemonStatus::Stopped)
                         .await;
                 }
                 Ok(false) => {
@@ -302,16 +305,13 @@ impl Supervisor {
     /// snapshot is never overwritten — its upsert serializes after ours and
     /// the in-lock check stands down. No hooks fire from these transitions —
     /// the monitor that would have observed the exit died with a previous
-    /// supervisor, mirroring the startup scan's handling.
+    /// supervisor, mirroring the startup scan's handling. `last_exit_success`
+    /// is left untouched for the same reason: these exits were never
+    /// observed, and fabricating a result would corrupt the cron
+    /// `retrigger = "success" | "fail"` decisions that read it.
     ///
     /// Returns whether the write happened.
-    async fn finalize_if_pid(
-        &self,
-        id: &DaemonId,
-        pid: u32,
-        status: DaemonStatus,
-        last_exit_success: Option<bool>,
-    ) -> bool {
+    async fn finalize_if_pid(&self, id: &DaemonId, pid: u32, status: DaemonStatus) -> bool {
         let mut state_file = self.state_file.lock().await;
         // A monitor entry appearing since the caller's snapshot means a live
         // monitor now owns this daemon — including a successor that recycled
@@ -337,10 +337,8 @@ impl Supervisor {
         d.pid = None;
         d.title = None;
         d.start_time = None;
+        d.boot_time = None;
         d.status = status;
-        if let Some(les) = last_exit_success {
-            d.last_exit_success = Some(les);
-        }
         d.active_port = None;
         state_file.clear_active_port(id);
         state_file.insert_daemon(id, d);
@@ -552,7 +550,12 @@ impl Supervisor {
                     d.pid = None;
                     d.title = None;
                     d.start_time = None;
+                    d.boot_time = None;
                     d.status = new_status;
+                    // The poll monitor did observe this process die (it just
+                    // cannot read the exit code of a non-child), so unlike the
+                    // unobserved startup/reconciler cases it is meaningful to
+                    // record whether the last run ended intentionally.
                     d.last_exit_success = Some(last_exit_success);
                     d.active_port = None;
                     state_file.insert_daemon(&id, d);

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1308,7 +1308,7 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
             // crashed supervisor (retryable) or with the machine.
             let status =
                 unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time, unclean);
-            reset_daemon_state(supervisor, &daemon.id, status).await;
+            reset_daemon_state(supervisor, &daemon.id, status, ExitObservation::Unobserved).await;
             continue;
         }
 
@@ -1342,7 +1342,7 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
             // to something else — same unobserved exit as a dead PID.
             let status =
                 unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time, unclean);
-            reset_daemon_state(supervisor, &daemon.id, status).await;
+            reset_daemon_state(supervisor, &daemon.id, status, ExitObservation::Unobserved).await;
             continue;
         }
 
@@ -1399,7 +1399,13 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
 
         // We terminated the orphan ourselves, so this is an observed,
         // intentional stop rather than an unobserved exit.
-        reset_daemon_state(supervisor, &daemon.id, DaemonStatus::Stopped).await;
+        reset_daemon_state(
+            supervisor,
+            &daemon.id,
+            DaemonStatus::Stopped,
+            ExitObservation::Terminated,
+        )
+        .await;
     }
 }
 
@@ -1435,19 +1441,44 @@ fn process_identity_matches(
     }
 }
 
+/// How a daemon's run ended, which decides what happens to the recorded
+/// `last_exit_success` that cron `retrigger = "success" | "fail"` reads.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExitObservation {
+    /// Nobody saw how the run ended — the monitor that would have died with a
+    /// previous supervisor. The recorded outcome is cleared: fabricating a
+    /// result would corrupt those retrigger decisions, and keeping the
+    /// previous value is just as wrong, since it would attribute an earlier
+    /// run's outcome to this one. `None` restores the "no result yet" reading
+    /// both retriggers already handle.
+    Unobserved,
+    /// We terminated the process ourselves, so the outcome is not a mystery:
+    /// it stopped because we asked it to. Recorded as a success, matching the
+    /// convention `Supervisor::stop` already uses for a deliberate stop.
+    Terminated,
+}
+
+impl ExitObservation {
+    /// The `last_exit_success` value this observation implies.
+    pub(crate) fn last_exit_success(self) -> Option<bool> {
+        match self {
+            ExitObservation::Unobserved => None,
+            ExitObservation::Terminated => Some(true),
+        }
+    }
+}
+
 /// Clear a daemon's runtime state (pid, process identity, active port) after
 /// its process is gone or is no longer ours to manage.
 ///
-/// `last_exit_success` is cleared rather than set or preserved. These
-/// transitions cover runs whose outcome nobody observed: fabricating a result
-/// would corrupt the cron `retrigger = "success" | "fail"` decisions that read
-/// it, and keeping the previous value is just as wrong — it would attribute an
-/// earlier run's outcome to this one. `None` restores the "no result yet"
-/// reading, which those retriggers already handle.
-///
 /// Config fields are preserved by cloning the existing record, so a reset can
 /// never drop a daemon's command, retry policy, or schedule.
-async fn reset_daemon_state(supervisor: &Supervisor, id: &DaemonId, status: DaemonStatus) {
+async fn reset_daemon_state(
+    supervisor: &Supervisor,
+    id: &DaemonId,
+    status: DaemonStatus,
+    observation: ExitObservation,
+) {
     let mut state_file = supervisor.state_file.lock().await;
     let Some(existing) = state_file.daemons.get(id) else {
         return;
@@ -1458,7 +1489,7 @@ async fn reset_daemon_state(supervisor: &Supervisor, id: &DaemonId, status: Daem
     daemon.start_time = None;
     daemon.boot_time = None;
     daemon.status = status;
-    daemon.last_exit_success = None;
+    daemon.last_exit_success = observation.last_exit_success();
     daemon.active_port = None;
     state_file.clear_active_port(id);
     state_file.insert_daemon(id, daemon);

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1445,12 +1445,25 @@ fn process_identity_matches(
 /// `last_exit_success` that cron `retrigger = "success" | "fail"` reads.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ExitObservation {
-    /// Nobody saw how the run ended — the monitor that would have died with a
-    /// previous supervisor. The recorded outcome is cleared: fabricating a
-    /// result would corrupt those retrigger decisions, and keeping the
-    /// previous value is just as wrong, since it would attribute an earlier
-    /// run's outcome to this one. `None` restores the "no result yet" reading
-    /// both retriggers already handle.
+    /// Nobody saw how the run ended, because the monitor that would have
+    /// observed it died with a previous supervisor. The recorded outcome is
+    /// cleared to `None`.
+    ///
+    /// Every option here is imperfect, so this picks the one that asserts
+    /// nothing false. `Some(false)` would fabricate a failure, silently
+    /// breaking a `retrigger = "success"` chain whose run may well have
+    /// succeeded; `Some(true)` fabricates the opposite; keeping the previous
+    /// value attributes an earlier run's outcome to this one. `None` says
+    /// "unknown", reusing the reading the cron watcher already applies to a
+    /// daemon that has never run.
+    ///
+    /// The tradeoff is that `None` satisfies both `retrigger = "success"`
+    /// (`unwrap_or(true)`) and `retrigger = "fail"` (`!unwrap_or(false)`), so
+    /// such a daemon fires once at its next scheduled time regardless of which
+    /// it configured. That is schedule-gated rather than a loop, and it biases
+    /// toward running the daemon over leaving it permanently untriggered.
+    /// Distinguishing "unknown" from "never ran" would require a third cron
+    /// state and is deliberately left out of scope here.
     Unobserved,
     /// We terminated the process ourselves, so the outcome is not a mystery:
     /// it stopped because we asked it to. Recorded as a success, matching the

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1292,6 +1292,7 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
 
     let policy = orphan_policy();
     let boot_time = PROCS.boot_time();
+    let unclean = supervisor_exited_uncleanly(supervisor).await;
 
     for daemon in candidates {
         let Some(pid) = daemon.pid else { continue };
@@ -1305,7 +1306,8 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
             // PID already dead — the daemon exited while unsupervised, so
             // record a terminal status that reflects whether it died under a
             // crashed supervisor (retryable) or with the machine.
-            let status = unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time);
+            let status =
+                unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time, unclean);
             reset_daemon_state(supervisor, &daemon.id, status).await;
             continue;
         }
@@ -1338,7 +1340,8 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
             );
             // The daemon died at some unknown point and the OS handed its PID
             // to something else — same unobserved exit as a dead PID.
-            let status = unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time);
+            let status =
+                unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time, unclean);
             reset_daemon_state(supervisor, &daemon.id, status).await;
             continue;
         }
@@ -1432,30 +1435,49 @@ fn process_identity_matches(
     }
 }
 
-/// Clear a daemon's runtime state (pid, status, active port) after its
-/// process is gone or no longer ours to manage.
+/// Clear a daemon's runtime state (pid, process identity, active port) after
+/// its process is gone or is no longer ours to manage.
 ///
-/// `last_exit_success` is deliberately left untouched: these transitions
-/// cover exits nobody observed, and fabricating a result would corrupt the
-/// cron `retrigger = "success" | "fail"` decisions that read it.
+/// `last_exit_success` is cleared rather than set or preserved. These
+/// transitions cover runs whose outcome nobody observed: fabricating a result
+/// would corrupt the cron `retrigger = "success" | "fail"` decisions that read
+/// it, and keeping the previous value is just as wrong — it would attribute an
+/// earlier run's outcome to this one. `None` restores the "no result yet"
+/// reading, which those retriggers already handle.
+///
+/// Config fields are preserved by cloning the existing record, so a reset can
+/// never drop a daemon's command, retry policy, or schedule.
 async fn reset_daemon_state(supervisor: &Supervisor, id: &DaemonId, status: DaemonStatus) {
-    let _ = supervisor
-        .upsert_daemon(
-            UpsertDaemonOpts::builder(id.clone())
-                .set(|o| {
-                    o.pid = None;
-                    o.status = status;
-                    o.active_port = None;
-                })
-                .build(),
-        )
-        .await;
+    let mut state_file = supervisor.state_file.lock().await;
+    let Some(existing) = state_file.daemons.get(id) else {
+        return;
+    };
+    let mut daemon = existing.clone();
+    daemon.pid = None;
+    daemon.title = None;
+    daemon.start_time = None;
+    daemon.boot_time = None;
+    daemon.status = status;
+    daemon.last_exit_success = None;
+    daemon.active_port = None;
+    state_file.clear_active_port(id);
+    state_file.insert_daemon(id, daemon);
 }
 
-/// Boot times this far apart are treated as different boots. Generous enough
-/// to absorb any platform jitter in `boot_time()` (Windows derives it from a
-/// tick count), while far below the gap any real reboot produces.
-const BOOT_TIME_TOLERANCE_SECS: u64 = 60;
+/// Boot times this far apart are treated as different boots.
+///
+/// Sized to the only platform that reports a jittery value: Windows derives
+/// boot time as `now - GetTickCount64()`, sampling two clocks independently,
+/// so consecutive calls within one boot can differ by about a second. Linux
+/// (`/proc/stat` btime) and macOS (`kern.boottime`) report stable values.
+///
+/// Deliberately kept this tight so a genuine reboot can never fall inside it:
+/// a prior session would have to boot, start the supervisor, spawn a daemon,
+/// have that daemon die, and complete a reboot inside two seconds, which no
+/// real boot cycle reaches. A larger window would misread a short-lived
+/// previous boot (e.g. a device in a reboot loop) as the current one and
+/// resurrect daemons a reboot should have left stopped.
+const BOOT_TIME_TOLERANCE_SECS: u64 = 2;
 
 /// Terminal status for a daemon whose process is gone and whose exit was
 /// never observed, because the monitor that would have seen it died with a
@@ -1474,14 +1496,36 @@ pub(crate) fn unobserved_exit_status(
     status: &DaemonStatus,
     recorded_boot_time: Option<u64>,
     current_boot_time: u64,
+    supervisor_exited_uncleanly: bool,
 ) -> DaemonStatus {
     let same_boot = recorded_boot_time
         .is_some_and(|recorded| recorded.abs_diff(current_boot_time) <= BOOT_TIME_TOLERANCE_SECS);
-    if status.is_running() && same_boot {
+    if status.is_running() && same_boot && supervisor_exited_uncleanly {
         DaemonStatus::Errored(-1)
     } else {
         DaemonStatus::Stopped
     }
+}
+
+/// Whether the supervisor that owned this state file failed to shut down
+/// cleanly, meaning any daemon it left behind stopped for reasons nobody
+/// recorded.
+///
+/// A clean shutdown removes the supervisor's own entry: `close()` does it on
+/// Unix, where the stop signal is delivered and handled, and the
+/// `supervisor stop` command does it on Windows, which has no POSIX signals
+/// and force-terminates the process instead. A crash, an external `kill -9`,
+/// or a `--force` replacement all leave the entry behind.
+///
+/// This must be read before the starting supervisor records itself, which is
+/// why `cleanup_orphaned_daemons` runs first in `start()`.
+async fn supervisor_exited_uncleanly(supervisor: &Supervisor) -> bool {
+    supervisor
+        .state_file
+        .lock()
+        .await
+        .daemons
+        .contains_key(&DaemonId::pitchfork())
 }
 
 /// Recursively chmod: directories → 0o755, files → 0o644.
@@ -1518,7 +1562,7 @@ mod tests {
         // Died under a crashed supervisor during this boot: Errored(-1) makes
         // the daemon eligible for its configured retries.
         assert!(matches!(
-            unobserved_exit_status(&DaemonStatus::Running, Some(BOOT), BOOT),
+            unobserved_exit_status(&DaemonStatus::Running, Some(BOOT), BOOT, true),
             DaemonStatus::Errored(-1)
         ));
     }
@@ -1528,23 +1572,53 @@ mod tests {
         // The process died with the machine; reviving every retry-configured
         // daemon after a reboot is what boot_start is for.
         assert!(matches!(
-            unobserved_exit_status(&DaemonStatus::Running, Some(BOOT - 86_400), BOOT),
+            unobserved_exit_status(&DaemonStatus::Running, Some(BOOT - 86_400), BOOT, true),
             DaemonStatus::Stopped
         ));
     }
 
     #[test]
     fn unobserved_exit_tolerates_boot_time_jitter() {
+        // Windows recomputes boot time as now - GetTickCount64(), which can
+        // drift about a second between samples within one boot.
         let within = BOOT + BOOT_TIME_TOLERANCE_SECS;
         assert!(matches!(
-            unobserved_exit_status(&DaemonStatus::Running, Some(within), BOOT),
+            unobserved_exit_status(&DaemonStatus::Running, Some(within), BOOT, true),
             DaemonStatus::Errored(-1)
         ));
         let beyond = BOOT + BOOT_TIME_TOLERANCE_SECS + 1;
         assert!(matches!(
-            unobserved_exit_status(&DaemonStatus::Running, Some(beyond), BOOT),
+            unobserved_exit_status(&DaemonStatus::Running, Some(beyond), BOOT, true),
             DaemonStatus::Stopped
         ));
+    }
+
+    #[test]
+    fn unobserved_exit_after_clean_shutdown_is_stopped() {
+        // A deliberate `supervisor stop` can leave running records behind on
+        // platforms where the supervisor cannot handle the stop signal. Those
+        // daemons were stopped on purpose, so they must not be reported as
+        // failures or resurrected by the retry checker.
+        assert!(matches!(
+            unobserved_exit_status(&DaemonStatus::Running, Some(BOOT), BOOT, false),
+            DaemonStatus::Stopped
+        ));
+    }
+
+    #[test]
+    fn unobserved_exit_treats_short_previous_boot_as_previous() {
+        // A device in a reboot loop can produce consecutive boots seconds
+        // apart. The jitter window must stay far below that so those records
+        // are still recognised as belonging to an earlier boot.
+        for gap in [5, 30, 59, 60] {
+            assert!(
+                matches!(
+                    unobserved_exit_status(&DaemonStatus::Running, Some(BOOT - gap), BOOT, true),
+                    DaemonStatus::Stopped
+                ),
+                "boot {gap}s earlier should be treated as a previous boot"
+            );
+        }
     }
 
     #[test]
@@ -1552,7 +1626,7 @@ mod tests {
         // Legacy state files predating the field fail closed to today's
         // behavior rather than triggering surprise retries.
         assert!(matches!(
-            unobserved_exit_status(&DaemonStatus::Running, None, BOOT),
+            unobserved_exit_status(&DaemonStatus::Running, None, BOOT, true),
             DaemonStatus::Stopped
         ));
     }
@@ -1562,7 +1636,7 @@ mod tests {
         // An intentional stop that completed while the supervisor was gone is
         // not a failure, even within the same boot.
         assert!(matches!(
-            unobserved_exit_status(&DaemonStatus::Stopping, Some(BOOT), BOOT),
+            unobserved_exit_status(&DaemonStatus::Stopping, Some(BOOT), BOOT, true),
             DaemonStatus::Stopped
         ));
     }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1291,6 +1291,7 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
     );
 
     let policy = orphan_policy();
+    let boot_time = PROCS.boot_time();
 
     for daemon in candidates {
         let Some(pid) = daemon.pid else { continue };
@@ -1301,8 +1302,11 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
         PROCS.refresh_pids(&[pid]);
 
         if !PROCS.is_running(pid) {
-            // PID already dead — just reset its state
-            reset_daemon_state(supervisor, &daemon.id).await;
+            // PID already dead — the daemon exited while unsupervised, so
+            // record a terminal status that reflects whether it died under a
+            // crashed supervisor (retryable) or with the machine.
+            let status = unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time);
+            reset_daemon_state(supervisor, &daemon.id, status).await;
             continue;
         }
 
@@ -1332,7 +1336,10 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
                 "pid {pid} recorded for daemon {} belongs to a different process now (PID recycled); resetting state without killing",
                 daemon.id,
             );
-            reset_daemon_state(supervisor, &daemon.id).await;
+            // The daemon died at some unknown point and the OS handed its PID
+            // to something else — same unobserved exit as a dead PID.
+            let status = unobserved_exit_status(&daemon.status, daemon.boot_time, boot_time);
+            reset_daemon_state(supervisor, &daemon.id, status).await;
             continue;
         }
 
@@ -1387,7 +1394,9 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
             }
         }
 
-        reset_daemon_state(supervisor, &daemon.id).await;
+        // We terminated the orphan ourselves, so this is an observed,
+        // intentional stop rather than an unobserved exit.
+        reset_daemon_state(supervisor, &daemon.id, DaemonStatus::Stopped).await;
     }
 }
 
@@ -1425,18 +1434,54 @@ fn process_identity_matches(
 
 /// Clear a daemon's runtime state (pid, status, active port) after its
 /// process is gone or no longer ours to manage.
-async fn reset_daemon_state(supervisor: &Supervisor, id: &DaemonId) {
+///
+/// `last_exit_success` is deliberately left untouched: these transitions
+/// cover exits nobody observed, and fabricating a result would corrupt the
+/// cron `retrigger = "success" | "fail"` decisions that read it.
+async fn reset_daemon_state(supervisor: &Supervisor, id: &DaemonId, status: DaemonStatus) {
     let _ = supervisor
         .upsert_daemon(
             UpsertDaemonOpts::builder(id.clone())
                 .set(|o| {
                     o.pid = None;
-                    o.status = DaemonStatus::Stopped;
+                    o.status = status;
                     o.active_port = None;
                 })
                 .build(),
         )
         .await;
+}
+
+/// Boot times this far apart are treated as different boots. Generous enough
+/// to absorb any platform jitter in `boot_time()` (Windows derives it from a
+/// tick count), while far below the gap any real reboot produces.
+const BOOT_TIME_TOLERANCE_SECS: u64 = 60;
+
+/// Terminal status for a daemon whose process is gone and whose exit was
+/// never observed, because the monitor that would have seen it died with a
+/// previous supervisor.
+///
+/// A daemon recorded `Running` was expected to still be alive, so it died
+/// under the crashed supervisor: `Errored(-1)` ("unknown exit code") makes it
+/// eligible for its configured retries. Two cases stay `Stopped` instead:
+///
+/// - records from an earlier boot, whose processes died with the machine —
+///   auto-restarting those is what `boot_start` is for, and reviving every
+///   retry-configured daemon after a reboot would be a surprise
+/// - any other status (in practice `Stopping`), i.e. an intentional stop that
+///   completed while the supervisor was gone
+pub(crate) fn unobserved_exit_status(
+    status: &DaemonStatus,
+    recorded_boot_time: Option<u64>,
+    current_boot_time: u64,
+) -> DaemonStatus {
+    let same_boot = recorded_boot_time
+        .is_some_and(|recorded| recorded.abs_diff(current_boot_time) <= BOOT_TIME_TOLERANCE_SECS);
+    if status.is_running() && same_boot {
+        DaemonStatus::Errored(-1)
+    } else {
+        DaemonStatus::Stopped
+    }
 }
 
 /// Recursively chmod: directories → 0o755, files → 0o644.
@@ -1459,8 +1504,68 @@ fn chmod_recursive(dir: &std::path::Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::{process_identity_matches, should_remove_liveness_session};
+    use super::{
+        BOOT_TIME_TOLERANCE_SECS, process_identity_matches, should_remove_liveness_session,
+        unobserved_exit_status,
+    };
+    use crate::daemon_status::DaemonStatus;
     use crate::state_file::ProjectSession;
+
+    const BOOT: u64 = 1_700_000_000;
+
+    #[test]
+    fn unobserved_running_death_in_current_boot_is_retryable() {
+        // Died under a crashed supervisor during this boot: Errored(-1) makes
+        // the daemon eligible for its configured retries.
+        assert!(matches!(
+            unobserved_exit_status(&DaemonStatus::Running, Some(BOOT), BOOT),
+            DaemonStatus::Errored(-1)
+        ));
+    }
+
+    #[test]
+    fn unobserved_running_death_from_previous_boot_is_stopped() {
+        // The process died with the machine; reviving every retry-configured
+        // daemon after a reboot is what boot_start is for.
+        assert!(matches!(
+            unobserved_exit_status(&DaemonStatus::Running, Some(BOOT - 86_400), BOOT),
+            DaemonStatus::Stopped
+        ));
+    }
+
+    #[test]
+    fn unobserved_exit_tolerates_boot_time_jitter() {
+        let within = BOOT + BOOT_TIME_TOLERANCE_SECS;
+        assert!(matches!(
+            unobserved_exit_status(&DaemonStatus::Running, Some(within), BOOT),
+            DaemonStatus::Errored(-1)
+        ));
+        let beyond = BOOT + BOOT_TIME_TOLERANCE_SECS + 1;
+        assert!(matches!(
+            unobserved_exit_status(&DaemonStatus::Running, Some(beyond), BOOT),
+            DaemonStatus::Stopped
+        ));
+    }
+
+    #[test]
+    fn unobserved_exit_without_recorded_boot_time_is_stopped() {
+        // Legacy state files predating the field fail closed to today's
+        // behavior rather than triggering surprise retries.
+        assert!(matches!(
+            unobserved_exit_status(&DaemonStatus::Running, None, BOOT),
+            DaemonStatus::Stopped
+        ));
+    }
+
+    #[test]
+    fn unobserved_exit_of_stopping_daemon_is_stopped() {
+        // An intentional stop that completed while the supervisor was gone is
+        // not a failure, even within the same boot.
+        assert!(matches!(
+            unobserved_exit_status(&DaemonStatus::Stopping, Some(BOOT), BOOT),
+            DaemonStatus::Stopped
+        ));
+    }
 
     #[test]
     fn orphan_identity_does_not_match_when_current_identity_is_missing() {

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -197,6 +197,10 @@ impl Supervisor {
                         .and_then(|d| d.start_time)
                 })
             }),
+            // Boot time is a system-wide constant, so it needs no cache
+            // fallback — it is recorded for any daemon with a live PID and
+            // dropped when the PID is cleared.
+            boot_time: opts.pid.map(|_| PROCS.boot_time()),
             pid: opts.pid,
             status: opts.status,
             shell_pid: opts.shell_pid,

--- a/test/supervisor.bats
+++ b/test/supervisor.bats
@@ -325,12 +325,11 @@ EOF
   assert_failure
 
   # And the daemon reads as stopped rather than errored after the restart.
+  # Poll rather than sleeping: this test also runs on Windows, where startup
+  # plus orphan reconciliation plus state persistence is slowest.
   run pitchfork supervisor start
   assert_success
-  sleep 2
-  run pitchfork status stop_marker
-  assert_success
-  assert_output --partial "stopped"
+  wait_for_status stop_marker stopped
 }
 
 @test "daemon record from a previous boot is not retried" {
@@ -345,9 +344,21 @@ EOF
 
   pitchfork supervisor stop 2>/dev/null || true
   sleep 1
-  # boot_time = 1 marks this record as belonging to a long-gone boot: the
-  # process died with the machine, not under a crashed supervisor.
+  # The leftover supervisor entry is what marks the previous shutdown as
+  # unclean. Without it the unclean check short-circuits to stopped and this
+  # test would pass even with the boot-time rule deleted; with it, boot_time
+  # is the only reason the daemon stays stopped. Orphan cleanup skips the
+  # supervisor's own id, and start() overwrites the entry immediately.
+  #
+  # boot_time = 1 marks the daemon record as belonging to a long-gone boot:
+  # the process died with the machine, not under a crashed supervisor.
   cat > "$PITCHFORK_STATE_DIR/state.toml" <<EOF
+[daemons."global/pitchfork"]
+id = "global/pitchfork"
+pid = $dead_pid
+status = "running"
+autostop = false
+
 [daemons."prevboot/svc"]
 id = "prevboot/svc"
 title = "sleep"

--- a/test/supervisor.bats
+++ b/test/supervisor.bats
@@ -252,9 +252,91 @@ EOF
 
   run pitchfork status recycled/victim
   assert_success
+  # The crafted record has no boot_time (as written by versions before the
+  # field existed), so the unobserved exit fails closed to stopped.
   assert_output --partial "stopped"
 
   { kill -9 "$bystander_pid" && wait "$bystander_pid"; } 2>/dev/null || true
+}
+
+@test "daemon that dies during a supervisor crash is retried on restart" {
+  skip_on_windows "relies on SIGKILL semantics for both supervisor and daemon"
+  export PITCHFORK_INTERVAL=1s
+
+  create_pitchfork_toml <<EOF
+[daemons.crash_retry]
+run = "sleep 120"
+ready_delay = 1
+retry = 1
+EOF
+
+  run pitchfork start crash_retry
+  assert_success
+  wait_for_status crash_retry running
+
+  local daemon_pid sup_pid
+  daemon_pid="$(get_daemon_pid crash_retry)"
+  sup_pid="$(get_supervisor_pid)"
+  [[ -n "$daemon_pid" && -n "$sup_pid" ]]
+
+  # Crash the supervisor, then kill the daemon while nothing is watching it,
+  # so its exit is never observed by any monitor.
+  kill_pid "$sup_pid"
+  sleep 1
+  kill_pid "$daemon_pid"
+  sleep 1
+
+  run pitchfork supervisor start
+  assert_success
+
+  # The unobserved death is recorded as errored, which makes the daemon
+  # eligible for its configured retry — it comes back on its own.
+  wait_for_status crash_retry running 30
+  local new_pid
+  new_pid="$(get_daemon_pid crash_retry)"
+  [[ -n "$new_pid" ]]
+  [[ "$new_pid" != "$daemon_pid" ]]
+
+  pitchfork stop crash_retry
+}
+
+@test "daemon record from a previous boot is not retried" {
+  skip_on_windows "state file crafting relies on Unix signal semantics"
+  export PITCHFORK_INTERVAL=1s
+
+  # A PID that is definitely dead: start a process and kill it.
+  sleep 60 >/dev/null 2>&1 &
+  local dead_pid=$!
+  kill -9 "$dead_pid" 2>/dev/null || true
+  wait "$dead_pid" 2>/dev/null || true
+
+  pitchfork supervisor stop 2>/dev/null || true
+  sleep 1
+  # boot_time = 1 marks this record as belonging to a long-gone boot: the
+  # process died with the machine, not under a crashed supervisor.
+  cat > "$PITCHFORK_STATE_DIR/state.toml" <<EOF
+[daemons."prevboot/svc"]
+id = "prevboot/svc"
+title = "sleep"
+pid = $dead_pid
+start_time = 1
+boot_time = 1
+status = "running"
+autostop = false
+retry = 3
+cmd = ["sleep", "120"]
+EOF
+
+  run pitchfork supervisor start
+  assert_success
+  sleep 3
+
+  # Stopped, not errored — so the retry checker leaves it alone instead of
+  # resurrecting a daemon the user never asked to start at boot.
+  run pitchfork status prevboot/svc
+  assert_success
+  assert_output --partial "stopped"
+  [[ "$(get_daemon_pid prevboot/svc)" == "" ]]
 }
 
 @test "crashed supervisor re-adopts running daemon by default" {

--- a/test/supervisor.bats
+++ b/test/supervisor.bats
@@ -300,6 +300,39 @@ EOF
   pitchfork stop crash_retry
 }
 
+@test "supervisor stop clears the supervisor record on every platform" {
+  # Orphan reconciliation reads the presence of this record as evidence that
+  # the previous supervisor died unexpectedly. A deliberate stop must always
+  # clear it, whether the supervisor handles the stop signal itself (Unix) or
+  # is force-terminated by the stop command (Windows) — otherwise the next
+  # supervisor reports intentionally stopped daemons as failures.
+  create_pitchfork_toml <<EOF
+[daemons.stop_marker]
+run = "sleep 60"
+ready_delay = 1
+EOF
+
+  run pitchfork start stop_marker
+  assert_success
+  wait_for_status stop_marker running
+  grep -q '\[daemons\."global/pitchfork"\]' "$PITCHFORK_STATE_DIR/state.toml"
+
+  run pitchfork supervisor stop
+  assert_success
+  sleep 1
+
+  run grep -q '\[daemons\."global/pitchfork"\]' "$PITCHFORK_STATE_DIR/state.toml"
+  assert_failure
+
+  # And the daemon reads as stopped rather than errored after the restart.
+  run pitchfork supervisor start
+  assert_success
+  sleep 2
+  run pitchfork status stop_marker
+  assert_success
+  assert_output --partial "stopped"
+}
+
 @test "daemon record from a previous boot is not retried" {
   skip_on_windows "state file crafting relies on Unix signal semantics"
   export PITCHFORK_INTERVAL=1s


### PR DESCRIPTION
## Context

Follow-up to #633, closing a divergence Bugbot flagged during its review ([thread](https://github.com/jdx/pitchfork/pull/633#discussion_r3647083552)) that I deliberately deferred rather than fold into that PR.

Startup orphan cleanup and the runtime reconciler disagreed about the same situation. When a daemon's recorded PID is dead (or has been recycled), startup cleared the record to `stopped` while the interval reconciler marked it `errored(-1)`. Since startup runs first on every restart, the startup answer always won — so a daemon that died while its supervisor was crashed **never became eligible for its configured retries**, and stayed silently `stopped` instead.

## Why not just mark it errored

Two hazards make the one-line version wrong, and both shape this change:

**Neither fabricating nor keeping an exit result is safe.** `CronRetrigger::Success` and `Fail` read `last_exit_success` ([watchers.rs](src/supervisor/watchers.rs)). Writing `false` for an exit nobody observed would block a one-shot cron daemon that actually *succeeded* during the crash window from its next `retrigger = "success"` run. But keeping the previous value is wrong too — it attributes an earlier run's outcome to this one. These transitions now **clear** the field: `None` restores the "no result yet" reading both retriggers already handle.

**A reboot, and a deliberate stop, are both indistinguishable from a crash by PID alone.** After a hard power-off every record is `running` with a stale PID. And on Windows a deliberate `pitchfork supervisor stop` leaves the same footprint: the stop signal is delivered and handled on Unix, where `close()` stops each daemon, but Windows has no POSIX signals so the supervisor is force-terminated and never runs its shutdown path. A blanket `errored` would report intentionally stopped daemons as failures and auto-restart the ones with `retry` configured. (Windows CI caught this on the first revision.)

So erroring a daemon requires two pieces of positive evidence, not an assumption:

1. **The previous supervisor exited uncleanly**, which its own state entry already tells us: a clean shutdown removes that entry, while a crash, an external kill, or a `--force` replacement leaves it. The `supervisor stop` command now removes the entry itself on the platform where the supervisor cannot, so both behave identically — and a test pins that invariant, since it is exactly what the platforms disagreed about.
2. **The daemon belonged to the current boot.** The existing `start_time` can't answer this: #632 replaced it with a platform-specific high-resolution token (Linux clock ticks *since boot*, macOS µs since epoch, Windows FILETIME), so it isn't comparable to a wall-clock boot time — and on Linux a token from a previous boot looks plausibly current. Hence a small, explicitly wall-clock companion field.

## Changes

- **`Daemon.boot_time`**: system boot time (epoch seconds, via `sysinfo::System::boot_time()`) recorded alongside the PID at spawn. `skip_serializing_if` so it's absent for daemons with no live process, and old state files simply lack it.
- **`unobserved_exit_status(status, recorded_boot_time, current_boot_time, supervisor_exited_uncleanly)`**: one pure function deciding the terminal status for an exit nobody observed. `Running` + same boot + unclean shutdown → `Errored(-1)` (retryable). Previous boot, or a clean shutdown → `Stopped`. Any other status, in practice `Stopping` → `Stopped` (an intentional stop that completed while the supervisor was gone). Only `Running` and `Stopping` can carry a PID, so that's the whole space.
- **Both paths now call it**: startup's dead-PID and recycled-PID branches, and the reconciler's equivalents. The kill-policy path still records `Stopped` — we terminated that process ourselves, so its exit *was* observed and intentional.
- Boot times within 2s compare as the same boot. That window exists only for Windows, which recomputes boot time as `now - GetTickCount64()` and can drift about a second between samples; Linux (`/proc/stat` btime) and macOS (`kern.boottime`) are exact. Kept deliberately tight so a genuine reboot can never fall inside it — a wider window would misread a short-lived previous boot (a device in a reboot loop) as the current one.
- Missing `boot_time` (state written before this change) → `Stopped`, i.e. exactly today's behavior. Fail-closed, consistent with the identity handling #632/#633 settled on.

No hooks fire from these transitions, unchanged from before: we don't know the daemon failed, and firing `on_fail`/`on_exit` for events that happened while the supervisor was dead would be a larger semantic change. Retries still fire `on_retry` normally through `check_retry`.

## Tests

- `daemon that dies during a supervisor crash is retried on restart` — the user-visible win: crash the supervisor, kill the daemon while nothing is watching, restart, and the daemon comes back on its own with a new PID.
- `daemon record from a previous boot is not retried` — a crafted record with an ancient `boot_time` stays `stopped` and is left alone despite `retry = 3`.
- Seven unit tests over `unobserved_exit_status` covering same-boot, previous-boot, the jitter boundary, short-previous-boot gaps (5/30/59/60s), a missing field, `Stopping`, and clean shutdown.
- `supervisor stop clears the supervisor record on every platform` — pins the clean-shutdown invariant the two platforms disagreed about.
- The recycled-PID bystander test keeps asserting `stopped` — its crafted record has no `boot_time`, which is now exactly the legacy fail-closed case; comment updated to say so.

## Compatibility

User-visible: after a supervisor crash, an affected daemon now reads `errored` rather than `stopped` in `pitchfork list`/`status`, and daemons with `retry` configured come back by themselves. That's the intended fix, but it's worth a changelog line. Downgrade is safe — an older binary ignores the unknown `boot_time` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core supervisor recovery, daemon terminal status, retry eligibility, and cron `last_exit_success` semantics after crashes; behavior is heavily tested but affects restart paths on all platforms.
> 
> **Overview**
> Fixes a mismatch where **startup orphan cleanup** always cleared dead PIDs to `stopped` while the **interval reconciler** used `errored(-1)`—startup ran first, so daemons that died during a supervisor crash never became **retry-eligible**.
> 
> **`Daemon.boot_time`** is recorded at spawn (epoch seconds via `PROCS.boot_time()`). **`unobserved_exit_status`** picks the terminal status when nobody observed the exit: `Running` + same boot + unclean supervisor shutdown → **`Errored(-1)`**; previous boot, clean shutdown, missing `boot_time`, or `Stopping` → **`Stopped`**. Startup orphan scan and runtime reconciler both use this logic.
> 
> **`ExitObservation`** drives **`last_exit_success`**: unobserved exits clear it to `None` (avoids lying to cron `retrigger`); supervisor-initiated orphan kills set success like a deliberate stop. **`supervisor stop`** removes the `global/pitchfork` state entry on Windows after force-kill so the next start does not treat a deliberate stop as a crash.
> 
> Bats and unit tests cover crash→retry, previous-boot no-retry, clean stop marker, and boot-time jitter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e66e910ca0f4c37e4be425e4b9da3710d23c288f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved supervisor recovery after crashes so unexpectedly terminated daemons can be retried appropriately.
  - Prevented daemons from being incorrectly retried after a machine reboot or intentional supervisor shutdown.
  - Improved handling of orphaned processes and recycled process IDs.
  - Ensured intentional supervisor stops are recorded correctly across platforms.
- **Tests**
  - Added coverage for crash recovery, intentional shutdowns, reboot scenarios, and orphan cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->