### PR TITLE
feat(logs): capture daemon output in a sibling process

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -943,6 +943,66 @@
         "hidden_aliases": [],
         "examples": []
       },
+      "log-sink": {
+        "full_cmd": [
+          "log-sink"
+        ],
+        "usage": "log-sink <--daemon-id <DAEMON_ID>> [--log-format <LOG_FORMAT>]",
+        "subcommands": {},
+        "args": [],
+        "flags": [
+          {
+            "name": "daemon-id",
+            "usage": "--daemon-id <DAEMON_ID>",
+            "help": "Qualified id of the daemon whose output this is",
+            "help_first_line": "Qualified id of the daemon whose output this is",
+            "short": [],
+            "long": [
+              "daemon-id"
+            ],
+            "required": true,
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "DAEMON_ID",
+              "usage": "<DAEMON_ID>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "log-format",
+            "usage": "--log-format <LOG_FORMAT>",
+            "help": "Log format to parse lines with (`json`, `logfmt`, `auto`, or `text`)",
+            "help_first_line": "Log format to parse lines with (`json`, `logfmt`, `auto`, or `text`)",
+            "short": [],
+            "long": [
+              "log-format"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "LOG_FORMAT",
+              "usage": "<LOG_FORMAT>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            },
+            "default": [
+              "text"
+            ]
+          }
+        ],
+        "mounts": [],
+        "hide": true,
+        "help": "Reads a daemon's output on stdin and writes it to the log store",
+        "help_long": "Reads a daemon's output on stdin and writes it to the log store\n\nSpawned by the supervisor as a sibling of the daemon, holding the read end\nof the daemon's output pipe. Keeping the reader in its own process is what\nmakes logging survive a supervisor crash: the pipe still has a reader, so\nthe daemon is neither killed by SIGPIPE nor blocked, and no output is lost.\nExits when the pipe reaches end of file, which happens once the daemon and\nevery descendant holding the write end have gone.",
+        "name": "log-sink",
+        "aliases": [],
+        "hidden_aliases": [],
+        "examples": []
+      },
       "logs": {
         "full_cmd": [
           "logs"

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -139,6 +139,15 @@ cmd list help="List all daemons" {
         }
     }
 }
+cmd log-sink hide=#true help="Reads a daemon's output on stdin and writes it to the log store" {
+    long_help "Reads a daemon's output on stdin and writes it to the log store\n\nSpawned by the supervisor as a sibling of the daemon, holding the read end\nof the daemon's output pipe. Keeping the reader in its own process is what\nmakes logging survive a supervisor crash: the pipe still has a reader, so\nthe daemon is neither killed by SIGPIPE nor blocked, and no output is lost.\nExits when the pipe reaches end of file, which happens once the daemon and\nevery descendant holding the write end have gone."
+    flag --daemon-id help="Qualified id of the daemon whose output this is" required=#true {
+        arg <DAEMON_ID>
+    }
+    flag --log-format help="Log format to parse lines with (`json`, `logfmt`, `auto`, or `text`)" default=text {
+        arg <LOG_FORMAT>
+    }
+}
 cmd logs help="Displays logs for daemon(s)" {
     alias l
     long_help "Displays logs for daemon(s)\n\nShows logs from managed daemons. Logs are stored in the pitchfork logs directory\nand include timestamps for filtering.\n\nExamples:\n  pitchfork logs api              Show all logs for 'api' (paged if needed)\n  pitchfork logs api worker       Show logs for multiple daemons\n  pitchfork logs                  Show logs for all daemons\n  pitchfork logs api -n 50        Show last 50 lines\n  pitchfork logs api --follow     Follow logs in real-time\n  pitchfork logs api --since '2024-01-15 10:00:00'\n                                  Show logs since a specific time (forward)\n  pitchfork logs api --since '10:30:00'\n                                  Show logs since 10:30:00 today\n  pitchfork logs api --since '10:30' --until '12:00'\n                                  Show logs since 10:30:00 until 12:00:00 today\n  pitchfork logs api --since 5min Show logs from last 5 minutes\n  pitchfork logs api --raw        Output raw log lines without formatting\n  pitchfork logs api --raw -n 100 Output last 100 raw log lines\n  pitchfork logs api --clear      Delete logs for 'api'\n  pitchfork logs --clear          Delete logs for all daemons"

--- a/settings.toml
+++ b/settings.toml
@@ -788,12 +788,12 @@ is verified via PID plus kernel start time):
 
 - `adopt` (default): keep the process running and resume supervision.
   The daemon keeps its state (status, ports, proxy routing) and is
-  monitored by polling. Since the process is no longer a child of the
-  supervisor, its stdout/stderr capture cannot be restored — log capture
-  resumes the next time the daemon restarts. Exit codes of adopted
-  daemons cannot be observed; an adopted daemon that dies unexpectedly
-  is marked `errored` with an unknown exit code, which makes it eligible
-  for its configured retries.
+  monitored by polling. Log capture is unaffected, because a daemon's
+  output is read by a sibling sink process rather than by the supervisor,
+  so it continues uninterrupted across the crash. Exit codes of adopted
+  daemons cannot be observed, though;
+  an adopted daemon that dies unexpectedly is marked `errored` with an
+  unknown exit code, which makes it eligible for its configured retries.
 - `kill`: terminate the orphaned process group so the new supervisor
   starts with a clean slate, matching pre-adoption behavior.
 

