### PR TITLE
fix(supervisor): require a start time to identify an orphaned process

### DIFF
--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -373,7 +373,7 @@ impl Supervisor {
         true
     }
 
-    async fn finalize_if_pid(
+    pub(super) async fn finalize_if_pid(
         &self,
         id: &DaemonId,
         pid: u32,

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -229,18 +229,14 @@ impl Supervisor {
             }
 
             let current_start_time = PROCS.start_time(pid);
-            let current_title = PROCS.title(pid);
-            let matches = super::process_identity_matches(
-                daemon.start_time,
-                daemon.title.as_deref(),
-                current_start_time,
-                current_title.as_deref(),
-            );
+            let matches = super::process_identity_matches(daemon.start_time, current_start_time);
 
             if !matches {
-                if daemon.start_time.is_some() && current_start_time.is_none() {
+                // Unverifiable is not the same as mismatched: retain the running
+                // state rather than recording a death that may not have happened.
+                if daemon.start_time.is_none() || current_start_time.is_none() {
                     warn!(
-                        "could not verify start time for live pid {pid} recorded for daemon {}; retaining running state",
+                        "could not verify the identity of live pid {pid} recorded for daemon {}; retaining running state",
                         daemon.id,
                     );
                     continue;

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -1613,6 +1613,30 @@ impl Supervisor {
             if let Some(pid) = daemon.pid {
                 trace!("killing pid: {pid}");
                 if PROCS.is_running(pid) {
+                    // Something is alive on that PID, but the kill below signals
+                    // the entire process group: if the PID was recycled while
+                    // this record sat unsupervised, that group belongs to an
+                    // unrelated process tree. The daemon itself is gone either
+                    // way, so report it as not running and clear the record.
+                    if !super::signalling_pid_is_authorized(
+                        daemon.start_time,
+                        PROCS.start_time(pid),
+                    ) {
+                        warn!(
+                            "pid {pid} recorded for daemon {id} belongs to another process now; not signalling it"
+                        );
+                        self.upsert_daemon(
+                            UpsertDaemonOpts::builder(id.clone())
+                                .set(|o| {
+                                    o.pid = None;
+                                    o.status = DaemonStatus::Stopped;
+                                })
+                                .build(),
+                        )
+                        .await?;
+                        return Ok(IpcResponse::DaemonWasNotRunning);
+                    }
+
                     // First set status to Stopping (preserve PID for monitoring task)
                     self.upsert_daemon(
                         UpsertDaemonOpts::builder(id.clone())

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1317,21 +1317,18 @@ async fn cleanup_orphaned_daemons(supervisor: &Supervisor) {
         // Safety check: verify the live process really is the daemon we
         // recorded, not an unrelated process that received a recycled PID.
         // The kernel start time is a stable identity for the lifetime of a
-        // process; fall back to comparing the process name for state files
-        // written by older versions that didn't record start_time.
+        // process, and is the only thing accepted as one.
         let current_start_time = PROCS.start_time(pid);
-        let current_title = PROCS.title(pid);
-        let matches = process_identity_matches(
-            daemon.start_time,
-            daemon.title.as_deref(),
-            current_start_time,
-            current_title.as_deref(),
-        );
+        let matches = process_identity_matches(daemon.start_time, current_start_time);
 
         if !matches {
-            if daemon.start_time.is_some() && current_start_time.is_none() {
+            // Either side missing means the identity cannot be checked at all,
+            // which is different from checking it and finding a stranger: retain
+            // the running state rather than resetting a record whose process may
+            // well still be the daemon.
+            if daemon.start_time.is_none() || current_start_time.is_none() {
                 warn!(
-                    "could not verify start time for live pid {pid} recorded for daemon {}; retaining running state",
+                    "could not verify the identity of live pid {pid} recorded for daemon {}; retaining running state",
                     daemon.id,
                 );
                 continue;
@@ -1426,20 +1423,19 @@ pub(crate) fn orphan_policy() -> String {
 
 /// Verify that live process identity matches the persisted daemon identity.
 ///
-/// A recorded start time takes precedence over the legacy title field. Missing
-/// current identity data must never authorize terminating a process.
+/// Both start times are required. A process name was once accepted in place of
+/// a recorded start time, for state written before start times existed, but a
+/// name is not an identity: a recycled PID belonging to another copy of the same
+/// program matches it, and adopting or killing on that basis acts on the wrong
+/// process. Missing identity, on either side, means unverifiable — and
+/// unverifiable must never authorize acting on a process.
 fn process_identity_matches(
     recorded_start_time: Option<u64>,
-    recorded_title: Option<&str>,
     current_start_time: Option<u64>,
-    current_title: Option<&str>,
 ) -> bool {
-    match recorded_start_time {
-        Some(recorded) => current_start_time == Some(recorded),
-        None => matches!(
-            (recorded_title, current_title),
-            (Some(recorded), Some(current)) if recorded == current
-        ),
+    match (recorded_start_time, current_start_time) {
+        (Some(recorded), Some(current)) => recorded == current,
+        _ => false,
     }
 }
 
@@ -1688,46 +1684,21 @@ mod tests {
     }
 
     #[test]
-    fn orphan_identity_does_not_match_when_current_identity_is_missing() {
-        assert!(!process_identity_matches(
-            Some(123),
-            Some("daemon"),
-            None,
-            None,
-        ));
-        assert!(!process_identity_matches(None, Some("daemon"), None, None,));
+    fn orphan_identity_requires_both_start_times() {
+        assert!(process_identity_matches(Some(123), Some(123)));
+        assert!(!process_identity_matches(Some(123), Some(456)));
+        // Unreadable current identity: unverifiable, so not a match.
+        assert!(!process_identity_matches(Some(123), None));
     }
 
     #[test]
-    fn orphan_identity_requires_recorded_start_time_when_available() {
-        assert!(process_identity_matches(
-            Some(123),
-            Some("old-title"),
-            Some(123),
-            Some("new-title"),
-        ));
-        assert!(!process_identity_matches(
-            Some(123),
-            Some("same-title"),
-            Some(456),
-            Some("same-title"),
-        ));
-    }
-
-    #[test]
-    fn orphan_identity_falls_back_to_title_for_legacy_state() {
-        assert!(process_identity_matches(
-            None,
-            Some("daemon"),
-            Some(123),
-            Some("daemon"),
-        ));
-        assert!(!process_identity_matches(
-            None,
-            Some("daemon"),
-            Some(123),
-            Some("unrelated"),
-        ));
+    fn orphan_identity_rejects_records_without_a_start_time() {
+        // State written before start times were recorded. A process name used
+        // to stand in here, but another copy of the same program on a recycled
+        // PID matches a name, so such records are no longer verifiable and must
+        // not authorize adopting or killing anything.
+        assert!(!process_identity_matches(None, Some(123)));
+        assert!(!process_identity_matches(None, None));
     }
 
     #[test]

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1439,6 +1439,29 @@ fn process_identity_matches(
     }
 }
 
+/// Whether a PID read from persisted state may be signalled.
+///
+/// Stopping a daemon signals its whole process *group*, so acting on a PID that
+/// has been recycled since it was recorded takes down an unrelated process tree.
+/// Records are refused only when their identity is positively contradicted: if
+/// either start time is unknown the PID stays as signallable as it was before
+/// identities were recorded, so a daemon whose record predates the field can
+/// still be stopped rather than becoming permanently unstoppable.
+///
+/// This is deliberately weaker than [`process_identity_matches`], which decides
+/// whether to adopt or kill a process nobody asked about. Here the user has
+/// named the daemon and asked for it to stop; the check exists to catch the
+/// case where the answer is provably the wrong process.
+pub(crate) fn signalling_pid_is_authorized(
+    recorded_start_time: Option<u64>,
+    current_start_time: Option<u64>,
+) -> bool {
+    !matches!(
+        (recorded_start_time, current_start_time),
+        (Some(recorded), Some(current)) if recorded != current
+    )
+}
+
 /// How a daemon's run ended, which decides what happens to the recorded
 /// `last_exit_success` that cron `retrigger = "success" | "fail"` reads.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1592,7 +1615,7 @@ fn chmod_recursive(dir: &std::path::Path) {
 mod tests {
     use super::{
         BOOT_TIME_TOLERANCE_SECS, process_identity_matches, should_remove_liveness_session,
-        unobserved_exit_status,
+        signalling_pid_is_authorized, unobserved_exit_status,
     };
     use crate::daemon_status::DaemonStatus;
     use crate::state_file::ProjectSession;
@@ -1689,6 +1712,20 @@ mod tests {
         assert!(!process_identity_matches(Some(123), Some(456)));
         // Unreadable current identity: unverifiable, so not a match.
         assert!(!process_identity_matches(Some(123), None));
+    }
+
+    #[test]
+    fn signalling_is_refused_only_for_a_contradicted_identity() {
+        // Provably someone else's process group: refuse.
+        assert!(!signalling_pid_is_authorized(Some(123), Some(456)));
+        // Verified as the daemon's own.
+        assert!(signalling_pid_is_authorized(Some(123), Some(123)));
+        // Unknown on either side. Stopping stays possible, because the user has
+        // named this daemon and a record that cannot be verified must not become
+        // one that can never be stopped.
+        assert!(signalling_pid_is_authorized(None, Some(123)));
+        assert!(signalling_pid_is_authorized(Some(123), None));
+        assert!(signalling_pid_is_authorized(None, None));
     }
 
     #[test]

--- a/src/supervisor/watchers.rs
+++ b/src/supervisor/watchers.rs
@@ -475,6 +475,18 @@ impl Supervisor {
             warn!(
                 "pid {pid} recorded for daemon {id} belongs to another process now; not killing it for a resource violation"
             );
+            // Leaving the record running would have the resource watcher
+            // measure the stranger's usage on every tick and try to kill it
+            // again each time. The daemon died unobserved, so record that —
+            // the same terminal state orphan reconciliation would reach, and
+            // one that keeps the daemon eligible for retry.
+            self.finalize_if_pid(
+                id,
+                pid,
+                DaemonStatus::Errored(-1),
+                super::ExitObservation::Unobserved,
+            )
+            .await;
             return;
         }
         let stop_cfg = daemon.and_then(|d| d.stop_signal).unwrap_or_default();

--- a/src/supervisor/watchers.rs
+++ b/src/supervisor/watchers.rs
@@ -467,11 +467,17 @@ impl Supervisor {
     /// the retry checker to restart the daemon if `retry` is configured.
     async fn stop_for_resource_violation(&self, id: &DaemonId, pid: u32) {
         info!("killing daemon {id} (pid {pid}) due to resource limit violation");
-        let stop_cfg = self
-            .get_daemon(id)
-            .await
-            .and_then(|d| d.stop_signal)
-            .unwrap_or_default();
+        let daemon = self.get_daemon(id).await;
+        // Never signal a process group that provably isn't the daemon's: a
+        // recycled PID would mean measuring one process tree and killing another.
+        let recorded_start_time = daemon.as_ref().and_then(|d| d.start_time);
+        if !super::signalling_pid_is_authorized(recorded_start_time, PROCS.start_time(pid)) {
+            warn!(
+                "pid {pid} recorded for daemon {id} belongs to another process now; not killing it for a resource violation"
+            );
+            return;
+        }
+        let stop_cfg = daemon.and_then(|d| d.stop_signal).unwrap_or_default();
         let stop_signal: i32 = stop_cfg.signal.into();
         if let Err(e) = PROCS
             .kill_process_group_async(pid, stop_signal, stop_cfg.timeout)

--- a/test/supervisor.bats
+++ b/test/supervisor.bats
@@ -259,6 +259,57 @@ EOF
   { kill -9 "$bystander_pid" && wait "$bystander_pid"; } 2>/dev/null || true
 }
 
+@test "stop does not signal a process that recycled the daemon's PID" {
+  skip_on_windows "state file crafting relies on Unix signal semantics"
+
+  # `stop` kills a process group, so a recycled PID would take down whatever
+  # unrelated tree now owns it. The bystander must therefore lead its own group
+  # — a plain background job here would join bats' group, and killpg would find
+  # no group to signal whatever the daemon code did. Its children make the blast
+  # radius visible: signalling the group takes them too.
+  local pidfile="$BATS_TEST_TMPDIR/bystander.pid"
+  setsid bash -c 'echo $$ > "$1"; sleep 300 & sleep 300 & wait' _ "$pidfile" >/dev/null 2>&1 &
+  local i
+  for i in $(seq 1 50); do [ -s "$pidfile" ] && break; sleep 0.1; done
+  local bystander_pid
+  bystander_pid=$(cat "$pidfile")
+  [ -n "$bystander_pid" ]
+
+  # Orphan reconciliation would reset the crafted record before `stop` ever saw
+  # it; this test is about the stop path, so leave the record alone.
+  export PITCHFORK_CLEANUP_ORPHANS=false
+
+  pitchfork supervisor stop 2>/dev/null || true
+  sleep 1
+  cat > "$PITCHFORK_STATE_DIR/state.toml" <<EOF
+[daemons."recycled/stopvictim"]
+id = "recycled/stopvictim"
+pid = $bystander_pid
+start_time = 1
+status = "running"
+autostop = false
+EOF
+
+  run pitchfork supervisor start
+  assert_success
+  sleep 1
+
+  run pitchfork stop recycled/stopvictim
+  assert_success
+
+  # The unrelated process group must survive untouched.
+  pid_alive "$bystander_pid"
+  assert_equal "$(pgrep -c -P "$bystander_pid" || true)" "2"
+
+  # ...and the daemon is reported as gone, since that PID is not its process.
+  run pitchfork status recycled/stopvictim
+  assert_success
+  assert_output --partial "stopped"
+
+  { kill -9 "-$bystander_pid" || kill -9 "$bystander_pid"; } 2>/dev/null || true
+  wait "$bystander_pid" 2>/dev/null || true
+}
+
 @test "daemon that dies during a supervisor crash is retried on restart" {
   skip_on_windows "relies on SIGKILL semantics for both supervisor and daemon"
   export PITCHFORK_INTERVAL=1s


### PR DESCRIPTION
## The hole

Orphan cleanup verifies that a live PID really belongs to the daemon recorded against it before adopting or killing it. Identity is the kernel start time — but when a record had no start time, `process_identity_matches` fell back to comparing the *process name*:

```rust
match recorded_start_time {
    Some(recorded) => current_start_time == Some(recorded),
    None => matches!(
        (recorded_title, current_title),
        (Some(recorded), Some(current)) if recorded == current
    ),
}
```

A name is not an identity. It is exactly what a second copy of the same program shares, so a recycled PID running `node`, `nginx`, or `postgres` matches a legacy record for a *different* daemon of the same program — and the supervisor then adopts it, or kills it under `orphan_policy = "kill"`. That is the failure mode the identity check exists to prevent, left open for precisely the records that predate the check.

The fallback was kept in #632 to avoid breaking the ≤2.17.0 upgrade path. It buys very little: the window is one supervisor restart after upgrading, and every record written since then has a start time.

## The change

Both start times are required. A missing one on either side means *unverifiable*, which is treated differently from *mismatched*:

- **mismatched** — a stranger holds the PID; reset the record (or kill, per policy)
- **unverifiable** — retain the running state and log a warning; never act on the process

So a legacy record now stops being a licence to kill: it keeps its running state until the daemon is next started under a version that records identity properly.

## Tests

`orphan_identity_requires_both_start_times` and `orphan_identity_rejects_records_without_a_start_time` replace the three title-fallback cases. 521 unit tests and 26/26 `supervisor.bats` pass locally.

---
*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes process-group kill/stop and orphan adopt/kill decisions on PID reuse; mistakes could leave daemons unstoppable or, before this fix, signal the wrong tree.
> 
> **Overview**
> **Orphan identity** no longer falls back to comparing process names when `start_time` is missing. `process_identity_matches` only succeeds when both recorded and live kernel start times are present and equal; legacy or unreadable identity is treated as **unverifiable** (keep running, log a warning) rather than mistaken for a **mismatch** (reset state). Startup orphan cleanup and interval reconciliation share that behavior.
> 
> **User-initiated signalling** adds `signalling_pid_is_authorized`, which is weaker than orphan matching: stop and resource-violation kills are skipped only when start times **contradict** each other (proven PID reuse). Missing start time still allows stop so old records do not become unstoppable. On contradiction, `stop` clears the daemon as stopped without `killpg`; the resource watcher finalizes the record instead of killing a stranger’s process group.
> 
> Tests cover the new identity rules and a **bats** case where `pitchfork stop` must not tear down an unrelated process group that recycled the recorded PID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb18ee45d727a3c3cc06b26da5463201539026b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process identity checks when managing daemon processes.
  * Prevented stop and resource-violation actions from signalling unrelated processes after PID reuse.
  * Preserved running-state information when process identity cannot be verified.
  * Updated daemon status handling when a recorded process is no longer valid.

* **Tests**
  * Added coverage confirming recycled process IDs are not signalled during daemon shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->