### PR TITLE
chore(ci): publish to crates.io with trusted publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,6 +21,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Lets this job mint the OIDC token that crates.io exchanges for a
+      # short-lived publish token; see the crates.io auth step below.
+      id-token: write
     outputs:
       tag: ${{ steps.release-plz.outputs.releases && fromJSON(steps.release-plz.outputs.releases)[0].tag || '' }}
     steps:
@@ -36,6 +39,13 @@ jobs:
         run: |
           aube install
           aube run build
+      # Exchanges this job's OIDC identity for a crates.io token that is valid
+      # for 30 minutes and scoped to this crate. The crate is configured on
+      # crates.io to accept publishes only from this workflow, so there is no
+      # long-lived registry token to leak or rotate.
+      - name: Authenticate to crates.io
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
@@ -43,7 +53,7 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
   upload-assets:
     name: Upload assets


### PR DESCRIPTION
## Why

Release-plz has failed on `main` twice since v2.19.0. The second failure names the cause exactly:

```
error: failed to publish pitchfork-cli v2.19.0 to registry at https://crates.io
  the remote server responded with an error (status 403 Forbidden): New versions of
  this crate can only be published using Trusted Publishing
  (see https://crates.io/docs/trusted-publishing).
```

The [first failure](https://github.com/jdx/pitchfork/actions/runs/30167320496/job/89702444926) returned the generic "API data access policy" 403 for the same reason. `secrets.CARGO_REGISTRY_TOKEN` can no longer publish this crate.

## What

The release job mints a crates.io token from its own OIDC identity instead of carrying a long-lived secret:

- `id-token: write` on `release-plz-release` so the job can request an OIDC token
- `rust-lang/crates-io-auth-action` (pinned to v1.0.5) exchanges it for a token that is scoped to this crate and expires in 30 minutes
- `CARGO_REGISTRY_TOKEN` comes from that step instead of `secrets.CARGO_REGISTRY_TOKEN`

Nothing else in the pipeline changes — release-plz still does the publish, tagging, and release creation.

## Checks worth making before merge

Trusted publishing only works if the crates.io side matches this workflow. On the `pitchfork-cli` crate's *Settings → Trusted Publishing*, the registered publisher must be:

| Field | Value |
|---|---|
| Repository owner | `jdx` |
| Repository name | `pitchfork` |
| Workflow filename | `release-plz.yml` |
| Environment | *(empty — this job doesn't declare one)* |

If an environment name is registered there, the job needs a matching `environment:` key or the token exchange is rejected.

## State this leaves behind

v2.19.0 is half-released: `main`'s Cargo.toml says `2.19.0`, but there is no `v2.19.0` tag, no GitHub release, and the crate was never published. Once this lands, the next push to `main` retries the whole release for 2.19.0 — no manual tagging needed.

`secrets.CARGO_REGISTRY_TOKEN` becomes unused and can be revoked whenever you like.

---
*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the only path that publishes to crates.io; misconfigured trusted publishing on crates.io would block releases until fixed, but scope is limited to CI credentials.
> 
> **Overview**
> **Fixes failed crates.io publishes** by switching the `release-plz-release` job from a long-lived `secrets.CARGO_REGISTRY_TOKEN` to **crates.io Trusted Publishing**.
> 
> The release job now requests **`id-token: write`**, runs **`rust-lang/crates-io-auth-action`** (pinned) to exchange the workflow’s OIDC identity for a short-lived registry token, and passes that token into **`CARGO_REGISTRY_TOKEN`** for release-plz. Release-plz, tagging, and asset upload behavior are unchanged.
> 
> **Operational note:** crates.io must list this repo/workflow (`release-plz.yml`, no environment) as a trusted publisher or the token exchange will fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91807ade603caeef78fb7cd743990b9828fe1f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->