### PR TITLE
style(procs): use div_ceil for the process-exit poll count

### DIFF
--- a/src/procs.rs
+++ b/src/procs.rs
@@ -364,7 +364,7 @@ impl Procs {
         }
 
         let exit_timeout = stop_timeout.unwrap_or_else(|| settings().supervisor_stop_timeout());
-        let checks = ((exit_timeout.as_millis().max(1) + 49) / 50) as usize;
+        let checks = exit_timeout.as_millis().max(1).div_ceil(50) as usize;
         for _ in 0..checks {
             if members.iter().all(|(_, pidfd)| !pidfd_is_running(pidfd)) {
                 return Ok(true);


### PR DESCRIPTION
Rust 1.97's clippy flags the manual round-up in `kill_process_group`'s exit-poll count.

This was the last remaining warning in the tree, so `cargo clippy --all-targets --all-features -- -D warnings` — the exact command CLAUDE.md documents under "Lint (check)" — now passes cleanly. CI's `hk` lint runs `cargo clippy --quiet` without `-D warnings`, so this never gated, but anyone following the documented workflow hit it.

Behavior is unchanged: `(n + 49) / 50` and `n.div_ceil(50)` are the same for all inputs here.

First in a stack:
1. **this PR** — clippy cleanup
2. `fix(supervisor)`: make child-monitor exit finalization atomic
3. `feat(supervisor)`: re-attach adopted daemon logs via procfs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line equivalent refactor in process termination polling; no logic or API changes.
> 
> **Overview**
> Replaces the manual round-up `((exit_timeout.as_millis().max(1) + 49) / 50)` with **`div_ceil(50)`** when computing how many 50ms polls run after SIGKILL in the Linux **`kill_process_group_with_pidfds`** path.
> 
> No behavior change—only satisfies Rust 1.97 clippy so **`cargo clippy --all-targets --all-features -- -D warnings`** passes cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4384d10603463c338016d67f54cc17a807b2dc23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timing precision when waiting for pinned processes to exit, helping ensure cleanup completes within the configured timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->