### PR TITLE
chore: release v2.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.19.0](https://github.com/jdx/pitchfork/compare/v2.18.0...v2.19.0) - 2026-07-25
+
+### Added
+
+- *(logs)* capture daemon output in a sibling process ([#661](https://github.com/jdx/pitchfork/pull/661))
+
 ## [2.18.0](https://github.com/jdx/pitchfork/compare/v2.17.0...v2.18.0) - 2026-07-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3029,7 +3029,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.18.0"
+version = "2.19.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.18.0"
+version = "2.19.0"
 edition = "2024"
 rust-version = "1.88"
 homepage = "https://pitchfork.jdx.dev"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3034,7 +3034,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.18.0",
+  "version": "2.19.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.18.0
+**Version**: 2.19.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,6 +1,6 @@
 name pitchfork
 bin pitchfork
-version "2.18.0"
+version "2.19.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" {

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -603,7 +603,7 @@ impl Supervisor {
                 // its way to end of file: let it finish writing before reporting,
                 // then reap whatever is left of it.
                 if sink_child.is_some() {
-                    super::log_sink::wait_for_output(&id, spawn_time, SINK_OUTPUT_TIMEOUT).await;
+                    super::log_sink::wait_for_output(id, spawn_time, SINK_OUTPUT_TIMEOUT).await;
                 }
                 return Ok(IpcResponse::DaemonFailed {
                     error: "Process exited immediately".to_string(),


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.18.0 -> 2.19.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.19.0](https://github.com/jdx/pitchfork/compare/v2.18.0...v2.19.0) - 2026-07-25

### Added

- *(logs)* capture daemon output in a sibling process ([#661](https://github.com/jdx/pitchfork/pull/661))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly version and documentation updates; the code change is a one-line argument pass-through with no behavioral intent beyond compile/signature alignment.
> 
> **Overview**
> **Release v2.19.0** bumps `pitchfork-cli` from 2.18.0 to 2.19.0 across `Cargo.toml`, lockfile, usage spec, and generated CLI docs, and adds the **2.19.0** changelog entry.
> 
> The release highlights **daemon log capture in a sibling `log-sink` process** ([#661](https://github.com/jdx/pitchfork/pull/661)), so stdout/stderr can keep draining if the supervisor dies. The only runtime tweak in this diff is passing `id` by value into `log_sink::wait_for_output` when a daemon exits before its PID is captured, matching that helper’s signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0804c7b24b75bb2d74d560d24c01fbe1b751926f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->