### PR TITLE
fix(logs): tolerate concurrent opens of the log store

### DIFF
--- a/src/log_store/sqlite.rs
+++ b/src/log_store/sqlite.rs
@@ -66,6 +66,42 @@ pub struct SqliteLogStore {
 /// overhead exceeds the query savings.
 const PARALLEL_QUERY_THRESHOLD: usize = 200_000;
 
+/// How long a statement waits for a contended lock before giving up. Generous
+/// enough to outlast any batch insert or retention prune, short enough that a
+/// genuinely stuck writer still surfaces as an error rather than hanging.
+const BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Put the database into WAL mode, tolerating a lost race.
+///
+/// Switching journal modes needs an exclusive lock and, unlike ordinary
+/// statements, does not consult the busy handler — so concurrent opens collide
+/// here no matter how large `busy_timeout` is. WAL is recorded in the database
+/// header and persists across connections, so only the first open has to
+/// succeed: retry briefly in case a peer is mid-switch, and if it still has not
+/// taken, carry on rather than fail. A connection that never personally set WAL
+/// still works correctly; refusing to open the log store over a transient
+/// pragma race would be far worse than running one connection unoptimised.
+fn enable_wal(conn: &Connection) {
+    const ATTEMPTS: usize = 5;
+    for attempt in 0..ATTEMPTS {
+        match conn.query_row("PRAGMA journal_mode", [], |row| row.get::<_, String>(0)) {
+            Ok(mode) if mode.eq_ignore_ascii_case("wal") => return,
+            Ok(_) => {}
+            Err(e) => {
+                debug!("could not read journal_mode: {e}");
+                return;
+            }
+        }
+        if conn.execute_batch("PRAGMA journal_mode = WAL;").is_ok() {
+            return;
+        }
+        if attempt + 1 < ATTEMPTS {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
+    debug!("log store is not in WAL mode; another connection may be switching it");
+}
+
 impl SqliteLogStore {
     /// Open or create the SQLite log store at the given path.
     pub fn open(path: impl Into<PathBuf>) -> Result<Self> {
@@ -74,10 +110,22 @@ impl SqliteLogStore {
             std::fs::create_dir_all(parent).into_diagnostic()?;
         }
         let conn = Connection::open(&path).into_diagnostic()?;
+
+        // A contended write must wait for the lock rather than fail: WAL
+        // allows concurrent readers but still serializes writers, and a writer
+        // with no timeout takes SQLITE_BUSY immediately and drops its work.
+        // rusqlite already defaults to this value, but state it explicitly so
+        // the requirement is visible here and does not rest on a dependency's
+        // default. Set before anything else, since the statements below take
+        // locks of their own.
+        conn.busy_timeout(BUSY_TIMEOUT).into_diagnostic()?;
+
         add_regexp_function(&conn)?;
+
+        enable_wal(&conn);
+
         conn.execute_batch(
-            "PRAGMA journal_mode = WAL;
-             PRAGMA synchronous = NORMAL;
+            "PRAGMA synchronous = NORMAL;
              PRAGMA mmap_size = 268435456;",
         )
         .into_diagnostic()?;
@@ -1134,4 +1182,100 @@ fn auto_migrate_legacy_logs(store: &SqliteLogStore) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::log_store::LogStore;
+
+    /// A writer that finds the lock held must wait for it, not give up. WAL
+    /// serializes writers, so without `busy_timeout` the second writer takes
+    /// SQLITE_BUSY immediately and silently discards its batch.
+    #[test]
+    fn write_waits_for_a_contended_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logs.db");
+        let store = SqliteLogStore::open(&path).unwrap();
+
+        // Hold the write lock from a second connection, then release it after a
+        // delay that a non-waiting writer could never survive.
+        let blocker = Connection::open(&path).unwrap();
+        blocker.busy_timeout(BUSY_TIMEOUT).unwrap();
+        blocker.execute_batch("BEGIN IMMEDIATE").unwrap();
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            blocker.execute_batch("COMMIT").unwrap();
+        });
+
+        let id = DaemonId::try_new("test", "blocked").unwrap();
+        let entries = vec![crate::log_parse::parse("held-lock-line", "text")];
+        store
+            .append_structured_batch(&id, &entries)
+            .expect("a contended write must wait for the lock, not fail");
+
+        releaser.join().unwrap();
+        let found = store
+            .query(&LogQuery {
+                daemon_ids: vec![id.qualified()],
+                ..Default::default()
+            })
+            .unwrap()
+            .len();
+        assert_eq!(found, 1, "the batch written under contention was lost");
+    }
+
+    /// Two processes writing the same store is the normal case, not an edge
+    /// case: daemon output and retention pruning already collide, and a
+    /// per-daemon writer multiplies the opportunities. WAL serializes writers,
+    /// so without `busy_timeout` the loser of that race takes SQLITE_BUSY
+    /// immediately and silently discards its batch.
+    #[test]
+    fn concurrent_writers_do_not_lose_batches() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logs.db");
+
+        const WRITERS: usize = 4;
+        const BATCHES: usize = 15;
+        const PER_BATCH: usize = 10;
+
+        std::thread::scope(|scope| {
+            for writer in 0..WRITERS {
+                let path = path.clone();
+                scope.spawn(move || {
+                    // A separate connection per writer, as separate processes
+                    // would have.
+                    let store = SqliteLogStore::open(&path).unwrap();
+                    let id = DaemonId::try_new("test", format!("w{writer}")).unwrap();
+                    for batch in 0..BATCHES {
+                        let entries: Vec<ParsedLog> = (0..PER_BATCH)
+                            .map(|i| {
+                                crate::log_parse::parse(&format!("w{writer}-{batch}-{i}"), "text")
+                            })
+                            .collect();
+                        store
+                            .append_structured_batch(&id, &entries)
+                            .expect("concurrent batch write must not fail");
+                    }
+                });
+            }
+        });
+
+        let store = SqliteLogStore::open(&path).unwrap();
+        for writer in 0..WRITERS {
+            let id = DaemonId::try_new("test", format!("w{writer}")).unwrap();
+            let found = store
+                .query(&LogQuery {
+                    daemon_ids: vec![id.qualified()],
+                    ..Default::default()
+                })
+                .unwrap()
+                .len();
+            assert_eq!(
+                found,
+                BATCHES * PER_BATCH,
+                "writer {writer} lost entries: got {found}"
+            );
+        }
+    }
 }

