### PR TITLE
fix(supervisor): make child-monitor exit finalization atomic

### DIFF
--- a/src/procs.rs
+++ b/src/procs.rs
@@ -364,7 +364,7 @@ impl Procs {
         }
 
         let exit_timeout = stop_timeout.unwrap_or_else(|| settings().supervisor_stop_timeout());
-        let checks = ((exit_timeout.as_millis().max(1) + 49) / 50) as usize;
+        let checks = exit_timeout.as_millis().max(1).div_ceil(50) as usize;
         for _ in 0..checks {
             if members.iter().all(|(_, pidfd)| !pidfd_is_running(pidfd)) {
                 return Ok(true);

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -335,6 +335,50 @@ impl Supervisor {
     /// the startup scan.
     ///
     /// Returns whether the write happened.
+    /// Write a daemon's terminal state on behalf of the monitor identified by
+    /// `token`, but only if that monitor still owns the record: the registry
+    /// entry must still carry the token, and the record must still name `pid`.
+    ///
+    /// Both checks and the write share one state-lock critical section, so a
+    /// successor installed after the caller's own ownership snapshot cannot be
+    /// overwritten — it registers before its running state becomes visible, so
+    /// either we see its token here and stand down, or its upsert serializes
+    /// after ours.
+    ///
+    /// Returns whether the write happened.
+    pub(crate) async fn finalize_monitored_exit(
+        &self,
+        id: &DaemonId,
+        pid: u32,
+        token: u64,
+        status: DaemonStatus,
+        last_exit_success: Option<bool>,
+    ) -> bool {
+        let mut state_file = self.state_file.lock().await;
+        if !self.monitor_token_valid(id, token) {
+            debug!("daemon {id} was superseded; skipping exit finalization");
+            return false;
+        }
+        let Some(d) = state_file.daemons.get(id) else {
+            return false;
+        };
+        if d.pid != Some(pid) {
+            debug!("daemon {id} was claimed by a successor; skipping exit finalization");
+            return false;
+        }
+        let mut d = d.clone();
+        d.pid = None;
+        d.title = None;
+        d.start_time = None;
+        d.boot_time = None;
+        d.status = status;
+        d.last_exit_success = last_exit_success;
+        d.active_port = None;
+        state_file.clear_active_port(id);
+        state_file.insert_daemon(id, d);
+        true
+    }
+
     async fn finalize_if_pid(
         &self,
         id: &DaemonId,
@@ -562,34 +606,16 @@ impl Supervisor {
                     "stop" => DaemonStatus::Stopped,
                     _ => DaemonStatus::Errored(exit_code),
                 };
+                // The poll monitor did observe this process die (it just cannot
+                // read the exit code of a non-child), so unlike the unobserved
+                // startup/reconciler cases it is meaningful to record whether
+                // the run ended intentionally.
                 let last_exit_success = exit_reason == "stop";
-                let mut state_file = SUPERVISOR.state_file.lock().await;
-                let still_ours = SUPERVISOR.monitor_token_valid(&id, token)
-                    && state_file
-                        .daemons
-                        .get(&id)
-                        .is_some_and(|d| d.pid == Some(pid));
-                if !still_ours {
-                    debug!(
-                        "adopted daemon {id} was claimed by a successor; skipping exit handling"
-                    );
+                if !SUPERVISOR
+                    .finalize_monitored_exit(&id, pid, token, new_status, Some(last_exit_success))
+                    .await
+                {
                     return;
-                }
-                state_file.clear_active_port(&id);
-                if let Some(d) = state_file.daemons.get(&id) {
-                    let mut d = d.clone();
-                    d.pid = None;
-                    d.title = None;
-                    d.start_time = None;
-                    d.boot_time = None;
-                    d.status = new_status;
-                    // The poll monitor did observe this process die (it just
-                    // cannot read the exit code of a non-child), so unlike the
-                    // unobserved startup/reconciler cases it is meaningful to
-                    // record whether the last run ended intentionally.
-                    d.last_exit_success = Some(last_exit_success);
-                    d.active_port = None;
-                    state_file.insert_daemon(&id, d);
                 }
             }
 

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -555,6 +555,7 @@ impl Supervisor {
         // guard unregisters on any early-error path below and is otherwise
         // handed to the monitoring task.
         let monitored_guard = super::adopt::MonitoredGuard::register(id.clone(), pid);
+        let monitor_token = monitored_guard.token();
         let daemon = self
             .upsert_daemon(
                 UpsertDaemonOpts::from_run_options(&opts, DaemonStatus::Running)
@@ -1435,19 +1436,22 @@ impl Supervisor {
                     ),
                     _ => (DaemonStatus::Errored(exit_code), false),
                 };
-                if let Err(e) = SUPERVISOR
-                    .upsert_daemon(
-                        UpsertDaemonOpts::builder(id.clone())
-                            .set(|o| {
-                                o.pid = None;
-                                o.status = new_status;
-                                o.last_exit_success = Some(last_exit_success);
-                            })
-                            .build(),
+                // Revalidate ownership inside the same state-lock section that
+                // performs the write. The snapshot above was taken without
+                // holding the lock, so a restart running on another thread can
+                // install a successor in between; overwriting its record would
+                // clear a live daemon's PID and undo the restart.
+                if !SUPERVISOR
+                    .finalize_monitored_exit(
+                        &id,
+                        pid,
+                        monitor_token,
+                        new_status,
+                        Some(last_exit_success),
                     )
                     .await
                 {
-                    error!("Failed to update daemon state for {id}: {e}");
+                    debug!("daemon {id} exit state was not written; a successor owns the record");
                 }
             }
 


### PR DESCRIPTION
## Context

Second in a stack; based on #658 (merge that first). Found while hardening the adopted-daemon path in #657 — the bots never flagged it because `lifecycle.rs` wasn't in any of those diffs.

## The race

The child monitoring task takes an ownership snapshot:

```rust
let current_daemon = SUPERVISOR.get_daemon(&id).await;   // lock acquired and released
```

…then, some lines later, writes the terminal state with a separate `upsert_daemon` call that acquires the lock again. Nothing holds it across both. On the multi-threaded runtime a concurrent `start()` / `restart` can install a successor in that gap, and the write then clears the successor's PID and replaces its `Running` status — orphaning a live process and silently undoing the restart. That is the same silent-duplicate failure mode #631 was about, reached from the other direction.

The window is narrow (no `.await` between the two, so only a genuine cross-thread interleaving hits it), but it is real, and it is exactly the window I closed on the adopted path in #657. That left the *adopted* poll monitor strictly safer than the *child* monitor it was modelled on — an asymmetry worth removing.

## Change

Both monitors now share `finalize_monitored_exit`, which revalidates two things inside the same state-lock critical section as the write:

- the registry entry still carries this monitor's token (so a successor that recycled the same numeric PID is still detected), and
- the record still names this monitor's PID.

If either fails, the monitor stands down and logs at debug instead of writing. This also removes the poll monitor's hand-rolled copy of the same logic, so there is one implementation rather than two.

Behavior is otherwise unchanged: the existing `already_stopped` / `pre_drain_is_stopping` gates still decide *whether* to write, and the recorded status and `last_exit_success` values are identical.

## Tests

Existing coverage exercises the paths this touches — `restart triggers on_stop and on_exit hooks`, `restart all includes ad-hoc daemons`, and the adoption suite all pass (61/61 across `supervisor.bats` + `basic.bats`, 519/519 unit). I did not add a test for the race itself: reproducing a cross-thread interleaving with no await point between the two operations is not something a bats test can do deterministically, and a flaky test would be worse than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core supervisor state on every monitored exit; behavior is intended to be equivalent when no race, but incorrect stand-down would leave stale state and wrong stand-down would still be a serious bug.
> 
> **Overview**
> **Daemon exit finalization is now one shared, lock-held path** for both the child monitor and the adopted poll monitor via `finalize_monitored_exit`.
> 
> That helper re-checks the monitor **token** and that the state file still records the exiting **PID**, then clears runtime fields and writes terminal status and `last_exit_success` in a single state-lock section. If a concurrent `start`/`restart` installed a successor, the stale monitor skips the write and logs at debug instead of clearing a live PID or undoing a restart.
> 
> The child monitor no longer uses a separate `upsert_daemon` after an unlocked `get_daemon` snapshot; it keeps the token from `MonitoredGuard::register` and calls the same helper. The poll monitor drops its duplicated inline finalization in favor of that call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a216c51cd632b5e76b90c22f6c2ffe1edec9aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->