### PR TITLE
test(cron): assert what a failing cron task actually does

### DIFF
--- a/test/cron.bats
+++ b/test/cron.bats
@@ -33,8 +33,10 @@ retrigger = "finish"
 immediate = true
 EOF
 
+  # The task fails immediately, so starting it reports failure. What this test
+  # is about is what the cron schedule does next.
   run pitchfork start cron_finish_fail
-  assert_success
+  assert_failure
 
   local count=0
   for _ in $(seq 1 65); do
@@ -64,8 +66,10 @@ retrigger = "always"
 immediate = true
 EOF
 
+  # The task fails immediately, so starting it reports failure. What this test
+  # is about is what the cron schedule does next.
   run pitchfork start cron_always_fail
-  assert_success
+  assert_failure
 
   local count=0
   for _ in $(seq 1 65); do
@@ -95,8 +99,10 @@ retrigger = "success"
 immediate = true
 EOF
 
+  # The task fails immediately, so starting it reports failure. What this test
+  # is about is what the cron schedule does next.
   run pitchfork start cron_success_fail
-  assert_success
+  assert_failure
 
   local count=0
   for _ in $(seq 1 65); do
@@ -126,8 +132,10 @@ retrigger = "fail"
 immediate = true
 EOF
 
+  # The task fails immediately, so starting it reports failure. What this test
+  # is about is what the cron schedule does next.
   run pitchfork start cron_fail_fail
-  assert_success
+  assert_failure
 
   local count=0
   for _ in $(seq 1 65); do
@@ -192,8 +200,10 @@ retrigger = "always"
 immediate = true
 EOF
 
+  # No assertion on the exit status: `retrigger = "always"` force-restarts the
+  # daemon every second, so it can be replaced while `start` is still waiting
+  # for it and either outcome is legitimate.
   run pitchfork start cron_always_long
-  assert_success
 
   local count=0
   for _ in $(seq 1 65); do


### PR DESCRIPTION
## What was wrong

All five slow cron tests have been failing on `main`. They are gated behind `RUN_SLOW`, so CI never runs them and nothing reported it — I found them while checking something unrelated and confirmed they still fail on v2.19.0.

**None of them is a product bug.** I checked that first, by removing the assertions and running the rest of each test: the retrigger behaviour they cover works correctly, including `retrigger = "always"` restarting a long-running daemon (14 restarts in a 20s window, cron firing every second as configured).

The tests were simply asserting the wrong thing. Each starts a daemon that is *meant* to fail:

```toml
run = 'bash "$fail_script" 0'    # prints, then exits 1
```

…and then asserts `pitchfork start` **succeeded**. It correctly does not — reporting the failure is exactly what start should do. So the assertion is now `assert_failure`, which is accurate and a stronger check than deleting it would be.

The long-running `always` case is different. That daemon is force-restarted every second, so it can be replaced while `start` is still waiting for it, and either exit status is legitimate. Asserting either way would be flaky, so it asserts neither, with a comment saying why.

## Result

`RUN_SLOW=1 bats test/cron.bats` now passes **13/13**; without the flag the tests skip exactly as before.

## Worth considering separately

The `RUN_SLOW` gate is why these rotted unnoticed, and cron retrigger has no CI coverage at all otherwise — this is a core feature (the reporter in #631 specifically called out `retrigger = "always"` as what they needed pitchfork for). Running them in CI costs roughly two to three minutes on one shard. I have left the gate alone here to keep this change to the fix, but it seems worth a follow-up either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to assertions and comments; no runtime or CLI behavior is modified.
> 
> **Overview**
> Fixes **slow cron retrigger tests** that were failing on `main` because they expected `pitchfork start` to succeed for daemons that exit immediately with failure.
> 
> For the four **failing-task** cases (`finish`, `always`, `success`, `fail`), assertions now use **`assert_failure`** on start, with comments clarifying that the test’s real check is still the log counts for cron retrigger behavior afterward.
> 
> For **`cron_always_long`** (`retrigger = "always"` on a long-running daemon), **`assert_success` is removed** so the test does not flake when cron force-restarts the daemon while `start` is still waiting; a comment documents why neither exit status is asserted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50a62855e6b1e0b264724ba35e96668ad52c4547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->