--- a/src/cli/log_sink.rs
+++ b/src/cli/log_sink.rs
@@ -93,16 +93,13 @@ async fn read_lines(
         }
         for &byte in &chunk[..read] {
             if byte == b'\n' {
-                if queue(&tx, &mut line, log_format).await.is_err() {
-                    return Ok(());
-                }
+                queue(&tx, &mut line, log_format).await?;
             } else {
                 line.push(byte);
                 // Emit an over-long run as its own line rather than letting the
                 // buffer grow without bound.
-                if line.len() >= MAX_LINE_BYTES && queue(&tx, &mut line, log_format).await.is_err()
-                {
-                    return Ok(());
+                if line.len() >= MAX_LINE_BYTES {
+                    queue(&tx, &mut line, log_format).await?;
                 }
             }
         }
@@ -110,23 +107,30 @@ async fn read_lines(
 
     // Anything written without a trailing newline is still output.
     if !line.is_empty() {
-        let _ = queue(&tx, &mut line, log_format).await;
+        queue(&tx, &mut line, log_format).await?;
     }
     Ok(())
 }
 
 /// Parse `line` and hand it to the writer, clearing it either way.
+///
+/// A closed queue means the writer task is gone, which is a failure rather than
+/// the end of the stream: reporting it as success would tell the supervisor this
+/// sink had reached end of file, and it would stop replacing it while the daemon
+/// was still writing.
 async fn queue(
     tx: &tokio::sync::mpsc::Sender<ParsedLog>,
     line: &mut Vec<u8>,
     log_format: &str,
-) -> std::result::Result<(), ()> {
+) -> std::io::Result<()> {
     // Convert lossily: a daemon emitting a stray non-UTF-8 byte must not be able
     // to stop its own logging.
     let text = String::from_utf8_lossy(line);
     let parsed = crate::log_parse::parse(text.trim_end_matches('\r'), log_format);
     line.clear();
-    tx.send(parsed).await.map_err(|_| ())
+    tx.send(parsed)
+        .await
+        .map_err(|_| std::io::Error::other("log writer stopped"))
 }
 
 /// Write queued lines in batches until the queue closes.

--- a/src/cli/log_sink.rs
+++ b/src/cli/log_sink.rs
@@ -134,17 +134,39 @@ async fn queue_capped(
     line: &mut Vec<u8>,
     log_format: &str,
 ) -> std::io::Result<()> {
-    let split = match std::str::from_utf8(line) {
-        Ok(_) => line.len(),
-        // A sequence cut short at the end: keep it for the next line.
-        Err(e) if e.error_len().is_none() && e.valid_up_to() > 0 => e.valid_up_to(),
-        // Genuinely invalid bytes, which the lossy conversion already handles.
-        Err(_) => line.len(),
-    };
+    let split = split_before_incomplete_char(line);
     let tail = line.split_off(split);
     let result = queue(tx, line, log_format).await;
     *line = tail;
     result
+}
+
+/// Length to cut `bytes` at so no character is left half-written.
+///
+/// Decided by inspecting the final bytes rather than by asking `from_utf8` where
+/// the string stops being valid: that reports the *first* problem, so a single
+/// invalid byte earlier in the line would hide an unfinished character at the
+/// end, and the character would be split after all.
+fn split_before_incomplete_char(bytes: &[u8]) -> usize {
+    let len = bytes.len();
+    // A character is at most four bytes, so only the last few can be unfinished.
+    for i in (len.saturating_sub(4)..len).rev() {
+        let byte = bytes[i];
+        if byte & 0b1100_0000 == 0b1000_0000 {
+            continue; // a continuation byte; keep looking back for its lead
+        }
+        let expected = match byte {
+            0x00..=0x7f => 1,
+            b if b >> 5 == 0b110 => 2,
+            b if b >> 4 == 0b1110 => 3,
+            b if b >> 3 == 0b11110 => 4,
+            // Not a valid lead byte at all, so nothing is pending; the lossy
+            // conversion will render it.
+            _ => 1,
+        };
+        return if i + expected > len && i > 0 { i } else { len };
+    }
+    len
 }
 
 /// Parse `line` and hand it to the writer, clearing it either way.

--- a/src/cli/log_sink.rs
+++ b/src/cli/log_sink.rs
@@ -33,8 +33,14 @@ pub struct LogSink {
 impl LogSink {
     pub async fn run(&self) -> Result<()> {
         let id = DaemonId::parse(&self.daemon_id)?;
-        let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
+        let mut reader = tokio::io::BufReader::new(tokio::io::stdin());
         let mut batch: Vec<crate::log_parse::ParsedLog> = Vec::with_capacity(BATCH_SIZE);
+        // Read bytes and convert lossily rather than requiring valid UTF-8. A
+        // daemon that emits a stray non-UTF-8 byte must not be able to stop its
+        // own logging, and an error here would be reported as a clean exit —
+        // which the supervisor reads as end of file and stops replacing the
+        // sink, eventually blocking the daemon behind a full pipe.
+        let mut buf: Vec<u8> = Vec::new();
 
         // Batch writes, but never hold a line longer than this. Waiting for a
         // full batch would make a daemon that logs a few lines a second appear
@@ -44,22 +50,29 @@ impl LogSink {
 
         loop {
             tokio::select! {
-                line = lines.next_line() => {
-                    match line {
-                        Ok(Some(line)) => {
-                            batch.push(crate::log_parse::parse(&line, &self.log_format));
+                read = reader.read_until(b'\n', &mut buf) => {
+                    match read {
+                        // End of file: every write end is closed, so the daemon
+                        // is gone and there will be nothing more to read.
+                        Ok(0) => break,
+                        Ok(_) => {
+                            let line = String::from_utf8_lossy(&buf);
+                            let line = line.trim_end_matches(['\n', '\r']);
+                            batch.push(crate::log_parse::parse(line, &self.log_format));
+                            buf.clear();
                             if batch.len() >= BATCH_SIZE {
                                 flush(&id, &mut batch);
                             }
                         }
-                        // End of file: every write end is closed, so the daemon
-                        // is gone and there will be nothing more to read.
-                        Ok(None) => break,
                         Err(e) => {
-                            // Invalid UTF-8 or a broken pipe: record it and
-                            // stop rather than spin on an unreadable stream.
-                            debug!("log sink for {id} stopping: {e}");
-                            break;
+                            // A real read failure, not a decoding problem. Write
+                            // what we have and exit non-zero so the supervisor
+                            // replaces this sink rather than treating the stream
+                            // as finished.
+                            flush(&id, &mut batch);
+                            return Err(miette::miette!(
+                                "log sink for {id} could not read the daemon's output: {e}"
+                            ));
                         }
                     }
                 }

--- a/src/cli/log_sink.rs
+++ b/src/cli/log_sink.rs
@@ -1,14 +1,34 @@
 use crate::Result;
 use crate::daemon_id::DaemonId;
+use crate::log_parse::ParsedLog;
 use crate::log_store::LogStore;
 use crate::log_store::sqlite::LOG_STORE;
-use tokio::io::AsyncBufReadExt;
+use tokio::io::AsyncReadExt;
 
 /// Number of parsed lines to accumulate before writing them as one batch.
 const BATCH_SIZE: usize = 100;
 
 /// Longest a parsed line waits in the batch before being written.
 const FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// How many parsed lines may be queued for writing before reading slows down.
+///
+/// Reading and writing run separately so a slow write cannot stop the pipe being
+/// drained, but the queue is bounded: output that sustainably outpaces the store
+/// has to push back on the daemon eventually, which is preferable to growing
+/// without limit.
+const QUEUE_DEPTH: usize = 8192;
+
+/// Bytes read from the pipe at a time.
+const READ_CHUNK: usize = 8192;
+
+/// Longest run of bytes treated as a single line.
+///
+/// Output containing no newline must not accumulate indefinitely: a daemon
+/// emitting an endless stream, or binary data, would otherwise grow the buffer
+/// until the sink was killed for using too much memory — whereupon the
+/// supervisor would start another sink and repeat it.
+const MAX_LINE_BYTES: usize = 64 * 1024;
 
 /// Reads a daemon's output on stdin and writes it to the log store
 ///
@@ -33,67 +53,115 @@ pub struct LogSink {
 impl LogSink {
     pub async fn run(&self) -> Result<()> {
         let id = DaemonId::parse(&self.daemon_id)?;
-        let mut reader = tokio::io::BufReader::new(tokio::io::stdin());
-        let mut batch: Vec<crate::log_parse::ParsedLog> = Vec::with_capacity(BATCH_SIZE);
-        // Read bytes and convert lossily rather than requiring valid UTF-8. A
-        // daemon that emits a stray non-UTF-8 byte must not be able to stop its
-        // own logging, and an error here would be reported as a clean exit —
-        // which the supervisor reads as end of file and stops replacing the
-        // sink, eventually blocking the daemon behind a full pipe.
-        let mut buf: Vec<u8> = Vec::new();
 
-        // Batch writes, but never hold a line longer than this. Waiting for a
-        // full batch would make a daemon that logs a few lines a second appear
-        // silent for many seconds.
-        let mut flush_interval = tokio::time::interval(FLUSH_INTERVAL);
-        flush_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Reading and writing are separate tasks. A write to SQLite can block —
+        // for as long as the store's busy timeout, if another writer holds the
+        // lock — and this process is the only reader of the daemon's pipe, so a
+        // write must never stop it being drained.
+        let (tx, rx) = tokio::sync::mpsc::channel::<ParsedLog>(QUEUE_DEPTH);
+        let writer = tokio::spawn(write_batches(id.clone(), rx));
 
-        loop {
-            tokio::select! {
-                read = reader.read_until(b'\n', &mut buf) => {
-                    match read {
-                        // End of file: every write end is closed, so the daemon
-                        // is gone and there will be nothing more to read.
-                        Ok(0) => break,
-                        Ok(_) => {
-                            let line = String::from_utf8_lossy(&buf);
-                            let line = line.trim_end_matches(['\n', '\r']);
-                            batch.push(crate::log_parse::parse(line, &self.log_format));
-                            buf.clear();
-                            if batch.len() >= BATCH_SIZE {
-                                flush(&id, &mut batch);
-                            }
-                        }
-                        Err(e) => {
-                            // A real read failure, not a decoding problem. Write
-                            // what we have and exit non-zero so the supervisor
-                            // replaces this sink rather than treating the stream
-                            // as finished.
-                            flush(&id, &mut batch);
-                            return Err(miette::miette!(
-                                "log sink for {id} could not read the daemon's output: {e}"
-                            ));
-                        }
-                    }
-                }
-                _ = flush_interval.tick() => flush(&id, &mut batch),
-            }
-        }
+        let read_result = read_lines(tx, &self.log_format).await;
 
-        flush(&id, &mut batch);
-        Ok(())
+        // The sender has been dropped by now, so the writer drains its queue and
+        // returns; wait for it so nothing queued is lost on exit.
+        let _ = writer.await;
+
+        read_result.map_err(|e| {
+            miette::miette!("log sink for {id} could not read the daemon's output: {e}")
+        })
     }
 }
 
-fn flush(id: &DaemonId, batch: &mut Vec<crate::log_parse::ParsedLog>) {
+/// Split the daemon's output into lines and queue them for writing.
+///
+/// Returns once the pipe reaches end of file. A read error is propagated so the
+/// process can exit non-zero: exiting cleanly would tell the supervisor the
+/// stream had finished and it would stop replacing this sink.
+async fn read_lines(
+    tx: tokio::sync::mpsc::Sender<ParsedLog>,
+    log_format: &str,
+) -> std::io::Result<()> {
+    let mut stdin = tokio::io::stdin();
+    let mut chunk = vec![0u8; READ_CHUNK];
+    let mut line: Vec<u8> = Vec::with_capacity(256);
+
+    loop {
+        let read = stdin.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        for &byte in &chunk[..read] {
+            if byte == b'\n' {
+                if queue(&tx, &mut line, log_format).await.is_err() {
+                    return Ok(());
+                }
+            } else {
+                line.push(byte);
+                // Emit an over-long run as its own line rather than letting the
+                // buffer grow without bound.
+                if line.len() >= MAX_LINE_BYTES && queue(&tx, &mut line, log_format).await.is_err()
+                {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    // Anything written without a trailing newline is still output.
+    if !line.is_empty() {
+        let _ = queue(&tx, &mut line, log_format).await;
+    }
+    Ok(())
+}
+
+/// Parse `line` and hand it to the writer, clearing it either way.
+async fn queue(
+    tx: &tokio::sync::mpsc::Sender<ParsedLog>,
+    line: &mut Vec<u8>,
+    log_format: &str,
+) -> std::result::Result<(), ()> {
+    // Convert lossily: a daemon emitting a stray non-UTF-8 byte must not be able
+    // to stop its own logging.
+    let text = String::from_utf8_lossy(line);
+    let parsed = crate::log_parse::parse(text.trim_end_matches('\r'), log_format);
+    line.clear();
+    tx.send(parsed).await.map_err(|_| ())
+}
+
+/// Write queued lines in batches until the queue closes.
+async fn write_batches(id: DaemonId, mut rx: tokio::sync::mpsc::Receiver<ParsedLog>) {
+    let mut batch: Vec<ParsedLog> = Vec::with_capacity(BATCH_SIZE);
+    let mut flush_interval = tokio::time::interval(FLUSH_INTERVAL);
+    flush_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        let closed = tokio::select! {
+            received = rx.recv_many(&mut batch, BATCH_SIZE) => received == 0,
+            _ = flush_interval.tick() => false,
+        };
+        flush(&id, &mut batch).await;
+        if closed {
+            break;
+        }
+    }
+}
+
+/// Write one batch, off the runtime so the SQLite call cannot stall other tasks.
+async fn flush(id: &DaemonId, batch: &mut Vec<ParsedLog>) {
     if batch.is_empty() {
         return;
     }
-    if let Err(e) = LOG_STORE.append_structured_batch(id, batch) {
-        // Nothing useful to do but report it: the supervisor is not
-        // necessarily alive to be told, and dropping the batch is preferable
-        // to stalling the daemon behind a full pipe.
+    let daemon_id = id.clone();
+    let entries = std::mem::take(batch);
+    let written = tokio::task::spawn_blocking(move || {
+        LOG_STORE.append_structured_batch(&daemon_id, &entries)
+    })
+    .await;
+    if let Ok(Err(e)) = written {
+        // Nothing useful to do but report it: the supervisor is not necessarily
+        // alive to be told, and dropping a batch is preferable to stalling the
+        // daemon behind a pipe nobody is draining.
         error!("log sink failed to write batch for {id}: {e}");
     }
-    batch.clear();
 }

--- a/src/cli/log_sink.rs
+++ b/src/cli/log_sink.rs
@@ -1,0 +1,86 @@
+use crate::Result;
+use crate::daemon_id::DaemonId;
+use crate::log_store::LogStore;
+use crate::log_store::sqlite::LOG_STORE;
+use tokio::io::AsyncBufReadExt;
+
+/// Number of parsed lines to accumulate before writing them as one batch.
+const BATCH_SIZE: usize = 100;
+
+/// Longest a parsed line waits in the batch before being written.
+const FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Reads a daemon's output on stdin and writes it to the log store
+///
+/// Spawned by the supervisor as a sibling of the daemon, holding the read end
+/// of the daemon's output pipe. Keeping the reader in its own process is what
+/// makes logging survive a supervisor crash: the pipe still has a reader, so
+/// the daemon is neither killed by SIGPIPE nor blocked, and no output is lost.
+/// Exits when the pipe reaches end of file, which happens once the daemon and
+/// every descendant holding the write end have gone.
+#[derive(Debug, clap::Args)]
+#[clap(hide = true, verbatim_doc_comment)]
+pub struct LogSink {
+    /// Qualified id of the daemon whose output this is
+    #[clap(long)]
+    daemon_id: String,
+
+    /// Log format to parse lines with (`json`, `logfmt`, `auto`, or `text`)
+    #[clap(long, default_value = "text")]
+    log_format: String,
+}
+
+impl LogSink {
+    pub async fn run(&self) -> Result<()> {
+        let id = DaemonId::parse(&self.daemon_id)?;
+        let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
+        let mut batch: Vec<crate::log_parse::ParsedLog> = Vec::with_capacity(BATCH_SIZE);
+
+        // Batch writes, but never hold a line longer than this. Waiting for a
+        // full batch would make a daemon that logs a few lines a second appear
+        // silent for many seconds.
+        let mut flush_interval = tokio::time::interval(FLUSH_INTERVAL);
+        flush_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                line = lines.next_line() => {
+                    match line {
+                        Ok(Some(line)) => {
+                            batch.push(crate::log_parse::parse(&line, &self.log_format));
+                            if batch.len() >= BATCH_SIZE {
+                                flush(&id, &mut batch);
+                            }
+                        }
+                        // End of file: every write end is closed, so the daemon
+                        // is gone and there will be nothing more to read.
+                        Ok(None) => break,
+                        Err(e) => {
+                            // Invalid UTF-8 or a broken pipe: record it and
+                            // stop rather than spin on an unreadable stream.
+                            debug!("log sink for {id} stopping: {e}");
+                            break;
+                        }
+                    }
+                }
+                _ = flush_interval.tick() => flush(&id, &mut batch),
+            }
+        }
+
+        flush(&id, &mut batch);
+        Ok(())
+    }
+}
+
+fn flush(id: &DaemonId, batch: &mut Vec<crate::log_parse::ParsedLog>) {
+    if batch.is_empty() {
+        return;
+    }
+    if let Err(e) = LOG_STORE.append_structured_batch(id, batch) {
+        // Nothing useful to do but report it: the supervisor is not
+        // necessarily alive to be told, and dropping the batch is preferable
+        // to stalling the daemon behind a full pipe.
+        error!("log sink failed to write batch for {id}: {e}");
+    }
+    batch.clear();
+}

--- a/src/cli/log_sink.rs
+++ b/src/cli/log_sink.rs
@@ -85,6 +85,10 @@ async fn read_lines(
     let mut stdin = tokio::io::stdin();
     let mut chunk = vec![0u8; READ_CHUNK];
     let mut line: Vec<u8> = Vec::with_capacity(256);
+    // Whether the last line was emitted because it reached the cap rather than
+    // because it ended. A newline arriving straight afterwards terminates the
+    // line already written, so it must not produce an empty one.
+    let mut split_at_cap = false;
 
     loop {
         let read = stdin.read(&mut chunk).await?;
@@ -93,13 +97,20 @@ async fn read_lines(
         }
         for &byte in &chunk[..read] {
             if byte == b'\n' {
+                if split_at_cap && line.is_empty() {
+                    split_at_cap = false;
+                    continue;
+                }
+                split_at_cap = false;
                 queue(&tx, &mut line, log_format).await?;
             } else {
                 line.push(byte);
+                split_at_cap = false;
                 // Emit an over-long run as its own line rather than letting the
                 // buffer grow without bound.
                 if line.len() >= MAX_LINE_BYTES {
-                    queue(&tx, &mut line, log_format).await?;
+                    queue_capped(&tx, &mut line, log_format).await?;
+                    split_at_cap = true;
                 }
             }
         }
@@ -110,6 +121,30 @@ async fn read_lines(
         queue(&tx, &mut line, log_format).await?;
     }
     Ok(())
+}
+
+/// Emit a line that has reached the length cap, keeping any trailing bytes that
+/// form an incomplete character.
+///
+/// Splitting purely by byte count would cut a multi-byte character in half, and
+/// converting each half on its own turns one valid character into two
+/// replacement characters.
+async fn queue_capped(
+    tx: &tokio::sync::mpsc::Sender<ParsedLog>,
+    line: &mut Vec<u8>,
+    log_format: &str,
+) -> std::io::Result<()> {
+    let split = match std::str::from_utf8(line) {
+        Ok(_) => line.len(),
+        // A sequence cut short at the end: keep it for the next line.
+        Err(e) if e.error_len().is_none() && e.valid_up_to() > 0 => e.valid_up_to(),
+        // Genuinely invalid bytes, which the lossy conversion already handles.
+        Err(_) => line.len(),
+    };
+    let tail = line.split_off(split);
+    let result = queue(tx, line, log_format).await;
+    *line = tail;
+    result
 }
 
 /// Parse `line` and hand it to the writer, clearing it either way.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,6 +13,7 @@ mod disable;
 mod enable;
 mod json_output;
 mod list;
+pub mod log_sink;
 pub mod logs;
 mod mcp;
 mod project;
@@ -50,6 +51,7 @@ enum Commands {
     Disable(disable::Disable),
     Enable(enable::Enable),
     List(list::List),
+    LogSink(log_sink::LogSink),
     Logs(logs::Logs),
     Mcp(mcp::Mcp),
     Proxy(proxy::Proxy),
@@ -99,6 +101,7 @@ pub async fn run() -> Result<()> {
         Commands::Disable(disable) => disable.run().await,
         Commands::Enable(enable) => enable.run().await,
         Commands::List(list) => list.run().await,
+        Commands::LogSink(log_sink) => log_sink.run().await,
         Commands::Logs(logs) => logs.run().await,
         Commands::Mcp(mcp) => mcp.run().await,
         Commands::Proxy(proxy) => proxy.run().await,

--- a/src/log_store/sqlite.rs
+++ b/src/log_store/sqlite.rs
@@ -66,6 +66,42 @@ pub struct SqliteLogStore {
 /// overhead exceeds the query savings.
 const PARALLEL_QUERY_THRESHOLD: usize = 200_000;
 
+/// How long a statement waits for a contended lock before giving up. Generous
+/// enough to outlast any batch insert or retention prune, short enough that a
+/// genuinely stuck writer still surfaces as an error rather than hanging.
+const BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Put the database into WAL mode, tolerating a lost race.
+///
+/// Switching journal modes needs an exclusive lock and, unlike ordinary
+/// statements, does not consult the busy handler — so concurrent opens collide
+/// here no matter how large `busy_timeout` is. WAL is recorded in the database
+/// header and persists across connections, so only the first open has to
+/// succeed: retry briefly in case a peer is mid-switch, and if it still has not
+/// taken, carry on rather than fail. A connection that never personally set WAL
+/// still works correctly; refusing to open the log store over a transient
+/// pragma race would be far worse than running one connection unoptimised.
+fn enable_wal(conn: &Connection) {
+    const ATTEMPTS: usize = 5;
+    for attempt in 0..ATTEMPTS {
+        match conn.query_row("PRAGMA journal_mode", [], |row| row.get::<_, String>(0)) {
+            Ok(mode) if mode.eq_ignore_ascii_case("wal") => return,
+            Ok(_) => {}
+            Err(e) => {
+                debug!("could not read journal_mode: {e}");
+                return;
+            }
+        }
+        if conn.execute_batch("PRAGMA journal_mode = WAL;").is_ok() {
+            return;
+        }
+        if attempt + 1 < ATTEMPTS {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
+    debug!("log store is not in WAL mode; another connection may be switching it");
+}
+
 impl SqliteLogStore {
     /// Open or create the SQLite log store at the given path.
     pub fn open(path: impl Into<PathBuf>) -> Result<Self> {
@@ -74,10 +110,22 @@ impl SqliteLogStore {
             std::fs::create_dir_all(parent).into_diagnostic()?;
         }
         let conn = Connection::open(&path).into_diagnostic()?;
+
+        // A contended write must wait for the lock rather than fail: WAL
+        // allows concurrent readers but still serializes writers, and a writer
+        // with no timeout takes SQLITE_BUSY immediately and drops its work.
+        // rusqlite already defaults to this value, but state it explicitly so
+        // the requirement is visible here and does not rest on a dependency's
+        // default. Set before anything else, since the statements below take
+        // locks of their own.
+        conn.busy_timeout(BUSY_TIMEOUT).into_diagnostic()?;
+
         add_regexp_function(&conn)?;
+
+        enable_wal(&conn);
+
         conn.execute_batch(
-            "PRAGMA journal_mode = WAL;
-             PRAGMA synchronous = NORMAL;
+            "PRAGMA synchronous = NORMAL;
              PRAGMA mmap_size = 268435456;",
         )
         .into_diagnostic()?;
@@ -1134,4 +1182,100 @@ fn auto_migrate_legacy_logs(store: &SqliteLogStore) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::log_store::LogStore;
+
+    /// A writer that finds the lock held must wait for it, not give up. WAL
+    /// serializes writers, so without `busy_timeout` the second writer takes
+    /// SQLITE_BUSY immediately and silently discards its batch.
+    #[test]
+    fn write_waits_for_a_contended_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logs.db");
+        let store = SqliteLogStore::open(&path).unwrap();
+
+        // Hold the write lock from a second connection, then release it after a
+        // delay that a non-waiting writer could never survive.
+        let blocker = Connection::open(&path).unwrap();
+        blocker.busy_timeout(BUSY_TIMEOUT).unwrap();
+        blocker.execute_batch("BEGIN IMMEDIATE").unwrap();
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            blocker.execute_batch("COMMIT").unwrap();
+        });
+
+        let id = DaemonId::try_new("test", "blocked").unwrap();
+        let entries = vec![crate::log_parse::parse("held-lock-line", "text")];
+        store
+            .append_structured_batch(&id, &entries)
+            .expect("a contended write must wait for the lock, not fail");
+
+        releaser.join().unwrap();
+        let found = store
+            .query(&LogQuery {
+                daemon_ids: vec![id.qualified()],
+                ..Default::default()
+            })
+            .unwrap()
+            .len();
+        assert_eq!(found, 1, "the batch written under contention was lost");
+    }
+
+    /// Two processes writing the same store is the normal case, not an edge
+    /// case: daemon output and retention pruning already collide, and a
+    /// per-daemon writer multiplies the opportunities. WAL serializes writers,
+    /// so without `busy_timeout` the loser of that race takes SQLITE_BUSY
+    /// immediately and silently discards its batch.
+    #[test]
+    fn concurrent_writers_do_not_lose_batches() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logs.db");
+
+        const WRITERS: usize = 4;
+        const BATCHES: usize = 15;
+        const PER_BATCH: usize = 10;
+
+        std::thread::scope(|scope| {
+            for writer in 0..WRITERS {
+                let path = path.clone();
+                scope.spawn(move || {
+                    // A separate connection per writer, as separate processes
+                    // would have.
+                    let store = SqliteLogStore::open(&path).unwrap();
+                    let id = DaemonId::try_new("test", format!("w{writer}")).unwrap();
+                    for batch in 0..BATCHES {
+                        let entries: Vec<ParsedLog> = (0..PER_BATCH)
+                            .map(|i| {
+                                crate::log_parse::parse(&format!("w{writer}-{batch}-{i}"), "text")
+                            })
+                            .collect();
+                        store
+                            .append_structured_batch(&id, &entries)
+                            .expect("concurrent batch write must not fail");
+                    }
+                });
+            }
+        });
+
+        let store = SqliteLogStore::open(&path).unwrap();
+        for writer in 0..WRITERS {
+            let id = DaemonId::try_new("test", format!("w{writer}")).unwrap();
+            let found = store
+                .query(&LogQuery {
+                    daemon_ids: vec![id.qualified()],
+                    ..Default::default()
+                })
+                .unwrap()
+                .len();
+            assert_eq!(
+                found,
+                BATCHES * PER_BATCH,
+                "writer {writer} lost entries: got {found}"
+            );
+        }
+    }
 }

--- a/src/log_store/sqlite.rs
+++ b/src/log_store/sqlite.rs
@@ -1239,12 +1239,20 @@ mod tests {
         const BATCHES: usize = 15;
         const PER_BATCH: usize = 10;
 
+        // Release every worker into open() at the same moment. Without this
+        // the scheduler is free to run them one after another, so the first
+        // would enable WAL and the rest would never contend for the
+        // journal-mode switch — leaving the race this guards unexercised.
+        let barrier = std::sync::Barrier::new(WRITERS);
+
         std::thread::scope(|scope| {
             for writer in 0..WRITERS {
                 let path = path.clone();
+                let barrier = &barrier;
                 scope.spawn(move || {
                     // A separate connection per writer, as separate processes
                     // would have.
+                    barrier.wait();
                     let store = SqliteLogStore::open(&path).unwrap();
                     let id = DaemonId::try_new("test", format!("w{writer}")).unwrap();
                     for batch in 0..BATCHES {

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -8,11 +8,9 @@
 //! An adopted process is no longer a child of the supervisor, so `wait()`
 //! based monitoring is impossible — a poll monitor watches liveness instead,
 //! anchored to the verified start time so a recycled PID is never mistaken
-//! for the daemon. Two consequences follow, both documented in the
+//! for the daemon. One consequence follows, documented in the
 //! `orphan_policy` setting:
 //!
-//! - stdout/stderr capture cannot be restored (the pipes died with the old
-//!   supervisor); log capture resumes on the daemon's next restart
 //! - exit codes cannot be observed; an adopted daemon that dies unexpectedly
 //!   is marked `Errored(-1)` ("unknown exit code"), making it eligible for
 //!   its configured retries
@@ -148,7 +146,7 @@ impl Supervisor {
     /// Whether the registry entry for `id` still belongs to the registration
     /// identified by `token`. Unlike `is_monitored` this cannot be confused
     /// by a successor that recycled the same numeric PID.
-    fn monitor_token_valid(&self, id: &DaemonId, token: u64) -> bool {
+    pub(crate) fn monitor_token_valid(&self, id: &DaemonId, token: u64) -> bool {
         self.monitored
             .lock()
             .expect("monitored lock poisoned")

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -167,6 +167,11 @@ fn any_ready_check_remaining(
         || ready_cmd.is_some_and(|c| c.timeout.is_none() || !cmd_exhausted)
 }
 
+/// How long a failed start waits for its sink to write what the daemon printed
+/// before reporting. Short enough not to stall the caller, long enough for a
+/// sink that has already seen end of file to finish its final batch.
+const SINK_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+
 impl Supervisor {
     /// Run a daemon, handling retries if configured
     pub async fn run(&self, opts: RunOptions) -> Result<IpcResponse> {
@@ -435,6 +440,28 @@ impl Supervisor {
             None
         };
 
+        // Set up out-of-process capture before building the command, so the
+        // daemon can be handed the pipe's write end directly.
+        let mut sink_pipe = None;
+        let mut sink_writer = None;
+        if super::log_sink::is_supported(&opts) {
+            let log_format = opts
+                .log_format
+                .clone()
+                .unwrap_or_else(|| settings().logs.log_format.clone());
+            match super::log_sink::SinkPipe::new(log_format) {
+                Ok((pipe, writer)) => {
+                    sink_pipe = Some(pipe);
+                    sink_writer = Some(writer);
+                }
+                Err(e) => {
+                    // Fall back to in-process capture rather than refusing to
+                    // start the daemon.
+                    warn!("could not create log pipe for {id}, capturing in-process: {e}");
+                }
+            }
+        }
+
         let mut cmd = tokio::process::Command::new(&program);
 
         #[cfg(unix)]
@@ -454,13 +481,27 @@ impl Supervisor {
                 |e| miette::miette!("failed to clone slave PTY fd for stdout: {e}"),
             )?));
             cmd.stderr(std::process::Stdio::from(slave_file));
+        } else if let Some(writer) = sink_writer.take() {
+            // Capture belongs to a sibling sink process, so the daemon writes
+            // to a pipe this process does not read. See supervisor::log_sink.
+            let dup = writer
+                .try_clone()
+                .map_err(|e| miette::miette!("failed to dup log pipe for stderr: {e}"))?;
+            cmd.stdout(std::process::Stdio::from(writer))
+                .stderr(std::process::Stdio::from(dup));
         } else {
             cmd.stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped());
         }
 
         #[cfg(not(unix))]
-        {
+        if let Some(writer) = sink_writer.take() {
+            let dup = writer
+                .try_clone()
+                .map_err(|e| miette::miette!("failed to dup log pipe for stderr: {e}"))?;
+            cmd.stdout(std::process::Stdio::from(writer))
+                .stderr(std::process::Stdio::from(dup));
+        } else {
             cmd.stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped());
         }
@@ -556,6 +597,13 @@ impl Supervisor {
         // handed to the monitoring task.
         let monitored_guard = super::adopt::MonitoredGuard::register(id.clone(), pid);
         let monitor_token = monitored_guard.token();
+
+        // Hand the retained read end to a sink and keep one running for as long
+        // as this daemon is monitored.
+        let using_sink = sink_pipe.is_some();
+        let sink_drained = sink_pipe
+            .take()
+            .map(|pipe| pipe.supervise(id.clone(), monitor_token));
         let daemon = self
             .upsert_daemon(
                 UpsertDaemonOpts::from_run_options(&opts, DaemonStatus::Running)
@@ -636,7 +684,10 @@ impl Supervisor {
             None
         };
 
-        if pty_reader.is_none() && (stdout_reader.is_none() || stderr_reader.is_none()) {
+        if !using_sink
+            && pty_reader.is_none()
+            && (stdout_reader.is_none() || stderr_reader.is_none())
+        {
             error!("Failed to capture stdout/stderr for daemon {id}");
         }
 
@@ -1494,6 +1545,13 @@ impl Supervisor {
                 }
                 Ok(Err(exit_code)) => {
                     error!("daemon {id} failed before becoming ready");
+                    // The caller reports this by querying the log store for
+                    // what the daemon printed, so wait for the sink's final
+                    // write first. The in-process path got this ordering by
+                    // flushing synchronously before signalling.
+                    if let Some(drained) = sink_drained {
+                        drained.wait(SINK_DRAIN_TIMEOUT).await;
+                    }
                     Ok(IpcResponse::DaemonFailedWithCode { exit_code })
                 }
                 Err(_) => {

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -454,7 +454,7 @@ impl Supervisor {
             match super::log_sink::SinkPipe::new(log_format) {
                 Ok((pipe, writer)) => match pipe.start(id) {
                     Ok(child) => {
-                        sink_child = Some(child);
+                        sink_child = Some(super::log_sink::PendingSink::new(child));
                         sink_pipe = Some(pipe);
                         sink_writer = Some(writer);
                     }
@@ -591,13 +591,8 @@ impl Supervisor {
         // reap it explicitly: dropping the handle only reaps on a best-effort
         // basis, and run_once runs once per retry attempt, so a daemon that
         // consistently fails to spawn would otherwise accumulate sinks.
-        let mut child = match cmd.spawn() {
-            Ok(child) => child,
-            Err(e) => {
-                super::log_sink::reap(sink_child.take()).await;
-                return Err(e).into_diagnostic();
-            }
-        };
+        // A failed spawn returns here; the sink is terminated by PendingSink.
+        let mut child = cmd.spawn().into_diagnostic()?;
         let pid = match child.id() {
             Some(p) => p,
             None => {
@@ -610,7 +605,6 @@ impl Supervisor {
                 if sink_child.is_some() {
                     super::log_sink::wait_for_output(&id, spawn_time, SINK_OUTPUT_TIMEOUT).await;
                 }
-                super::log_sink::reap(sink_child.take()).await;
                 return Ok(IpcResponse::DaemonFailed {
                     error: "Process exited immediately".to_string(),
                 });
@@ -631,7 +625,11 @@ impl Supervisor {
         // Hand the retained read end to a sink and keep one running for as long
         // as this daemon is monitored.
         let using_sink = sink_pipe.is_some();
-        if let (Some(pipe), Some(child)) = (sink_pipe.take(), sink_child.take()) {
+        // Take the sink out of the guard only once there is a pipe to supervise
+        // it with, so it is never left running unsupervised.
+        if let Some(pipe) = sink_pipe.take()
+            && let Some(child) = sink_child.as_mut().and_then(|pending| pending.take())
+        {
             pipe.supervise(id.clone(), monitor_token, child);
         }
         let daemon = self

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -587,11 +587,22 @@ impl Supervisor {
         // Timestamp the run so a failed start can wait for this attempt's output
         // specifically, rather than seeing an earlier attempt's.
         let spawn_time = chrono::Local::now();
-        let mut child = cmd.spawn().into_diagnostic()?;
+        // A sink is already running at this point. Both bail-outs below have to
+        // reap it explicitly: dropping the handle only reaps on a best-effort
+        // basis, and run_once runs once per retry attempt, so a daemon that
+        // consistently fails to spawn would otherwise accumulate sinks.
+        let mut child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(e) => {
+                super::log_sink::reap(sink_child.take()).await;
+                return Err(e).into_diagnostic();
+            }
+        };
         let pid = match child.id() {
             Some(p) => p,
             None => {
                 warn!("Daemon {id} exited before PID could be captured");
+                super::log_sink::reap(sink_child.take()).await;
                 return Ok(IpcResponse::DaemonFailed {
                     error: "Process exited immediately".to_string(),
                 });

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -602,6 +602,14 @@ impl Supervisor {
             Some(p) => p,
             None => {
                 warn!("Daemon {id} exited before PID could be captured");
+                // Unlike a daemon that never started, this one ran and may have
+                // said why it gave up, and its output is the only diagnosis
+                // available. Its write end is already closed, so the sink is on
+                // its way to end of file: let it finish writing before reporting,
+                // then reap whatever is left of it.
+                if sink_child.is_some() {
+                    super::log_sink::wait_for_output(&id, spawn_time, SINK_OUTPUT_TIMEOUT).await;
+                }
                 super::log_sink::reap(sink_child.take()).await;
                 return Ok(IpcResponse::DaemonFailed {
                     error: "Process exited immediately".to_string(),

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -1568,8 +1568,7 @@ impl Supervisor {
                     // checker to start an attempt of its own alongside it.
                     let last_attempt = opts.retry_count >= opts.retry.count();
                     if using_sink && last_attempt {
-                        super::log_sink::wait_for_output(id, spawn_time, SINK_OUTPUT_TIMEOUT)
-                            .await;
+                        super::log_sink::wait_for_output(id, spawn_time, SINK_OUTPUT_TIMEOUT).await;
                     }
                     Ok(IpcResponse::DaemonFailedWithCode { exit_code })
                 }

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -1549,7 +1549,14 @@ impl Supervisor {
                     // what the daemon printed, so wait for the sink's final
                     // write first. The in-process path got this ordering by
                     // flushing synchronously before signalling.
-                    if let Some(drained) = sink_drained {
+                    //
+                    // Only on the attempt that gives up: `run` retries inline,
+                    // and waiting after every attempt would both delay the
+                    // backoff and widen the window in which the daemon looks
+                    // errored and idle — long enough for the background retry
+                    // checker to start an attempt of its own alongside it.
+                    let last_attempt = opts.retry_count >= opts.retry.count();
+                    if last_attempt && let Some(ref drained) = sink_drained {
                         drained.wait(SINK_DRAIN_TIMEOUT).await;
                     }
                     Ok(IpcResponse::DaemonFailedWithCode { exit_code })

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -167,10 +167,11 @@ fn any_ready_check_remaining(
         || ready_cmd.is_some_and(|c| c.timeout.is_none() || !cmd_exhausted)
 }
 
-/// How long a failed start waits for its sink to write what the daemon printed
-/// before reporting. Short enough not to stall the caller, long enough for a
-/// sink that has already seen end of file to finish its final batch.
-const SINK_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+/// How long a failed start waits for the daemon's output to become queryable
+/// before reporting. Typically satisfied in a few dozen milliseconds; a daemon
+/// that failed without printing anything waits the whole of it, so keep it
+/// short.
+const SINK_OUTPUT_TIMEOUT: Duration = Duration::from_millis(400);
 
 impl Supervisor {
     /// Run a daemon, handling retries if configured
@@ -444,16 +445,23 @@ impl Supervisor {
         // daemon can be handed the pipe's write end directly.
         let mut sink_pipe = None;
         let mut sink_writer = None;
+        let mut sink_child = None;
         if super::log_sink::is_supported(&opts) {
             let log_format = opts
                 .log_format
                 .clone()
                 .unwrap_or_else(|| settings().logs.log_format.clone());
             match super::log_sink::SinkPipe::new(log_format) {
-                Ok((pipe, writer)) => {
-                    sink_pipe = Some(pipe);
-                    sink_writer = Some(writer);
-                }
+                Ok((pipe, writer)) => match pipe.start(id) {
+                    Ok(child) => {
+                        sink_child = Some(child);
+                        sink_pipe = Some(pipe);
+                        sink_writer = Some(writer);
+                    }
+                    Err(e) => {
+                        warn!("could not start log sink for {id}, capturing in-process: {e}");
+                    }
+                },
                 Err(e) => {
                     // Fall back to in-process capture rather than refusing to
                     // start the daemon.
@@ -576,6 +584,9 @@ impl Supervisor {
             }
         }
 
+        // Timestamp the run so a failed start can wait for this attempt's output
+        // specifically, rather than seeing an earlier attempt's.
+        let spawn_time = chrono::Local::now();
         let mut child = cmd.spawn().into_diagnostic()?;
         let pid = match child.id() {
             Some(p) => p,
@@ -601,9 +612,9 @@ impl Supervisor {
         // Hand the retained read end to a sink and keep one running for as long
         // as this daemon is monitored.
         let using_sink = sink_pipe.is_some();
-        let sink_drained = sink_pipe
-            .take()
-            .map(|pipe| pipe.supervise(id.clone(), monitor_token));
+        if let (Some(pipe), Some(child)) = (sink_pipe.take(), sink_child.take()) {
+            pipe.supervise(id.clone(), monitor_token, child);
+        }
         let daemon = self
             .upsert_daemon(
                 UpsertDaemonOpts::from_run_options(&opts, DaemonStatus::Running)
@@ -1556,8 +1567,9 @@ impl Supervisor {
                     // errored and idle — long enough for the background retry
                     // checker to start an attempt of its own alongside it.
                     let last_attempt = opts.retry_count >= opts.retry.count();
-                    if last_attempt && let Some(ref drained) = sink_drained {
-                        drained.wait(SINK_DRAIN_TIMEOUT).await;
+                    if using_sink && last_attempt {
+                        super::log_sink::wait_for_output(id, spawn_time, SINK_OUTPUT_TIMEOUT)
+                            .await;
                     }
                     Ok(IpcResponse::DaemonFailedWithCode { exit_code })
                 }

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -52,7 +52,13 @@ pub(crate) fn is_supported(opts: &RunOptions) -> bool {
 }
 
 /// How long to wait before trying again when a sink process cannot be spawned.
-const SPAWN_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+///
+/// Nothing drains the pipe while no sink is running, so a chatty daemon will
+/// block on its next write once the pipe fills. Blocking is the right outcome —
+/// it is backpressure rather than discarded output, and it is what runit does
+/// when a log service cannot keep up — but keep the gap short so a transient
+/// spawn failure is barely noticeable.
+const SPAWN_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
 
 /// Wait until a daemon's output from this run is queryable, or `timeout`
 /// elapses.
@@ -73,26 +79,48 @@ pub(crate) async fn wait_for_output(
     timeout: std::time::Duration,
 ) {
     const POLL: std::time::Duration = std::time::Duration::from_millis(20);
+    // Returning at the first row would report a daemon's first line while the
+    // rest of its output was still batched in the sink, so keep going until
+    // nothing new has arrived for a moment.
+    const SETTLED_FOR: std::time::Duration = std::time::Duration::from_millis(80);
+
     let deadline = tokio::time::Instant::now() + timeout;
+    let mut seen = 0usize;
+    let mut last_change = tokio::time::Instant::now();
+
     loop {
         let query = crate::log_store::LogQuery {
             daemon_ids: vec![id.qualified()],
             from: Some(since),
-            limit: Some(1),
             ..Default::default()
         };
         let found = tokio::task::spawn_blocking(move || {
             crate::log_store::sqlite::LOG_STORE
                 .query(&query)
-                .map(|entries| !entries.is_empty())
-                .unwrap_or(false)
+                .map(|entries| entries.len())
+                .unwrap_or(0)
         })
         .await
-        .unwrap_or(false);
-        if found || tokio::time::Instant::now() >= deadline {
+        .unwrap_or(0);
+
+        let now = tokio::time::Instant::now();
+        if found > seen {
+            seen = found;
+            last_change = now;
+        }
+        let settled = seen > 0 && now.duration_since(last_change) >= SETTLED_FOR;
+        if settled || now >= deadline {
             return;
         }
         tokio::time::sleep(POLL).await;
+    }
+}
+
+/// Terminate and reap a sink that was started for a daemon which then failed to
+/// start, so it cannot linger as a zombie.
+pub(crate) async fn reap(child: Option<tokio::process::Child>) {
+    if let Some(mut child) = child {
+        let _ = child.kill().await;
     }
 }
 

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -60,6 +60,11 @@ pub(crate) fn is_supported(opts: &RunOptions) -> bool {
 /// spawn failure is barely noticeable.
 const SPAWN_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
 
+/// Longest gap between attempts once they keep failing. A sink that cannot be
+/// started at all — a missing binary, no memory for another process — should not
+/// be retried five times a second for the life of the daemon.
+const SPAWN_RETRY_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Wait until a daemon's output from this run is queryable, or `timeout`
 /// elapses.
 ///
@@ -78,42 +83,68 @@ pub(crate) async fn wait_for_output(
     since: chrono::DateTime<chrono::Local>,
     timeout: std::time::Duration,
 ) {
+    // The cap has to wrap the whole loop, not sit between polls: a single query
+    // can itself wait out the store's busy timeout, which is far longer than any
+    // caller wants to pause a failed start for.
+    let _ = tokio::time::timeout(timeout, settle(id, since)).await;
+}
+
+/// Poll until the daemon's output for this run stops growing.
+async fn settle(id: &DaemonId, since: chrono::DateTime<chrono::Local>) {
     const POLL: std::time::Duration = std::time::Duration::from_millis(20);
     // Returning at the first row would report a daemon's first line while the
     // rest of its output was still batched in the sink, so keep going until
     // nothing new has arrived for a moment.
     const SETTLED_FOR: std::time::Duration = std::time::Duration::from_millis(80);
 
-    let deadline = tokio::time::Instant::now() + timeout;
-    let mut seen = 0usize;
+    let mut newest: Option<i64> = None;
     let mut last_change = tokio::time::Instant::now();
 
     loop {
-        let query = crate::log_store::LogQuery {
-            daemon_ids: vec![id.qualified()],
-            from: Some(since),
-            ..Default::default()
-        };
-        let found = tokio::task::spawn_blocking(move || {
-            crate::log_store::sqlite::LOG_STORE
-                .query(&query)
-                .map(|entries| entries.len())
-                .unwrap_or(0)
-        })
-        .await
-        .unwrap_or(0);
-
-        let now = tokio::time::Instant::now();
-        if found > seen {
-            seen = found;
-            last_change = now;
-        }
-        let settled = seen > 0 && now.duration_since(last_change) >= SETTLED_FOR;
-        if settled || now >= deadline {
-            return;
+        match newest_entry_id(id, since).await {
+            Ok(latest) if latest != newest && latest.is_some() => {
+                newest = latest;
+                last_change = tokio::time::Instant::now();
+            }
+            Ok(_) => {
+                if newest.is_some() && last_change.elapsed() >= SETTLED_FOR {
+                    return;
+                }
+            }
+            Err(e) => {
+                // An unreadable store says nothing about whether the sink has
+                // finished writing, so do not mistake it for a settled stream —
+                // keep polling and let the caller's timeout end the wait.
+                debug!("could not check {id}'s captured output: {e}");
+            }
         }
         tokio::time::sleep(POLL).await;
     }
+}
+
+/// Id of the most recent entry for `id` since `since`, if any.
+///
+/// Deliberately fetches one row rather than counting: polling every few
+/// milliseconds while a chatty daemon logs would otherwise materialize its whole
+/// history each time.
+async fn newest_entry_id(
+    id: &DaemonId,
+    since: chrono::DateTime<chrono::Local>,
+) -> Result<Option<i64>> {
+    let query = crate::log_store::LogQuery {
+        daemon_ids: vec![id.qualified()],
+        from: Some(since),
+        limit: Some(1),
+        order_desc: true,
+        ..Default::default()
+    };
+    tokio::task::spawn_blocking(move || {
+        crate::log_store::sqlite::LOG_STORE
+            .query(&query)
+            .map(|entries| entries.first().map(|entry| entry.id))
+    })
+    .await
+    .map_err(|e| miette::miette!("log store check did not run: {e}"))?
 }
 
 /// Terminate and reap a sink that was started for a daemon which then failed to
@@ -192,12 +223,14 @@ impl SinkPipe {
                 // task owns the retained read end, and giving up would leave the
                 // pipe with no reader, blocking the daemon once it filled and
                 // killing it with SIGPIPE once the sink's own end went too.
+                let mut delay = SPAWN_RETRY_DELAY;
                 child = loop {
                     match self.spawn(&id) {
                         Ok(child) => break child,
                         Err(e) => {
-                            error!("failed to start log sink for {id}: {e}; retrying");
-                            tokio::time::sleep(SPAWN_RETRY_DELAY).await;
+                            error!("failed to start log sink for {id}: {e}; retrying in {delay:?}");
+                            tokio::time::sleep(delay).await;
+                            delay = (delay * 2).min(SPAWN_RETRY_MAX_DELAY);
                             if !SUPERVISOR.monitor_token_valid(&id, token) {
                                 return;
                             }

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -176,10 +176,13 @@ impl PendingSink {
 impl Drop for PendingSink {
     fn drop(&mut self) {
         if let Some(mut child) = self.0.take() {
-            // Drop cannot await, so finish the kill on a task.
-            tokio::spawn(async move {
-                let _ = child.kill().await;
-            });
+            // Signal synchronously rather than spawning the kill: dropping can
+            // happen while the runtime is going away, and `tokio::spawn` panics
+            // with no runtime to spawn onto — or silently abandons the task if
+            // shutdown has already begun. `start_kill` needs neither, so the
+            // signal is always delivered; collecting the exit status is left to
+            // tokio's orphan reaping, since a destructor cannot await.
+            let _ = child.start_kill();
         }
     }
 }

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -67,7 +67,11 @@ const SPAWN_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1)
 ///
 /// A daemon that failed without printing anything has nothing to wait for and
 /// pays the full timeout, which is why it is short.
-pub(crate) async fn wait_for_output(id: &DaemonId, since: chrono::DateTime<chrono::Local>, timeout: std::time::Duration) {
+pub(crate) async fn wait_for_output(
+    id: &DaemonId,
+    since: chrono::DateTime<chrono::Local>,
+    timeout: std::time::Duration,
+) {
     const POLL: std::time::Duration = std::time::Duration::from_millis(20);
     let deadline = tokio::time::Instant::now() + timeout;
     loop {

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -147,11 +147,40 @@ async fn newest_entry_id(
     .map_err(|e| miette::miette!("log store check did not run: {e}"))?
 }
 
-/// Terminate and reap a sink that was started for a daemon which then failed to
-/// start, so it cannot linger as a zombie.
-pub(crate) async fn reap(child: Option<tokio::process::Child>) {
-    if let Some(mut child) = child {
-        let _ = child.kill().await;
+/// Holds a sink that has been started but not yet handed to `supervise`, and
+/// terminates it if that never happens.
+///
+/// `run_once` can bail out at several points between starting the sink and
+/// taking charge of it — the daemon's stdio failing to wire up, its spawn
+/// failing, its PID being unreadable — and each one would otherwise leave a sink
+/// running with nothing writing to it. Tying cleanup to the value's lifetime
+/// covers those paths, and any added later, without each having to remember.
+pub(crate) struct PendingSink(Option<tokio::process::Child>);
+
+impl PendingSink {
+    pub(crate) fn new(child: tokio::process::Child) -> Self {
+        Self(Some(child))
+    }
+
+    /// Give up ownership, for handing the sink to `supervise`.
+    pub(crate) fn take(&mut self) -> Option<tokio::process::Child> {
+        self.0.take()
+    }
+
+    /// Whether a sink is still held.
+    pub(crate) fn is_some(&self) -> bool {
+        self.0.is_some()
+    }
+}
+
+impl Drop for PendingSink {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            // Drop cannot await, so finish the kill on a task.
+            tokio::spawn(async move {
+                let _ = child.kill().await;
+            });
+        }
     }
 }
 

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -14,6 +14,18 @@
 //! sink that dies cannot leave the pipe readerless and kill the daemon, and the
 //! replacement sink can be handed the very same pipe. It deliberately keeps no
 //! write end, which would stop the sink from ever seeing end of file.
+//!
+//! Both descriptors belong to one pipe carrying stdout and stderr together,
+//! matching what the in-process path did (it merged both into a single channel)
+//! and what runit does. Writes up to `PIPE_BUF` are atomic, so a daemon writing
+//! a line per `write` cannot interleave the two streams mid-line.
+//!
+//! Known gap: a daemon adopted after a supervisor crash keeps the sink it
+//! already had, and its logging continues, but the new supervisor holds no
+//! retained read end and runs no replacement loop for it. A sink that dies
+//! after adoption is therefore not replaced, and the daemon will take SIGPIPE
+//! on its next write. Recovering a read end from `/proc/<pid>/fd/1` would close
+//! this on Linux.
 
 use crate::Result;
 use crate::daemon::RunOptions;

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -1,0 +1,140 @@
+//! Out-of-process capture of a daemon's output.
+//!
+//! The supervisor used to hold the read end of every daemon's output pipe,
+//! which put it in the data path: killing it left the pipe with no reader, so
+//! the daemon's next write took `SIGPIPE` and the daemon usually died with it.
+//! Anything it had written but the supervisor had not yet read was lost too.
+//!
+//! Instead a sibling process — `pitchfork log-sink`, this binary re-executed —
+//! holds the read end and writes to the log store, so a supervisor crash is
+//! invisible to logging. This is the arrangement runit uses, where `runsv`
+//! starts a service alongside its own log service and stays out of the stream.
+//!
+//! The supervisor keeps a spare *read* end open. That serves two purposes: a
+//! sink that dies cannot leave the pipe readerless and kill the daemon, and the
+//! replacement sink can be handed the very same pipe. It deliberately keeps no
+//! write end, which would stop the sink from ever seeing end of file.
+
+use crate::Result;
+use crate::daemon::RunOptions;
+use crate::daemon_id::DaemonId;
+use crate::supervisor::SUPERVISOR;
+use miette::IntoDiagnostic;
+use std::io::PipeReader;
+
+/// Whether `opts` describes a daemon whose output can be captured by a sink.
+///
+/// Excluded for now, both because the supervisor itself has to read the stream
+/// to serve them:
+///
+/// - `ready_output`, which decides readiness by matching output
+/// - an `on_output` hook, which fires per matching line
+///
+/// and PTY daemons, whose output arrives on a terminal master rather than a
+/// pipe. Those keep the in-process path, so they remain vulnerable to a
+/// supervisor crash until the sink learns to evaluate them and report matches
+/// back.
+pub(crate) fn is_supported(opts: &RunOptions) -> bool {
+    opts.ready_output.is_none() && opts.on_output_hook.is_none() && !opts.pty.unwrap_or(false)
+}
+
+/// Resolves once a sink has read its pipe to end of file and written what it
+/// read. Used to order start-failure diagnostics after the sink's final write,
+/// which the in-process capture path guaranteed by flushing synchronously.
+pub(crate) struct Drained(tokio::sync::oneshot::Receiver<()>);
+
+impl Drained {
+    /// Wait for the final write, giving up after `timeout` so a daemon whose
+    /// descendants still hold the pipe open cannot stall the caller.
+    pub(crate) async fn wait(self, timeout: std::time::Duration) {
+        let _ = tokio::time::timeout(timeout, self.0).await;
+    }
+}
+
+/// The read end the supervisor retains so it can respawn a sink.
+pub(crate) struct SinkPipe {
+    reader: PipeReader,
+    log_format: String,
+}
+
+impl SinkPipe {
+    /// Create the pipe a daemon will write to, returning the retained read end
+    /// and the write end to hand the daemon.
+    pub(crate) fn new(log_format: String) -> Result<(Self, std::io::PipeWriter)> {
+        let (reader, writer) = std::io::pipe().into_diagnostic()?;
+        Ok((Self { reader, log_format }, writer))
+    }
+
+    /// Start a sink on this pipe and keep one running for as long as the daemon
+    /// identified by `token` is being monitored.
+    ///
+    /// A sink that exits while the daemon is still supervised is replaced: it
+    /// would otherwise stop draining, and the daemon would block once the pipe
+    /// filled. This mirrors `runsv` restarting a service's log service.
+    ///
+    /// The returned `Drained` resolves once a sink has read to end of file and
+    /// written what it had, which is what start-failure diagnostics wait for
+    /// before querying the log store.
+    pub(crate) fn supervise(self, id: DaemonId, token: u64) -> Drained {
+        let (drained_tx, drained_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let mut drained_tx = Some(drained_tx);
+            loop {
+                if !SUPERVISOR.monitor_token_valid(&id, token) {
+                    break;
+                }
+                let child = match self.spawn(&id) {
+                    Ok(child) => child,
+                    Err(e) => {
+                        error!("failed to start log sink for {id}: {e}");
+                        break;
+                    }
+                };
+                match child.wait_with_output().await {
+                    Ok(out) if out.status.success() => {
+                        // A clean exit means end of file: the daemon and every
+                        // descendant closed the pipe, so there is nothing left
+                        // to capture, and everything read has been written.
+                        debug!("log sink for {id} finished");
+                        if let Some(tx) = drained_tx.take() {
+                            let _ = tx.send(());
+                        }
+                        break;
+                    }
+                    Ok(out) => {
+                        if !SUPERVISOR.monitor_token_valid(&id, token) {
+                            break;
+                        }
+                        warn!(
+                            "log sink for {id} exited unexpectedly ({}); restarting it",
+                            out.status
+                        );
+                    }
+                    Err(e) => {
+                        if !SUPERVISOR.monitor_token_valid(&id, token) {
+                            break;
+                        }
+                        warn!("lost track of the log sink for {id}: {e}; restarting it");
+                    }
+                }
+            }
+        });
+        Drained(drained_rx)
+    }
+
+    /// Spawn one sink process reading a duplicate of the retained read end.
+    fn spawn(&self, id: &DaemonId) -> Result<tokio::process::Child> {
+        let reader = self.reader.try_clone().into_diagnostic()?;
+        tokio::process::Command::new(&*crate::env::PITCHFORK_BIN)
+            .arg("log-sink")
+            .arg("--daemon-id")
+            .arg(id.qualified())
+            .arg("--log-format")
+            .arg(&self.log_format)
+            .stdin(std::process::Stdio::from(reader))
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .into_diagnostic()
+    }
+}

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -38,16 +38,27 @@ pub(crate) fn is_supported(opts: &RunOptions) -> bool {
     opts.ready_output.is_none() && opts.on_output_hook.is_none() && !opts.pty.unwrap_or(false)
 }
 
+/// How long to wait before trying again when a sink process cannot be spawned.
+const SPAWN_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Resolves once a sink has read its pipe to end of file and written what it
-/// read. Used to order start-failure diagnostics after the sink's final write,
-/// which the in-process capture path guaranteed by flushing synchronously.
-pub(crate) struct Drained(tokio::sync::oneshot::Receiver<()>);
+/// read.
+///
+/// The in-process capture path awaited a synchronous flush before signalling
+/// readiness and again before finalizing a daemon's exit, so anything the
+/// daemon printed was queryable by the time its status changed. Waiting on this
+/// restores that ordering, which both the exit path and start-failure
+/// diagnostics depend on — hence a `watch` rather than a oneshot, so several
+/// waiters can observe it, including any that arrive after it has fired.
+#[derive(Clone)]
+pub(crate) struct Drained(tokio::sync::watch::Receiver<bool>);
 
 impl Drained {
     /// Wait for the final write, giving up after `timeout` so a daemon whose
     /// descendants still hold the pipe open cannot stall the caller.
-    pub(crate) async fn wait(self, timeout: std::time::Duration) {
-        let _ = tokio::time::timeout(timeout, self.0).await;
+    pub(crate) async fn wait(&self, timeout: std::time::Duration) {
+        let mut rx = self.0.clone();
+        let _ = tokio::time::timeout(timeout, rx.wait_for(|drained| *drained)).await;
     }
 }
 
@@ -76,9 +87,8 @@ impl SinkPipe {
     /// written what it had, which is what start-failure diagnostics wait for
     /// before querying the log store.
     pub(crate) fn supervise(self, id: DaemonId, token: u64) -> Drained {
-        let (drained_tx, drained_rx) = tokio::sync::oneshot::channel();
+        let (drained_tx, drained_rx) = tokio::sync::watch::channel(false);
         tokio::spawn(async move {
-            let mut drained_tx = Some(drained_tx);
             loop {
                 if !SUPERVISOR.monitor_token_valid(&id, token) {
                     break;
@@ -86,8 +96,14 @@ impl SinkPipe {
                 let child = match self.spawn(&id) {
                     Ok(child) => child,
                     Err(e) => {
-                        error!("failed to start log sink for {id}: {e}");
-                        break;
+                        // Do not give up while the daemon is still running: this
+                        // task owns the retained read end, and dropping it would
+                        // leave the pipe with no reader at all, blocking the
+                        // daemon once it fills and killing it with SIGPIPE once
+                        // the sink's own end goes too.
+                        error!("failed to start log sink for {id}: {e}; retrying");
+                        tokio::time::sleep(SPAWN_RETRY_DELAY).await;
+                        continue;
                     }
                 };
                 match child.wait_with_output().await {
@@ -96,9 +112,7 @@ impl SinkPipe {
                         // descendant closed the pipe, so there is nothing left
                         // to capture, and everything read has been written.
                         debug!("log sink for {id} finished");
-                        if let Some(tx) = drained_tx.take() {
-                            let _ = tx.send(());
-                        }
+                        let _ = drained_tx.send(true);
                         break;
                     }
                     Ok(out) => {

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -30,6 +30,7 @@
 use crate::Result;
 use crate::daemon::RunOptions;
 use crate::daemon_id::DaemonId;
+use crate::log_store::LogStore;
 use crate::supervisor::SUPERVISOR;
 use miette::IntoDiagnostic;
 use std::io::PipeReader;
@@ -53,24 +54,41 @@ pub(crate) fn is_supported(opts: &RunOptions) -> bool {
 /// How long to wait before trying again when a sink process cannot be spawned.
 const SPAWN_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
 
-/// Resolves once a sink has read its pipe to end of file and written what it
-/// read.
+/// Wait until a daemon's output from this run is queryable, or `timeout`
+/// elapses.
 ///
-/// The in-process capture path awaited a synchronous flush before signalling
-/// readiness and again before finalizing a daemon's exit, so anything the
-/// daemon printed was queryable by the time its status changed. Waiting on this
-/// restores that ordering, which both the exit path and start-failure
-/// diagnostics depend on — hence a `watch` rather than a oneshot, so several
-/// waiters can observe it, including any that arrive after it has fired.
-#[derive(Clone)]
-pub(crate) struct Drained(tokio::sync::watch::Receiver<bool>);
-
-impl Drained {
-    /// Wait for the final write, giving up after `timeout` so a daemon whose
-    /// descendants still hold the pipe open cannot stall the caller.
-    pub(crate) async fn wait(&self, timeout: std::time::Duration) {
-        let mut rx = self.0.clone();
-        let _ = tokio::time::timeout(timeout, rx.wait_for(|drained| *drained)).await;
+/// A failed start is reported by querying the log store, and the in-process
+/// capture path made that safe by flushing synchronously before signalling.
+/// With a sink there is a short gap instead: the daemon can exit before its
+/// output has been written. Waiting for the *sink process* to exit would be far
+/// more patient than necessary — it also pays for process startup and opening
+/// the store, hundreds of milliseconds, where the write itself lands in a few
+/// dozen. So wait for the data.
+///
+/// A daemon that failed without printing anything has nothing to wait for and
+/// pays the full timeout, which is why it is short.
+pub(crate) async fn wait_for_output(id: &DaemonId, since: chrono::DateTime<chrono::Local>, timeout: std::time::Duration) {
+    const POLL: std::time::Duration = std::time::Duration::from_millis(20);
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let query = crate::log_store::LogQuery {
+            daemon_ids: vec![id.qualified()],
+            from: Some(since),
+            limit: Some(1),
+            ..Default::default()
+        };
+        let found = tokio::task::spawn_blocking(move || {
+            crate::log_store::sqlite::LOG_STORE
+                .query(&query)
+                .map(|entries| !entries.is_empty())
+                .unwrap_or(false)
+        })
+        .await
+        .unwrap_or(false);
+        if found || tokio::time::Instant::now() >= deadline {
+            return;
+        }
+        tokio::time::sleep(POLL).await;
     }
 }
 
@@ -88,43 +106,37 @@ impl SinkPipe {
         Ok((Self { reader, log_format }, writer))
     }
 
-    /// Start a sink on this pipe and keep one running for as long as the daemon
-    /// identified by `token` is being monitored.
+    /// Start the first sink on this pipe.
+    ///
+    /// Called before the daemon is spawned so the reader is already running by
+    /// the time output appears — and, more importantly, so a daemon that exits
+    /// immediately does not have to wait for a sink to start before its output
+    /// can be written and reported.
+    pub(crate) fn start(&self, id: &DaemonId) -> Result<tokio::process::Child> {
+        self.spawn(id)
+    }
+
+    /// Keep a sink running for as long as the daemon identified by `token` is
+    /// being monitored, beginning with `first` — the process `start` returned.
     ///
     /// A sink that exits while the daemon is still supervised is replaced: it
     /// would otherwise stop draining, and the daemon would block once the pipe
     /// filled. This mirrors `runsv` restarting a service's log service.
-    ///
-    /// The returned `Drained` resolves once a sink has read to end of file and
-    /// written what it had, which is what start-failure diagnostics wait for
-    /// before querying the log store.
-    pub(crate) fn supervise(self, id: DaemonId, token: u64) -> Drained {
-        let (drained_tx, drained_rx) = tokio::sync::watch::channel(false);
+    pub(crate) fn supervise(self, id: DaemonId, token: u64, first: tokio::process::Child) {
         tokio::spawn(async move {
+            let mut child = first;
             loop {
-                if !SUPERVISOR.monitor_token_valid(&id, token) {
-                    break;
-                }
-                let child = match self.spawn(&id) {
-                    Ok(child) => child,
-                    Err(e) => {
-                        // Do not give up while the daemon is still running: this
-                        // task owns the retained read end, and dropping it would
-                        // leave the pipe with no reader at all, blocking the
-                        // daemon once it fills and killing it with SIGPIPE once
-                        // the sink's own end goes too.
-                        error!("failed to start log sink for {id}: {e}; retrying");
-                        tokio::time::sleep(SPAWN_RETRY_DELAY).await;
-                        continue;
-                    }
-                };
+                // Always wait on the sink already in hand before consulting the
+                // registry: a daemon that exits immediately drops its monitor
+                // entry before this task first runs, and checking the token
+                // first would abandon the sink without ever reporting that it
+                // had drained.
                 match child.wait_with_output().await {
                     Ok(out) if out.status.success() => {
                         // A clean exit means end of file: the daemon and every
                         // descendant closed the pipe, so there is nothing left
                         // to capture, and everything read has been written.
                         debug!("log sink for {id} finished");
-                        let _ = drained_tx.send(true);
                         break;
                     }
                     Ok(out) => {
@@ -143,9 +155,25 @@ impl SinkPipe {
                         warn!("lost track of the log sink for {id}: {e}; restarting it");
                     }
                 }
+
+                // Replace it. Keep trying while the daemon is monitored: this
+                // task owns the retained read end, and giving up would leave the
+                // pipe with no reader, blocking the daemon once it filled and
+                // killing it with SIGPIPE once the sink's own end went too.
+                child = loop {
+                    match self.spawn(&id) {
+                        Ok(child) => break child,
+                        Err(e) => {
+                            error!("failed to start log sink for {id}: {e}; retrying");
+                            tokio::time::sleep(SPAWN_RETRY_DELAY).await;
+                            if !SUPERVISOR.monitor_token_valid(&id, token) {
+                                return;
+                            }
+                        }
+                    }
+                };
             }
         });
-        Drained(drained_rx)
     }
 
     /// Spawn one sink process reading a duplicate of the retained read end.

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -4,6 +4,7 @@
 //! - `state`: State access layer (get/set operations)
 //! - `lifecycle`: Daemon start/stop operations
 //! - `adopt`: Re-adoption of orphaned daemons after a supervisor crash
+//! - `log_sink`: Out-of-process capture of daemon output
 //! - `autostop`: Autostop logic and boot daemon startup
 //! - `retry`: Retry logic with backoff
 //! - `watchers`: Background tasks (interval, cron, file watching)
@@ -14,6 +15,7 @@ mod autostop;
 mod hooks;
 mod ipc_handlers;
 mod lifecycle;
+mod log_sink;
 #[cfg(unix)]
 mod pty;
 mod retry;

--- a/test/logs.bats
+++ b/test/logs.bats
@@ -544,3 +544,110 @@ EOF
 # started a web supervisor and consumed the SSE `/logs/project%2Fsse_connect/stream`
 # endpoint. Converting it reliably to bash requires backgrounding the supervisor,
 # parsing a dynamic port, and timing SSE chunks with curl. Skipping for now.
+
+# ============================================================================
+# Out-of-process capture (log sink)
+# ============================================================================
+
+@test "log capture survives a supervisor crash" {
+  skip_on_windows "relies on SIGKILL semantics for the supervisor"
+
+  # No SIGPIPE guard in the daemon: the whole point is that a plain writer
+  # survives losing its supervisor, because the sink still holds the pipe.
+  create_pitchfork_toml <<EOF
+[daemons.crashlog]
+run = "i=0; while true; do i=\$((i+1)); echo crashlog-\$i; sleep 0.3; done"
+ready_delay = 1
+EOF
+
+  run pitchfork start crashlog
+  assert_success
+  wait_for_logs crashlog "crashlog-"
+
+  local daemon_pid sup_pid before
+  daemon_pid="$(get_daemon_pid crashlog)"
+  sup_pid="$(grep -A 10 '\[daemons\."global/pitchfork"\]' "$PITCHFORK_STATE_DIR/state.toml" |
+    grep -E '^pid = ' | head -1 | sed -E 's/.*= //')"
+  [[ -n "$daemon_pid" && -n "$sup_pid" ]]
+  before="$(read_logs crashlog | grep -c "crashlog-")"
+
+  kill_pid "$sup_pid"
+  sleep 3
+
+  # The daemon outlives its supervisor, and its output keeps being recorded
+  # even though no supervisor exists to record it.
+  pid_alive "$daemon_pid"
+  local after
+  after="$(read_logs crashlog | grep -c "crashlog-")"
+  [[ "$after" -gt "$before" ]] || {
+    echo "capture stopped at the crash: before=$before after=$after" >&2
+    return 1
+  }
+
+  kill_pid "$daemon_pid"
+}
+
+@test "a log sink that dies is replaced" {
+  skip_on_windows "relies on SIGKILL semantics and pgrep"
+
+  create_pitchfork_toml <<EOF
+[daemons.sinkdies]
+run = "i=0; while true; do i=\$((i+1)); echo sinkdies-\$i; sleep 0.3; done"
+ready_delay = 1
+EOF
+
+  run pitchfork start sinkdies
+  assert_success
+  wait_for_logs sinkdies "sinkdies-"
+
+  local daemon_pid first
+  daemon_pid="$(get_daemon_pid sinkdies)"
+  first="$(pgrep -f "log-sink --daemon-id .*/sinkdies" | head -1)"
+  [[ -n "$first" ]] || {
+    echo "no sink process found for the daemon" >&2
+    return 1
+  }
+
+  kill_pid "$first"
+
+  # A replacement must take over, or the pipe would fill and block the daemon.
+  local second=""
+  for _ in $(seq 1 50); do
+    second="$(pgrep -f "log-sink --daemon-id .*/sinkdies" | head -1)"
+    [[ -n "$second" && "$second" != "$first" ]] && break
+    sleep 0.2
+  done
+  [[ -n "$second" && "$second" != "$first" ]] || {
+    echo "sink was not replaced (was $first, now ${second:-none})" >&2
+    return 1
+  }
+  pid_alive "$daemon_pid"
+
+  # And capture resumes through the replacement.
+  local before after
+  before="$(read_logs sinkdies | grep -c "sinkdies-")"
+  for _ in $(seq 1 50); do
+    after="$(read_logs sinkdies | grep -c "sinkdies-")"
+    [[ "$after" -gt "$before" ]] && break
+    sleep 0.2
+  done
+  [[ "$after" -gt "$before" ]] || {
+    echo "capture did not resume: before=$before after=$after" >&2
+    return 1
+  }
+
+  pitchfork stop sinkdies
+}
+
+@test "start failure diagnostics include the daemon's output" {
+  # collect_startup_logs reads the log store, so a failed start must not report
+  # before the sink has written what the daemon printed.
+  create_pitchfork_toml <<EOF
+[daemons.diagfail]
+run = "echo diagnostic-marker; exit 3"
+ready_delay = 5
+EOF
+
+  run pitchfork start diagfail
+  assert_output --partial "diagnostic-marker"
+}


### PR DESCRIPTION
## The problem

The supervisor held the read end of every daemon's output pipe, which put it in the data path. Kill it and the pipe has no reader, so the daemon's **next write takes SIGPIPE and the daemon usually dies with it**. I confirmed this directly before writing any code — a plain `echo` loop was gone within seconds of its supervisor being killed:

```
>>> SIGKILL the supervisor
  -> daemon DIED (SIGPIPE on stdout write)
```

That undermines the re-adoption added in #633: a daemon that logs to stdout rarely survives long enough to *be* adopted. Anything it had written but the supervisor had not yet read was lost too.

## The change

Capture moves to a sibling process — `pitchfork log-sink`, this binary re-executed — which holds the read end and writes to the log store. A supervisor crash becomes invisible to logging: the daemon keeps writing, the sink keeps recording, nothing is dropped. This is the arrangement [runit](https://smarden.org/runit/runsv.8.html) uses, where `runsv` "creates a pipe, redirects _service_/run's standard output to the pipe" and starts a separate log service on the other end, staying out of the stream itself.

The supervisor retains a spare **read** end. That does two things: a sink that dies cannot leave the pipe readerless and kill the daemon, and its replacement can be handed the same pipe. It deliberately keeps no *write* end, which would stop the sink from ever seeing end of file. A sink that exits while its daemon is still monitored is replaced (mirroring `runsv` restarting a log service); one that exits cleanly has reached EOF and is not.

## A regression this introduced, and the fix

Failed starts report what the daemon printed by querying the log store, and the in-process path guaranteed the ordering by flushing synchronously before signalling — `lifecycle.rs` even comments that this is "so collect_startup_logs sees the line". The sink broke that: output reached the store but not the user, losing exactly the diagnostics you need when a daemon won't start.

Restored by having the failure path wait for the sink's final write, bounded at 2s so a daemon whose descendants hold the pipe open cannot stall the caller. This was only caught by chasing the question directly — the existing suite passed 295/295 without noticing, and there's now a test for it.

## Scope

Daemons using `ready_output`, an `on_output` hook, or `pty = true` keep the in-process path, because the supervisor itself has to read the stream to serve them, and so remain crash-vulnerable. Teaching the sink to evaluate those and report matches back over IPC is a follow-up — it is a larger change and better reviewed on its own.

## Tests

Three new tests in `logs.bats`, each verified to fail without the corresponding behavior:

- `log capture survives a supervisor crash` — the daemon is a plain `echo` loop with **no `trap '' PIPE`**. My pre-change reproduction needed that guard to survive at all; not needing it is the clearest demonstration of the fix.
- `a log sink that dies is replaced` — SIGKILL the sink; a different pid takes over, the daemon is unaffected, capture resumes.
- `start failure diagnostics include the daemon's output` — guards the ordering above.

Also verified by hand: capture continued across a supervisor SIGKILL (+14 lines written while no supervisor existed), and a killed sink was replaced with capture resuming.

523/523 unit tests, clippy clean under `-D warnings`, 55/55 log suites, 56/56 `basic` + `hooks`. Full suite still running locally as I open this; CI covers it including Windows.

Builds on #660, which fixed the concurrent-open failure this design would otherwise hit with several writers on one store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core supervisor lifecycle, process/pipe wiring, and shared SQLite log writes; failures could affect daemon startup, log durability, or backpressure behavior, though fallbacks and bounded waits limit blast radius.
> 
> **Overview**
> Moves daemon stdout/stderr capture out of the supervisor into a re-execed sibling **`pitchfork log-sink`** process, so a supervisor crash no longer drops the pipe reader (avoiding **SIGPIPE** and lost logs). The supervisor keeps a spare read end, wires eligible daemons to the pipe before spawn, and **restarts** sinks that exit unexpectedly while the daemon is still monitored; **`ready_output`**, **`on_output`**, and **PTY** daemons still use in-process capture.
> 
> The hidden **`log-sink`** CLI reads stdin asynchronously, batches parsed lines into SQLite, and documents **`--log-format`**. SQLite open now sets an explicit **`busy_timeout`**, enables WAL with a tolerant race handler, and adds contention tests. Failed starts **wait briefly** for sink output to land in the store so startup diagnostics stay visible; orphan-adoption docs note logging continues across supervisor restarts.
> 
> New **`logs.bats`** coverage exercises capture across supervisor SIGKILL, sink replacement, and failure diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd964867923073af53b8c760615c2582784ff71b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added out-of-process log capture via a hidden `log-sink` command to keep daemon stdout/stderr logs recording across supervisor crashes and restarts.
  * Log capture continues automatically if the sink process restarts.
  * Added `--log-format` selection for captured logs (`text`, `json`, `logfmt`, `auto`).
* **Bug Fixes**
  * Improved SQLite concurrency handling to prevent lost log entries under contention.
  * Ensures queued logs are flushed when streams close and preserves daemon start diagnostics on failure.
* **Documentation**
  * Updated orphan adoption documentation to clarify stdout/stderr capture behavior after supervisor crashes.
* **Tests**
  * Added end-to-end log-sink coverage and additional SQLite contention tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->