--- a/src/log_store/sqlite.rs
+++ b/src/log_store/sqlite.rs
@@ -1239,12 +1239,20 @@ mod tests {
         const BATCHES: usize = 15;
         const PER_BATCH: usize = 10;
 
+        // Release every worker into open() at the same moment. Without this
+        // the scheduler is free to run them one after another, so the first
+        // would enable WAL and the rest would never contend for the
+        // journal-mode switch — leaving the race this guards unexercised.
+        let barrier = std::sync::Barrier::new(WRITERS);
+
         std::thread::scope(|scope| {
             for writer in 0..WRITERS {
                 let path = path.clone();
+                let barrier = &barrier;
                 scope.spawn(move || {
                     // A separate connection per writer, as separate processes
                     // would have.
+                    barrier.wait();
                     let store = SqliteLogStore::open(&path).unwrap();
                     let id = DaemonId::try_new("test", format!("w{writer}")).unwrap();
                     for batch in 0..BATCHES {


### PR DESCRIPTION
## The bug

Opening the log store from two processes at once fails outright:

```
Error code 5: database is locked
```

Switching a database into WAL mode needs an exclusive lock and, unlike ordinary statements, **does not consult the busy handler** — so the connection that loses the race takes `SQLITE_BUSY` regardless of how long its timeout is. Because that happens inside `SqliteLogStore::open`, the failure takes down the whole store rather than one statement.

WAL is recorded in the database header and persists across connections, so only the very first open ever needs to set it. `enable_wal` now retries briefly in case a peer is mid-switch, then carries on regardless: a connection that never personally set WAL still works correctly, and refusing to open the log store over a transient pragma race is far worse than running one connection unoptimised.

## A correction worth recording

I originally wrote this PR as "add `busy_timeout`", assuming the missing pragma was the cause. Probing the actual value proved otherwise:

```
PROBE default busy_timeout = 5000
```

**rusqlite already defaults to 5s**, so that part was a no-op — and my first contention test passed with the change reverted, which is what exposed the wrong diagnosis. The real defect was the journal-mode race. I kept the explicit `busy_timeout` call because it records the requirement at the call site rather than resting on a dependency default, but it changes no behavior today and I don't want it read as the fix.

## Tests

- `concurrent_writers_do_not_lose_batches` — four threads open the same store simultaneously and each write 150 entries; all 600 are present afterwards. **Fails without the `enable_wal` fix** (that is how the bug was found), passes with it.
- `write_waits_for_a_contended_lock` — a second connection holds `BEGIN IMMEDIATE` for 300ms while a batch is appended; the append must wait rather than fail. This one documents already-correct behavior and guards the timeout, so it passes on `main` too.

Verified: 523/523 unit tests, 34/34 `logs.bats` + `log_store.bats`, clippy clean under `-D warnings`.

## Why now

Prerequisite for moving log writes out of the supervisor process — the runit-style design where a per-daemon sink owns the pipe, so a supervisor crash can neither kill daemons with `SIGPIPE` nor interrupt log capture. That has several writers opening this store concurrently, which is exactly the case that fails today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core log persistence open path and locking behavior; incorrect WAL or timeout handling could drop or block log writes under multi-writer load.
> 
> **Overview**
> Fixes **concurrent `SqliteLogStore::open` failures** (`database is locked`) when multiple processes or threads open the same log DB at once.
> 
> **WAL setup** no longer runs as a single `PRAGMA journal_mode = WAL` in the init batch. New `enable_wal` reads the current mode, retries the switch up to five times with short sleeps, and **continues opening** if another connection wins the exclusive journal-mode lock—because WAL is persisted in the DB header and `busy_timeout` does not apply to that pragma.
> 
> **`open`** now sets an explicit **5s `busy_timeout`** before other pragmas (documents the writer-contention requirement; matches rusqlite’s default) and leaves synchronous/mmap pragmas unchanged.
> 
> Adds unit tests for **contended writes** (`BEGIN IMMEDIATE` hold) and **barrier-synchronized concurrent opens + batch appends** so WAL races and writer waiting are covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f445e4256cfcc242d0be10373ee1db0ba37fd92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->