### PR TITLE
feat(logs): let the sink decide ready_output

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1012,6 +1012,29 @@
               "double_dash": "Optional",
               "hide": false
             }
+          },
+          {
+            "name": "relay-token",
+            "usage": "--relay-token <RELAY_TOKEN>",
+            "help": "Token identifying the start attempt this sink belongs to",
+            "help_long": "Token identifying the start attempt this sink belongs to\n\nQuoted back when reporting a match. The supervisor drops reports whose token is no longer current, so a sink still draining a failed attempt cannot mark that daemon's retry ready.",
+            "help_first_line": "Token identifying the start attempt this sink belongs to",
+            "short": [],
+            "long": [
+              "relay-token"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "RELAY_TOKEN",
+              "usage": "<RELAY_TOKEN>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            },
+            "default": [
+              "0"
+            ]
           }
         ],
         "mounts": [],

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -947,7 +947,7 @@
         "full_cmd": [
           "log-sink"
         ],
-        "usage": "log-sink <--daemon-id <DAEMON_ID>> [--log-format <LOG_FORMAT>]",
+        "usage": "log-sink <FLAGS>",
         "subcommands": {},
         "args": [],
         "flags": [
@@ -992,6 +992,26 @@
             "default": [
               "text"
             ]
+          },
+          {
+            "name": "ready-pattern",
+            "usage": "--ready-pattern <READY_PATTERN>",
+            "help": "Regex whose first match means the daemon is ready",
+            "help_long": "Regex whose first match means the daemon is ready\n\nSet for a daemon configured with `ready_output`. The supervisor cannot match it itself — this process holds the output — so the match is reported back over IPC.",
+            "help_first_line": "Regex whose first match means the daemon is ready",
+            "short": [],
+            "long": [
+              "ready-pattern"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "READY_PATTERN",
+              "usage": "<READY_PATTERN>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
           }
         ],
         "mounts": [],

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -147,6 +147,10 @@ cmd log-sink hide=#true help="Reads a daemon's output on stdin and writes it to 
     flag --log-format help="Log format to parse lines with (`json`, `logfmt`, `auto`, or `text`)" default=text {
         arg <LOG_FORMAT>
     }
+    flag --ready-pattern help="Regex whose first match means the daemon is ready" {
+        long_help "Regex whose first match means the daemon is ready\n\nSet for a daemon configured with `ready_output`. The supervisor cannot match it itself — this process holds the output — so the match is reported back over IPC."
+        arg <READY_PATTERN>
+    }
 }
 cmd logs help="Displays logs for daemon(s)" {
     alias l

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -151,6 +151,10 @@ cmd log-sink hide=#true help="Reads a daemon's output on stdin and writes it to 
         long_help "Regex whose first match means the daemon is ready\n\nSet for a daemon configured with `ready_output`. The supervisor cannot match it itself — this process holds the output — so the match is reported back over IPC."
         arg <READY_PATTERN>
     }
+    flag --relay-token help="Token identifying the start attempt this sink belongs to" default="0" {
+        long_help "Token identifying the start attempt this sink belongs to\n\nQuoted back when reporting a match. The supervisor drops reports whose token is no longer current, so a sink still draining a failed attempt cannot mark that daemon's retry ready."
+        arg <RELAY_TOKEN>
+    }
 }
 cmd logs help="Displays logs for daemon(s)" {
     alias l

--- a/src/cli/log_sink.rs
+++ b/src/cli/log_sink.rs
@@ -56,6 +56,14 @@ pub struct LogSink {
     /// reported back over IPC.
     #[clap(long)]
     ready_pattern: Option<String>,
+
+    /// Token identifying the start attempt this sink belongs to
+    ///
+    /// Quoted back when reporting a match. The supervisor drops reports whose
+    /// token is no longer current, so a sink still draining a failed attempt
+    /// cannot mark that daemon's retry ready.
+    #[clap(long, default_value_t = 0)]
+    relay_token: u64,
 }
 
 impl LogSink {
@@ -77,9 +85,9 @@ impl LogSink {
         // lock — and this process is the only reader of the daemon's pipe, so a
         // write must never stop it being drained.
         let (tx, rx) = tokio::sync::mpsc::channel::<SinkEvent>(QUEUE_DEPTH);
-        let writer = tokio::spawn(write_batches(id.clone(), rx));
+        let writer = tokio::spawn(write_batches(id.clone(), self.relay_token, rx));
 
-        let read_result = read_lines(tx, &self.log_format, ready_pattern).await;
+        let read_result = read_lines(tx, &self.log_format, ReadyMatcher::new(ready_pattern)).await;
 
         // The sender has been dropped by now, so the writer drains its queue and
         // returns; wait for it so nothing queued is lost on exit.
@@ -102,6 +110,73 @@ enum SinkEvent {
     ReadyMatch(String),
 }
 
+/// How much of a capped line is carried forward for matching.
+///
+/// A line longer than [`MAX_LINE_BYTES`] is emitted in pieces, and a readiness
+/// pattern straddling a split would match none of them — the daemon would then
+/// be killed at its readiness timeout despite having announced itself. Keeping
+/// the tail of the previous piece closes that for any pattern shorter than this
+/// while still bounding what is held.
+const MATCH_CARRY_BYTES: usize = 4 * 1024;
+
+/// Watches a daemon's output for its readiness pattern.
+struct ReadyMatcher {
+    /// Cleared once it has matched: readiness happens once.
+    pattern: Option<regex::Regex>,
+    /// Tail of the previous piece of a line split at the length cap. Empty
+    /// whenever the last piece ended at a real newline.
+    carried: String,
+}
+
+impl ReadyMatcher {
+    fn new(pattern: Option<regex::Regex>) -> Self {
+        Self {
+            pattern,
+            carried: String::new(),
+        }
+    }
+
+    /// Test `text` — one whole line, or one piece of an over-long one — and
+    /// return what matched, which is what the supervisor is told about.
+    ///
+    /// `split_at_cap` says another piece of the same logical line follows.
+    fn consider(&mut self, text: &str, split_at_cap: bool) -> Option<String> {
+        if self.pattern.is_none() {
+            self.carried.clear();
+            return None;
+        }
+        let clean = console::strip_ansi_codes(text);
+        let candidate = if self.carried.is_empty() {
+            clean.into_owned()
+        } else {
+            format!("{}{clean}", self.carried)
+        };
+
+        self.carried = if split_at_cap {
+            let start = candidate.len().saturating_sub(MATCH_CARRY_BYTES);
+            // Never split a character in half; walk forward to a boundary.
+            let start = (start..candidate.len())
+                .find(|i| candidate.is_char_boundary(*i))
+                .unwrap_or(candidate.len());
+            candidate[start..].to_string()
+        } else {
+            String::new()
+        };
+
+        let matched = self
+            .pattern
+            .as_ref()
+            .is_some_and(|re| re.is_match(&candidate));
+        if matched {
+            self.pattern = None;
+            // The supervisor re-matches what it is sent, so send the text the
+            // pattern actually matched against, not just this piece of it.
+            return Some(candidate);
+        }
+        None
+    }
+}
+
 /// Split the daemon's output into lines and queue them for writing.
 ///
 /// Returns once the pipe reaches end of file. A read error is propagated so the
@@ -110,7 +185,7 @@ enum SinkEvent {
 async fn read_lines(
     tx: tokio::sync::mpsc::Sender<SinkEvent>,
     log_format: &str,
-    mut ready_pattern: Option<regex::Regex>,
+    mut matcher: ReadyMatcher,
 ) -> std::io::Result<()> {
     let mut stdin = tokio::io::stdin();
     let mut chunk = vec![0u8; READ_CHUNK];
@@ -132,14 +207,14 @@ async fn read_lines(
                     continue;
                 }
                 split_at_cap = false;
-                queue(&tx, &mut line, log_format, &mut ready_pattern).await?;
+                queue(&tx, &mut line, log_format, &mut matcher).await?;
             } else {
                 line.push(byte);
                 split_at_cap = false;
                 // Emit an over-long run as its own line rather than letting the
                 // buffer grow without bound.
                 if line.len() >= MAX_LINE_BYTES {
-                    queue_capped(&tx, &mut line, log_format, &mut ready_pattern).await?;
+                    queue_capped(&tx, &mut line, log_format, &mut matcher).await?;
                     split_at_cap = true;
                 }
             }
@@ -148,7 +223,7 @@ async fn read_lines(
 
     // Anything written without a trailing newline is still output.
     if !line.is_empty() {
-        queue(&tx, &mut line, log_format, &mut ready_pattern).await?;
+        queue(&tx, &mut line, log_format, &mut matcher).await?;
     }
     Ok(())
 }
@@ -163,13 +238,38 @@ async fn queue_capped(
     tx: &tokio::sync::mpsc::Sender<SinkEvent>,
     line: &mut Vec<u8>,
     log_format: &str,
-    ready_pattern: &mut Option<regex::Regex>,
+    matcher: &mut ReadyMatcher,
 ) -> std::io::Result<()> {
     let split = split_before_incomplete_char(line);
     let tail = line.split_off(split);
-    let result = queue(tx, line, log_format, ready_pattern).await;
+    let result = queue_piece(tx, line, log_format, matcher).await;
     *line = tail;
     result
+}
+
+/// Queue one piece of a line that hit the length cap, telling the matcher that
+/// the rest of the logical line is still to come.
+async fn queue_piece(
+    tx: &tokio::sync::mpsc::Sender<SinkEvent>,
+    line: &mut Vec<u8>,
+    log_format: &str,
+    matcher: &mut ReadyMatcher,
+) -> std::io::Result<()> {
+    let text = String::from_utf8_lossy(line);
+    let text = text.trim_end_matches('\r');
+    let parsed = crate::log_parse::parse(text, log_format);
+    let matched = matcher.consider(text, true);
+    line.clear();
+
+    tx.send(SinkEvent::Line(parsed))
+        .await
+        .map_err(|_| std::io::Error::other("log writer stopped"))?;
+    if let Some(matched) = matched {
+        tx.send(SinkEvent::ReadyMatch(matched))
+            .await
+            .map_err(|_| std::io::Error::other("log writer stopped"))?;
+    }
+    Ok(())
 }
 
 /// Length to cut `bytes` at so no character is left half-written.
@@ -210,7 +310,7 @@ async fn queue(
     tx: &tokio::sync::mpsc::Sender<SinkEvent>,
     line: &mut Vec<u8>,
     log_format: &str,
-    ready_pattern: &mut Option<regex::Regex>,
+    matcher: &mut ReadyMatcher,
 ) -> std::io::Result<()> {
     // Convert lossily: a daemon emitting a stray non-UTF-8 byte must not be able
     // to stop its own logging.
@@ -219,18 +319,13 @@ async fn queue(
     let parsed = crate::log_parse::parse(text, log_format);
     // Strip ANSI before matching so a pattern works whether or not the daemon
     // colours its output, matching what in-process capture did.
-    let matched = ready_pattern.as_ref().and_then(|re| {
-        let clean = console::strip_ansi_codes(text);
-        re.is_match(&clean).then(|| clean.into_owned())
-    });
+    let matched = matcher.consider(text, false);
     line.clear();
 
     tx.send(SinkEvent::Line(parsed))
         .await
         .map_err(|_| std::io::Error::other("log writer stopped"))?;
     if let Some(matched) = matched {
-        // Only the first match means anything; readiness happens once.
-        *ready_pattern = None;
         tx.send(SinkEvent::ReadyMatch(matched))
             .await
             .map_err(|_| std::io::Error::other("log writer stopped"))?;
@@ -239,7 +334,11 @@ async fn queue(
 }
 
 /// Write queued lines in batches until the queue closes.
-async fn write_batches(id: DaemonId, mut rx: tokio::sync::mpsc::Receiver<SinkEvent>) {
+async fn write_batches(
+    id: DaemonId,
+    relay_token: u64,
+    mut rx: tokio::sync::mpsc::Receiver<SinkEvent>,
+) {
     let mut events: Vec<SinkEvent> = Vec::with_capacity(BATCH_SIZE);
     let mut batch: Vec<ParsedLog> = Vec::with_capacity(BATCH_SIZE);
     let mut flush_interval = tokio::time::interval(FLUSH_INTERVAL);
@@ -258,7 +357,7 @@ async fn write_batches(id: DaemonId, mut rx: tokio::sync::mpsc::Receiver<SinkEve
                     // the store before the supervisor is told, so whatever it
                     // does next can already read it.
                     flush(&id, &mut batch).await;
-                    report_ready_match(&id, line).await;
+                    report_ready_match(&id, relay_token, line).await;
                 }
             }
         }
@@ -274,11 +373,11 @@ async fn write_batches(id: DaemonId, mut rx: tokio::sync::mpsc::Receiver<SinkEve
 /// Failure is logged and dropped. There is no supervisor to retry against if it
 /// has crashed — and if it has, this daemon's readiness is no longer anyone's
 /// concern — while the daemon's output keeps being captured either way.
-async fn report_ready_match(id: &DaemonId, line: String) {
+async fn report_ready_match(id: &DaemonId, relay_token: u64, line: String) {
     // `autostart: false` — a sink must never bring a supervisor into being.
     match crate::ipc::client::IpcClient::connect(false).await {
         Ok(client) => {
-            if let Err(e) = client.sink_ready_match(id.clone(), line).await {
+            if let Err(e) = client.sink_ready_match(id.clone(), relay_token, line).await {
                 warn!("log sink for {id} could not report its readiness match: {e}");
             }
         }
@@ -304,5 +403,70 @@ async fn flush(id: &DaemonId, batch: &mut Vec<ParsedLog>) {
         // alive to be told, and dropping a batch is preferable to stalling the
         // daemon behind a pipe nobody is draining.
         error!("log sink failed to write batch for {id}: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MATCH_CARRY_BYTES, ReadyMatcher};
+
+    fn matcher(pattern: &str) -> ReadyMatcher {
+        ReadyMatcher::new(Some(regex::Regex::new(pattern).unwrap()))
+    }
+
+    #[test]
+    fn reports_the_first_match_and_then_stops_looking() {
+        let mut m = matcher("READY");
+        assert_eq!(m.consider("starting up", false), None);
+        assert_eq!(
+            m.consider("READY to serve", false).as_deref(),
+            Some("READY to serve")
+        );
+        // Readiness happens once; later matches are somebody else's business.
+        assert_eq!(m.consider("READY again", false), None);
+    }
+
+    #[test]
+    fn matches_a_pattern_split_across_the_line_cap() {
+        // The daemon emitted one enormous line whose announcement straddles the
+        // point where the sink had to cut it.
+        let mut m = matcher("SERVER READY");
+        assert_eq!(m.consider("....SERVER ", true), None);
+        let matched = m
+            .consider("READY....", false)
+            .expect("should match across the split");
+        assert!(matched.contains("SERVER READY"), "reported {matched:?}");
+    }
+
+    #[test]
+    fn does_not_match_across_a_completed_line() {
+        // Two separate lines are not one line: a pattern spanning them must not
+        // match, or "SERVER" at the end of one line plus "READY" at the start of
+        // the next would look like an announcement.
+        let mut m = matcher("SERVER READY");
+        assert_eq!(m.consider("SERVER ", false), None);
+        assert_eq!(m.consider("READY", false), None);
+    }
+
+    #[test]
+    fn carries_a_bounded_amount_of_a_capped_line() {
+        let mut m = matcher("nothing-matches-this");
+        m.consider(&"x".repeat(MATCH_CARRY_BYTES * 3), true);
+        assert!(m.carried.len() <= MATCH_CARRY_BYTES);
+    }
+
+    #[test]
+    fn carrying_never_splits_a_character() {
+        // A carry boundary landing mid-character would panic on the slice, or
+        // corrupt the text a pattern is matched against.
+        let mut m = matcher("nothing-matches-this");
+        m.consider(&"é".repeat(MATCH_CARRY_BYTES), true);
+        assert!(m.carried.chars().all(|c| c == 'é'));
+    }
+
+    #[test]
+    fn strips_ansi_before_matching() {
+        let mut m = matcher("^READY$");
+        assert!(m.consider("\x1b[32mREADY\x1b[0m", false).is_some());
     }
 }

--- a/src/cli/log_sink.rs
+++ b/src/cli/log_sink.rs
@@ -48,20 +48,38 @@ pub struct LogSink {
     /// Log format to parse lines with (`json`, `logfmt`, `auto`, or `text`)
     #[clap(long, default_value = "text")]
     log_format: String,
+
+    /// Regex whose first match means the daemon is ready
+    ///
+    /// Set for a daemon configured with `ready_output`. The supervisor cannot
+    /// match it itself — this process holds the output — so the match is
+    /// reported back over IPC.
+    #[clap(long)]
+    ready_pattern: Option<String>,
 }
 
 impl LogSink {
     pub async fn run(&self) -> Result<()> {
         let id = DaemonId::parse(&self.daemon_id)?;
 
+        // A pattern that does not compile is reported and then ignored, rather
+        // than failing the sink: refusing to start would leave the daemon's
+        // output unread, which is far worse than a readiness check that never
+        // fires. The supervisor validates patterns too, so this is a backstop.
+        let ready_pattern = self.ready_pattern.as_deref().and_then(|p| {
+            regex::Regex::new(p)
+                .map_err(|e| error!("log sink for {id} ignoring unparsable ready pattern: {e}"))
+                .ok()
+        });
+
         // Reading and writing are separate tasks. A write to SQLite can block —
         // for as long as the store's busy timeout, if another writer holds the
         // lock — and this process is the only reader of the daemon's pipe, so a
         // write must never stop it being drained.
-        let (tx, rx) = tokio::sync::mpsc::channel::<ParsedLog>(QUEUE_DEPTH);
+        let (tx, rx) = tokio::sync::mpsc::channel::<SinkEvent>(QUEUE_DEPTH);
         let writer = tokio::spawn(write_batches(id.clone(), rx));
 
-        let read_result = read_lines(tx, &self.log_format).await;
+        let read_result = read_lines(tx, &self.log_format, ready_pattern).await;
 
         // The sender has been dropped by now, so the writer drains its queue and
         // returns; wait for it so nothing queued is lost on exit.
@@ -73,14 +91,26 @@ impl LogSink {
     }
 }
 
+/// Something for the writer task to do, in the order the reader saw it.
+///
+/// Reporting a readiness match travels the same queue as the lines rather than
+/// jumping ahead of them, so the line that triggered the match is always in the
+/// log store by the time the supervisor hears about it — `collect_startup_logs`
+/// and `pitchfork logs` would otherwise be able to miss it.
+enum SinkEvent {
+    Line(ParsedLog),
+    ReadyMatch(String),
+}
+
 /// Split the daemon's output into lines and queue them for writing.
 ///
 /// Returns once the pipe reaches end of file. A read error is propagated so the
 /// process can exit non-zero: exiting cleanly would tell the supervisor the
 /// stream had finished and it would stop replacing this sink.
 async fn read_lines(
-    tx: tokio::sync::mpsc::Sender<ParsedLog>,
+    tx: tokio::sync::mpsc::Sender<SinkEvent>,
     log_format: &str,
+    mut ready_pattern: Option<regex::Regex>,
 ) -> std::io::Result<()> {
     let mut stdin = tokio::io::stdin();
     let mut chunk = vec![0u8; READ_CHUNK];
@@ -102,14 +132,14 @@ async fn read_lines(
                     continue;
                 }
                 split_at_cap = false;
-                queue(&tx, &mut line, log_format).await?;
+                queue(&tx, &mut line, log_format, &mut ready_pattern).await?;
             } else {
                 line.push(byte);
                 split_at_cap = false;
                 // Emit an over-long run as its own line rather than letting the
                 // buffer grow without bound.
                 if line.len() >= MAX_LINE_BYTES {
-                    queue_capped(&tx, &mut line, log_format).await?;
+                    queue_capped(&tx, &mut line, log_format, &mut ready_pattern).await?;
                     split_at_cap = true;
                 }
             }
@@ -118,7 +148,7 @@ async fn read_lines(
 
     // Anything written without a trailing newline is still output.
     if !line.is_empty() {
-        queue(&tx, &mut line, log_format).await?;
+        queue(&tx, &mut line, log_format, &mut ready_pattern).await?;
     }
     Ok(())
 }
@@ -130,13 +160,14 @@ async fn read_lines(
 /// converting each half on its own turns one valid character into two
 /// replacement characters.
 async fn queue_capped(
-    tx: &tokio::sync::mpsc::Sender<ParsedLog>,
+    tx: &tokio::sync::mpsc::Sender<SinkEvent>,
     line: &mut Vec<u8>,
     log_format: &str,
+    ready_pattern: &mut Option<regex::Regex>,
 ) -> std::io::Result<()> {
     let split = split_before_incomplete_char(line);
     let tail = line.split_off(split);
-    let result = queue(tx, line, log_format).await;
+    let result = queue(tx, line, log_format, ready_pattern).await;
     *line = tail;
     result
 }
@@ -176,34 +207,83 @@ fn split_before_incomplete_char(bytes: &[u8]) -> usize {
 /// sink had reached end of file, and it would stop replacing it while the daemon
 /// was still writing.
 async fn queue(
-    tx: &tokio::sync::mpsc::Sender<ParsedLog>,
+    tx: &tokio::sync::mpsc::Sender<SinkEvent>,
     line: &mut Vec<u8>,
     log_format: &str,
+    ready_pattern: &mut Option<regex::Regex>,
 ) -> std::io::Result<()> {
     // Convert lossily: a daemon emitting a stray non-UTF-8 byte must not be able
     // to stop its own logging.
     let text = String::from_utf8_lossy(line);
-    let parsed = crate::log_parse::parse(text.trim_end_matches('\r'), log_format);
+    let text = text.trim_end_matches('\r');
+    let parsed = crate::log_parse::parse(text, log_format);
+    // Strip ANSI before matching so a pattern works whether or not the daemon
+    // colours its output, matching what in-process capture did.
+    let matched = ready_pattern.as_ref().and_then(|re| {
+        let clean = console::strip_ansi_codes(text);
+        re.is_match(&clean).then(|| clean.into_owned())
+    });
     line.clear();
-    tx.send(parsed)
+
+    tx.send(SinkEvent::Line(parsed))
         .await
-        .map_err(|_| std::io::Error::other("log writer stopped"))
+        .map_err(|_| std::io::Error::other("log writer stopped"))?;
+    if let Some(matched) = matched {
+        // Only the first match means anything; readiness happens once.
+        *ready_pattern = None;
+        tx.send(SinkEvent::ReadyMatch(matched))
+            .await
+            .map_err(|_| std::io::Error::other("log writer stopped"))?;
+    }
+    Ok(())
 }
 
 /// Write queued lines in batches until the queue closes.
-async fn write_batches(id: DaemonId, mut rx: tokio::sync::mpsc::Receiver<ParsedLog>) {
+async fn write_batches(id: DaemonId, mut rx: tokio::sync::mpsc::Receiver<SinkEvent>) {
+    let mut events: Vec<SinkEvent> = Vec::with_capacity(BATCH_SIZE);
     let mut batch: Vec<ParsedLog> = Vec::with_capacity(BATCH_SIZE);
     let mut flush_interval = tokio::time::interval(FLUSH_INTERVAL);
     flush_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         let closed = tokio::select! {
-            received = rx.recv_many(&mut batch, BATCH_SIZE) => received == 0,
+            received = rx.recv_many(&mut events, BATCH_SIZE) => received == 0,
             _ = flush_interval.tick() => false,
         };
+        for event in events.drain(..) {
+            match event {
+                SinkEvent::Line(parsed) => batch.push(parsed),
+                SinkEvent::ReadyMatch(line) => {
+                    // Everything up to and including the matching line goes to
+                    // the store before the supervisor is told, so whatever it
+                    // does next can already read it.
+                    flush(&id, &mut batch).await;
+                    report_ready_match(&id, line).await;
+                }
+            }
+        }
         flush(&id, &mut batch).await;
         if closed {
             break;
+        }
+    }
+}
+
+/// Tell the supervisor that the daemon's output matched its readiness pattern.
+///
+/// Failure is logged and dropped. There is no supervisor to retry against if it
+/// has crashed — and if it has, this daemon's readiness is no longer anyone's
+/// concern — while the daemon's output keeps being captured either way.
+async fn report_ready_match(id: &DaemonId, line: String) {
+    // `autostart: false` — a sink must never bring a supervisor into being.
+    match crate::ipc::client::IpcClient::connect(false).await {
+        Ok(client) => {
+            if let Err(e) = client.sink_ready_match(id.clone(), line).await {
+                warn!("log sink for {id} could not report its readiness match: {e}");
+            }
+        }
+        Err(e) => {
+            warn!("log sink for {id} could not reach the supervisor to report readiness: {e}");
         }
     }
 }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -425,9 +425,9 @@ impl IpcClient {
     /// Called by a log sink, which reads the daemon's output in the
     /// supervisor's place and so is the only process in a position to see the
     /// match.
-    pub async fn sink_ready_match(&self, id: DaemonId, line: String) -> Result<()> {
+    pub async fn sink_ready_match(&self, id: DaemonId, token: u64, line: String) -> Result<()> {
         let rsp = self
-            .request(IpcRequest::SinkReadyMatch { id, line })
+            .request(IpcRequest::SinkReadyMatch { id, token, line })
             .await?;
         match rsp {
             IpcResponse::Ok => Ok(()),

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -420,6 +420,21 @@ impl IpcClient {
         Ok(())
     }
 
+    /// Report output that matched a daemon's readiness pattern.
+    ///
+    /// Called by a log sink, which reads the daemon's output in the
+    /// supervisor's place and so is the only process in a position to see the
+    /// match.
+    pub async fn sink_ready_match(&self, id: DaemonId, line: String) -> Result<()> {
+        let rsp = self
+            .request(IpcRequest::SinkReadyMatch { id, line })
+            .await?;
+        match rsp {
+            IpcResponse::Ok => Ok(()),
+            rsp => Err(Self::unexpected_response("Ok", &rsp).into()),
+        }
+    }
+
     pub async fn clean(&self) -> Result<()> {
         let rsp = self.request(IpcRequest::Clean).await?;
         match rsp {

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -75,6 +75,15 @@ pub enum IpcRequest {
     /// List all tracked project sessions with live liveness status filled in
     /// by the supervisor.
     GetProjectSessions,
+    /// A daemon's log sink reporting output that matched its readiness pattern.
+    ///
+    /// The sink owns the daemon's output stream, so it does the matching and
+    /// tells the supervisor rather than the other way around. Sent by
+    /// `pitchfork log-sink`, not by any user-facing command.
+    SinkReadyMatch {
+        id: DaemonId,
+        line: String,
+    },
     /// Invalid request (failed to deserialize)
     #[serde(skip)]
     Invalid {

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -82,6 +82,9 @@ pub enum IpcRequest {
     /// `pitchfork log-sink`, not by any user-facing command.
     SinkReadyMatch {
         id: DaemonId,
+        /// Identifies the start attempt this sink belongs to, so a report from
+        /// a sink still draining a previous attempt cannot satisfy a retry.
+        token: u64,
         line: String,
     },
     /// Invalid request (failed to deserialize)

--- a/src/supervisor/ipc_handlers.rs
+++ b/src/supervisor/ipc_handlers.rs
@@ -102,8 +102,8 @@ impl Supervisor {
                 self.refresh().await?;
                 IpcResponse::Ok
             }
-            IpcRequest::SinkReadyMatch { id, line } => {
-                super::log_sink::deliver_reported_line(&id, line).await;
+            IpcRequest::SinkReadyMatch { id, token, line } => {
+                super::log_sink::deliver_reported_line(&id, token, line).await;
                 IpcResponse::Ok
             }
             IpcRequest::Clean => {

--- a/src/supervisor/ipc_handlers.rs
+++ b/src/supervisor/ipc_handlers.rs
@@ -102,6 +102,10 @@ impl Supervisor {
                 self.refresh().await?;
                 IpcResponse::Ok
             }
+            IpcRequest::SinkReadyMatch { id, line } => {
+                super::log_sink::deliver_reported_line(&id, line).await;
+                IpcResponse::Ok
+            }
             IpcRequest::Clean => {
                 self.clean().await?;
                 IpcResponse::Ok

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -441,6 +441,14 @@ impl Supervisor {
             None
         };
 
+        // Output reaches the monitoring task either from readers this process
+        // owns or, when a sink owns the stream, relayed over IPC. The channel is
+        // created here rather than in that task so it exists before the sink
+        // starts: a daemon whose very first line matches its readiness pattern
+        // would otherwise have the match reported with nowhere to deliver it.
+        let (output_tx, output_rx) = tokio::sync::mpsc::channel::<super::OutputLine>(256);
+        let mut output_relay = None;
+
         // Set up out-of-process capture before building the command, so the
         // daemon can be handed the pipe's write end directly.
         let mut sink_pipe = None;
@@ -451,7 +459,14 @@ impl Supervisor {
                 .log_format
                 .clone()
                 .unwrap_or_else(|| settings().logs.log_format.clone());
-            match super::log_sink::SinkPipe::new(log_format) {
+            let ready_pattern = opts.ready_output.as_ref().map(|o| o.pattern.clone());
+            if ready_pattern.is_some() {
+                output_relay = Some(super::log_sink::OutputRelay::register(
+                    id,
+                    output_tx.clone(),
+                ));
+            }
+            match super::log_sink::SinkPipe::new(log_format, ready_pattern) {
                 Ok((pipe, writer)) => match pipe.start(id) {
                     Ok(child) => {
                         sink_child = Some(super::log_sink::PendingSink::new(child));
@@ -724,9 +739,14 @@ impl Supervisor {
             // Registered before the Running upsert above; unregisters when
             // this monitoring task ends.
             let _monitored_guard = monitored_guard;
+            // Likewise for sink-relayed output: dropping this stops the
+            // supervisor delivering into a channel nobody is reading. Dropped
+            // explicitly once the daemon exits, before the drain below.
+            let output_relay = output_relay;
 
-            // Merge all output sources (PTY master OR stdout+stderr) into a single channel.
-            let (output_tx, mut output_rx) = tokio::sync::mpsc::channel::<String>(256);
+            // Merge all output sources (PTY master OR stdout+stderr, or a
+            // sink's IPC reports) into a single channel.
+            let mut output_rx = output_rx;
 
             if let Some(mut reader) = pty_reader {
                 // PTY mode: single merged stream from the master.
@@ -738,7 +758,14 @@ impl Supervisor {
                         if line.ends_with('\r') {
                             line.pop();
                         }
-                        if output_tx.send(line).await.is_err() {
+                        if output_tx
+                            .send(super::OutputLine {
+                                text: line,
+                                persist: true,
+                            })
+                            .await
+                            .is_err()
+                        {
                             break;
                         }
                     }
@@ -752,7 +779,14 @@ impl Supervisor {
                     let tx = output_tx.clone();
                     tokio::spawn(async move {
                         while let Ok(Some(line)) = stdout.next_line().await {
-                            if tx.send(line).await.is_err() {
+                            if tx
+                                .send(super::OutputLine {
+                                    text: line,
+                                    persist: true,
+                                })
+                                .await
+                                .is_err()
+                            {
                                 break;
                             }
                         }
@@ -762,13 +796,22 @@ impl Supervisor {
                     let tx = output_tx.clone();
                     tokio::spawn(async move {
                         while let Ok(Some(line)) = stderr.next_line().await {
-                            if tx.send(line).await.is_err() {
+                            if tx
+                                .send(super::OutputLine {
+                                    text: line,
+                                    persist: true,
+                                })
+                                .await
+                                .is_err()
+                            {
                                 break;
                             }
                         }
                     });
                 }
-                // Drop the last sender so the channel closes when all readers finish.
+                // Drop the last sender so the channel closes when all readers
+                // finish. The relay holds its own clone, so a sink's reports
+                // still have somewhere to go after these end.
                 drop(output_tx);
             }
             let log_store = Arc::clone(&LOG_STORE);
@@ -996,11 +1039,16 @@ impl Supervisor {
                         }
                         break;
                     },
-                    Some(line) = output_rx.recv() => {
-                        let parsed = parse_line(&line);
-                        log_buffer.push(parsed);
-                        if log_buffer.len() >= LOG_BATCH_SIZE {
-                            let _ = flush_logs(&mut log_buffer);
+                    Some(super::OutputLine { text: line, persist }) = output_rx.recv() => {
+                        // A line relayed by a sink is already in the store —
+                        // the sink wrote and flushed it before reporting it —
+                        // so it arrives here only to be matched against.
+                        if persist {
+                            let parsed = parse_line(&line);
+                            log_buffer.push(parsed);
+                            if log_buffer.len() >= LOG_BATCH_SIZE {
+                                let _ = flush_logs(&mut log_buffer);
+                            }
                         }
                         trace!("output: {id} {line}");
 
@@ -1399,6 +1447,12 @@ impl Supervisor {
             // None when all data has been consumed. A total deadline of 5 s
             // guards against a stuck reader (e.g. PTY master FD not closing)
             // while ensuring drain doesn't block post-exit cleanup indefinitely.
+            //
+            // Stop accepting relayed output first: the relay holds a sender of
+            // its own, so leaving it registered would keep the channel open and
+            // make every drain wait out the whole deadline. Readiness is moot
+            // now anyway — the process has exited.
+            drop(output_relay);
             let drain_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
             loop {
                 let now = tokio::time::Instant::now();
@@ -1410,7 +1464,10 @@ impl Supervisor {
                 else {
                     break;
                 };
-                log_buffer.push(parse_line(&line));
+                // Sink-relayed lines are already stored; see the select loop.
+                if line.persist {
+                    log_buffer.push(parse_line(&line.text));
+                }
             }
             // Flush any remaining log lines (including drained) before the process exits.
             // Await the flush to guarantee all buffered logs are persisted before cleanup.

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -460,13 +460,18 @@ impl Supervisor {
                 .clone()
                 .unwrap_or_else(|| settings().logs.log_format.clone());
             let ready_pattern = opts.ready_output.as_ref().map(|o| o.pattern.clone());
-            if ready_pattern.is_some() {
-                output_relay = Some(super::log_sink::OutputRelay::register(
-                    id,
-                    output_tx.clone(),
-                ));
-            }
-            match super::log_sink::SinkPipe::new(log_format, ready_pattern) {
+            // The token ties this attempt's sink to this attempt's channel, so
+            // a sink still draining a previous attempt cannot report into it.
+            let relay_token = match ready_pattern {
+                Some(_) => {
+                    let relay = super::log_sink::OutputRelay::register(id, output_tx.clone());
+                    let token = relay.token();
+                    output_relay = Some(relay);
+                    token
+                }
+                None => 0,
+            };
+            match super::log_sink::SinkPipe::new(log_format, ready_pattern, relay_token) {
                 Ok((pipe, writer)) => match pipe.start(id) {
                     Ok(child) => {
                         sink_child = Some(super::log_sink::PendingSink::new(child));

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -37,18 +37,91 @@ use std::io::PipeReader;
 
 /// Whether `opts` describes a daemon whose output can be captured by a sink.
 ///
-/// Excluded for now, both because the supervisor itself has to read the stream
-/// to serve them:
+/// Still excluded:
 ///
-/// - `ready_output`, which decides readiness by matching output
 /// - an `on_output` hook, which fires per matching line
+/// - PTY daemons, whose output arrives on a terminal master rather than a pipe
 ///
-/// and PTY daemons, whose output arrives on a terminal master rather than a
-/// pipe. Those keep the in-process path, so they remain vulnerable to a
-/// supervisor crash until the sink learns to evaluate them and report matches
-/// back.
+/// Those keep the in-process path, so they remain vulnerable to a supervisor
+/// crash. `ready_output` is served by the sink: it matches the pattern itself
+/// and reports the line back over IPC.
 pub(crate) fn is_supported(opts: &RunOptions) -> bool {
-    opts.ready_output.is_none() && opts.on_output_hook.is_none() && !opts.pty.unwrap_or(false)
+    opts.on_output_hook.is_none() && !opts.pty.unwrap_or(false)
+}
+
+/// Registers where a daemon's sink-reported output should be delivered, and
+/// stops delivery when dropped.
+///
+/// Tied to the monitoring task's lifetime: once that task is gone there is
+/// nothing waiting on readiness, and a sink that outlives it — one still
+/// draining a daemon's last output — must not be able to deliver into a channel
+/// belonging to a later run of the same daemon.
+pub(crate) struct OutputRelay(DaemonId, tokio::sync::mpsc::Sender<super::OutputLine>);
+
+impl OutputRelay {
+    /// Route lines reported for `id` into `tx` until this guard is dropped.
+    ///
+    /// Registered before the sink is started, so a match found in the daemon's
+    /// very first line still has somewhere to go.
+    pub(crate) fn register(
+        id: &DaemonId,
+        tx: tokio::sync::mpsc::Sender<super::OutputLine>,
+    ) -> Self {
+        SUPERVISOR
+            .sink_output
+            .lock()
+            .expect("sink_output lock poisoned")
+            .insert(id.clone(), tx.clone());
+        Self(id.clone(), tx)
+    }
+}
+
+impl Drop for OutputRelay {
+    fn drop(&mut self) {
+        let mut relays = SUPERVISOR
+            .sink_output
+            .lock()
+            .expect("sink_output lock poisoned");
+        // Only withdraw this registration, never a successor's. A retry
+        // registers the next attempt's channel as soon as the previous attempt
+        // reports failure, which can be before that attempt's monitoring task
+        // has finished unwinding — an unconditional remove would leave the new
+        // attempt with a sink reporting into nowhere.
+        if relays
+            .get(&self.0)
+            .is_some_and(|current| current.same_channel(&self.1))
+        {
+            relays.remove(&self.0);
+        }
+    }
+}
+
+/// Hand a line reported by a sink to the daemon's monitoring task.
+///
+/// Silently does nothing when no task is listening: a sink outliving its daemon
+/// is normal — it exits only once every descendant has closed the pipe — and a
+/// late line is not worth an error.
+pub(crate) async fn deliver_reported_line(id: &DaemonId, text: String) {
+    let tx = SUPERVISOR
+        .sink_output
+        .lock()
+        .expect("sink_output lock poisoned")
+        .get(id)
+        .cloned();
+    let Some(tx) = tx else {
+        debug!("no monitoring task is listening for output reported by the sink for {id}");
+        return;
+    };
+    if tx
+        .send(super::OutputLine {
+            text,
+            persist: false,
+        })
+        .await
+        .is_err()
+    {
+        debug!("monitoring task for {id} stopped before its sink's output arrived");
+    }
 }
 
 /// How long to wait before trying again when a sink process cannot be spawned.
@@ -191,14 +264,29 @@ impl Drop for PendingSink {
 pub(crate) struct SinkPipe {
     reader: PipeReader,
     log_format: String,
+    /// Readiness pattern for the sink to match, for a daemon configured with
+    /// `ready_output`. Passed to every sink started on this pipe, including
+    /// replacements: a daemon that is not ready yet when its sink dies still
+    /// needs the pattern watched for.
+    ready_pattern: Option<String>,
 }
 
 impl SinkPipe {
     /// Create the pipe a daemon will write to, returning the retained read end
     /// and the write end to hand the daemon.
-    pub(crate) fn new(log_format: String) -> Result<(Self, std::io::PipeWriter)> {
+    pub(crate) fn new(
+        log_format: String,
+        ready_pattern: Option<String>,
+    ) -> Result<(Self, std::io::PipeWriter)> {
         let (reader, writer) = std::io::pipe().into_diagnostic()?;
-        Ok((Self { reader, log_format }, writer))
+        Ok((
+            Self {
+                reader,
+                log_format,
+                ready_pattern,
+            },
+            writer,
+        ))
     }
 
     /// Start the first sink on this pipe.
@@ -276,13 +364,16 @@ impl SinkPipe {
     /// Spawn one sink process reading a duplicate of the retained read end.
     fn spawn(&self, id: &DaemonId) -> Result<tokio::process::Child> {
         let reader = self.reader.try_clone().into_diagnostic()?;
-        tokio::process::Command::new(&*crate::env::PITCHFORK_BIN)
-            .arg("log-sink")
+        let mut cmd = tokio::process::Command::new(&*crate::env::PITCHFORK_BIN);
+        cmd.arg("log-sink")
             .arg("--daemon-id")
             .arg(id.qualified())
             .arg("--log-format")
-            .arg(&self.log_format)
-            .stdin(std::process::Stdio::from(reader))
+            .arg(&self.log_format);
+        if let Some(ref pattern) = self.ready_pattern {
+            cmd.arg("--ready-pattern").arg(pattern);
+        }
+        cmd.stdin(std::process::Stdio::from(reader))
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -49,6 +49,17 @@ pub(crate) fn is_supported(opts: &RunOptions) -> bool {
     opts.on_output_hook.is_none() && !opts.pty.unwrap_or(false)
 }
 
+/// Source of relay tokens. Never reused within a supervisor's lifetime, and a
+/// restarted supervisor has no relays to be confused about.
+static NEXT_RELAY_TOKEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+/// A daemon's registration entry: which start attempt it belongs to, and where
+/// that attempt's output should go.
+pub(crate) struct Relay {
+    token: u64,
+    tx: tokio::sync::mpsc::Sender<super::OutputLine>,
+}
+
 /// Registers where a daemon's sink-reported output should be delivered, and
 /// stops delivery when dropped.
 ///
@@ -56,10 +67,14 @@ pub(crate) fn is_supported(opts: &RunOptions) -> bool {
 /// nothing waiting on readiness, and a sink that outlives it — one still
 /// draining a daemon's last output — must not be able to deliver into a channel
 /// belonging to a later run of the same daemon.
-pub(crate) struct OutputRelay(DaemonId, tokio::sync::mpsc::Sender<super::OutputLine>);
+pub(crate) struct OutputRelay {
+    id: DaemonId,
+    token: u64,
+}
 
 impl OutputRelay {
-    /// Route lines reported for `id` into `tx` until this guard is dropped.
+    /// Route lines reported for `id` under the returned token into `tx`, until
+    /// this guard is dropped.
     ///
     /// Registered before the sink is started, so a match found in the daemon's
     /// very first line still has somewhere to go.
@@ -67,12 +82,21 @@ impl OutputRelay {
         id: &DaemonId,
         tx: tokio::sync::mpsc::Sender<super::OutputLine>,
     ) -> Self {
+        let token = NEXT_RELAY_TOKEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         SUPERVISOR
             .sink_output
             .lock()
             .expect("sink_output lock poisoned")
-            .insert(id.clone(), tx.clone());
-        Self(id.clone(), tx)
+            .insert(id.clone(), Relay { token, tx });
+        Self {
+            id: id.clone(),
+            token,
+        }
+    }
+
+    /// The token a sink must quote for its reports to be delivered.
+    pub(crate) fn token(&self) -> u64 {
+        self.token
     }
 }
 
@@ -88,28 +112,34 @@ impl Drop for OutputRelay {
         // has finished unwinding — an unconditional remove would leave the new
         // attempt with a sink reporting into nowhere.
         if relays
-            .get(&self.0)
-            .is_some_and(|current| current.same_channel(&self.1))
+            .get(&self.id)
+            .is_some_and(|current| current.token == self.token)
         {
-            relays.remove(&self.0);
+            relays.remove(&self.id);
         }
     }
 }
 
 /// Hand a line reported by a sink to the daemon's monitoring task.
 ///
-/// Silently does nothing when no task is listening: a sink outliving its daemon
-/// is normal — it exits only once every descendant has closed the pipe — and a
-/// late line is not worth an error.
-pub(crate) async fn deliver_reported_line(id: &DaemonId, text: String) {
+/// `token` identifies the start attempt the reporting sink belongs to. A sink
+/// outlives its daemon — it exits only once every descendant has closed the
+/// pipe — so the previous attempt's sink can still be draining, and reporting,
+/// while a retry is starting. Without the token that line would be delivered to
+/// the new attempt and could mark a process ready that has printed nothing.
+///
+/// Silently does nothing when the token has expired or nothing is listening:
+/// both are ordinary, not errors.
+pub(crate) async fn deliver_reported_line(id: &DaemonId, token: u64, text: String) {
     let tx = SUPERVISOR
         .sink_output
         .lock()
         .expect("sink_output lock poisoned")
         .get(id)
-        .cloned();
+        .filter(|relay| relay.token == token)
+        .map(|relay| relay.tx.clone());
     let Some(tx) = tx else {
-        debug!("no monitoring task is listening for output reported by the sink for {id}");
+        debug!("dropping output reported for {id} by a sink from a finished start attempt");
         return;
     };
     if tx
@@ -265,10 +295,11 @@ pub(crate) struct SinkPipe {
     reader: PipeReader,
     log_format: String,
     /// Readiness pattern for the sink to match, for a daemon configured with
-    /// `ready_output`. Passed to every sink started on this pipe, including
-    /// replacements: a daemon that is not ready yet when its sink dies still
-    /// needs the pattern watched for.
+    /// `ready_output`, and the relay token its reports must quote. Passed to
+    /// every sink started on this pipe, including replacements: a daemon that
+    /// is not ready yet when its sink dies still needs the pattern watched for.
     ready_pattern: Option<String>,
+    relay_token: u64,
 }
 
 impl SinkPipe {
@@ -277,6 +308,7 @@ impl SinkPipe {
     pub(crate) fn new(
         log_format: String,
         ready_pattern: Option<String>,
+        relay_token: u64,
     ) -> Result<(Self, std::io::PipeWriter)> {
         let (reader, writer) = std::io::pipe().into_diagnostic()?;
         Ok((
@@ -284,6 +316,7 @@ impl SinkPipe {
                 reader,
                 log_format,
                 ready_pattern,
+                relay_token,
             },
             writer,
         ))
@@ -371,7 +404,10 @@ impl SinkPipe {
             .arg("--log-format")
             .arg(&self.log_format);
         if let Some(ref pattern) = self.ready_pattern {
-            cmd.arg("--ready-pattern").arg(pattern);
+            cmd.arg("--ready-pattern")
+                .arg(pattern)
+                .arg("--relay-token")
+                .arg(self.relay_token.to_string());
         }
         cmd.stdin(std::process::Stdio::from(reader))
             .stdout(std::process::Stdio::null())

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -109,7 +109,7 @@ pub struct Supervisor {
     /// sends back the line that matched. The monitoring task registers here
     /// before the sink starts and unregisters when it ends, so a line arriving
     /// from a sink that outlived its daemon has nowhere to go and is dropped.
-    pub(crate) sink_output: std::sync::Mutex<HashMap<DaemonId, mpsc::Sender<OutputLine>>>,
+    pub(crate) sink_output: std::sync::Mutex<HashMap<DaemonId, log_sink::Relay>>,
 }
 
 /// A line of daemon output on its way to the monitoring task.

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -47,7 +47,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32};
 use std::time::Duration;
 #[cfg(unix)]
 use tokio::signal::unix::SignalKind;
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::{Mutex, Notify, mpsc};
 use tokio::task::JoinHandle;
 use tokio::{signal, time};
 
@@ -102,6 +102,26 @@ pub struct Supervisor {
     /// reconciliation tell a supervised daemon from one whose monitor died
     /// with a previous supervisor process.
     pub(crate) monitored: std::sync::Mutex<HashMap<DaemonId, adopt::MonitorEntry>>,
+    /// Where to deliver output a log sink reports over IPC.
+    ///
+    /// A daemon whose output is captured by a sink writes nothing this process
+    /// reads, so the sink evaluates the daemon's readiness pattern itself and
+    /// sends back the line that matched. The monitoring task registers here
+    /// before the sink starts and unregisters when it ends, so a line arriving
+    /// from a sink that outlived its daemon has nowhere to go and is dropped.
+    pub(crate) sink_output: std::sync::Mutex<HashMap<DaemonId, mpsc::Sender<OutputLine>>>,
+}
+
+/// A line of daemon output on its way to the monitoring task.
+#[derive(Debug, Clone)]
+pub(crate) struct OutputLine {
+    pub(crate) text: String,
+    /// Whether the monitoring task must write this line to the log store.
+    ///
+    /// False for lines relayed by a sink: the sink has already stored the line
+    /// — and flushed it — before reporting it, so storing it again here would
+    /// duplicate it.
+    pub(crate) persist: bool,
 }
 
 pub(crate) fn interval_duration() -> Duration {
@@ -271,6 +291,7 @@ impl Supervisor {
             lan_monitor_task: Mutex::new(None),
             flush_cancel: std::sync::Mutex::new(None),
             monitored: std::sync::Mutex::new(HashMap::new()),
+            sink_output: std::sync::Mutex::new(HashMap::new()),
         })
     }
 

--- a/test/logs.bats
+++ b/test/logs.bats
@@ -587,6 +587,80 @@ EOF
   kill_pid "$daemon_pid"
 }
 
+@test "ready_output is decided by the sink" {
+  skip_on_windows "relies on pgrep to see the sink process"
+
+  # Readiness must not arrive before the daemon says it is ready, and must
+  # arrive once it does — with the supervisor never reading the output itself.
+  create_pitchfork_toml <<EOF
+[daemons.sinkready]
+run = "sleep 2; echo SERVING on 8080; sleep 300"
+ready_output = "SERVING"
+EOF
+
+  local start end
+  start="$(date +%s)"
+  run pitchfork start sinkready
+  assert_success
+  end="$(date +%s)"
+
+  # A sink owns the stream, so the match came back over IPC rather than from
+  # the supervisor reading the pipe.
+  run pgrep -f "log-sink --daemon-id .*sinkready"
+  assert_success
+
+  # It waited for the line rather than returning early on a timer.
+  [[ "$((end - start))" -ge 2 ]] || {
+    echo "returned after $((end - start))s; readiness did not wait for the output" >&2
+    return 1
+  }
+
+  run pitchfork status sinkready
+  assert_output --partial "running"
+
+  # The line that decided readiness is in the log store exactly once: the sink
+  # stores it, and the copy relayed to the supervisor is for matching only.
+  assert_equal "$(read_logs sinkready | grep -c "SERVING on 8080")" "1"
+
+  pitchfork stop sinkready
+}
+
+@test "log capture for a ready_output daemon survives a supervisor crash" {
+  skip_on_windows "relies on SIGKILL semantics for the supervisor"
+
+  # `ready_output` used to force in-process capture, which put the supervisor
+  # back in the data path for exactly these daemons.
+  create_pitchfork_toml <<EOF
+[daemons.readycrash]
+run = "echo LISTENING; i=0; while true; do i=\$((i+1)); echo readycrash-\$i; sleep 0.3; done"
+ready_output = "LISTENING"
+EOF
+
+  run pitchfork start readycrash
+  assert_success
+  wait_for_logs readycrash "readycrash-"
+
+  local daemon_pid sup_pid before
+  daemon_pid="$(get_daemon_pid readycrash)"
+  sup_pid="$(grep -A 10 '\[daemons\."global/pitchfork"\]' "$PITCHFORK_STATE_DIR/state.toml" |
+    grep -E '^pid = ' | head -1 | sed -E 's/.*= //')"
+  [[ -n "$daemon_pid" && -n "$sup_pid" ]]
+  before="$(read_logs readycrash | grep -c "readycrash-")"
+
+  kill_pid "$sup_pid"
+  sleep 3
+
+  pid_alive "$daemon_pid"
+  local after
+  after="$(read_logs readycrash | grep -c "readycrash-")"
+  [[ "$after" -gt "$before" ]] || {
+    echo "capture stopped at the crash: before=$before after=$after" >&2
+    return 1
+  }
+
+  kill_pid "$daemon_pid"
+}
+
 @test "a log sink that dies is replaced" {
   skip_on_windows "relies on SIGKILL semantics and pgrep"
 


### PR DESCRIPTION
## The gap

#661 moved log capture out of the supervisor, but `ready_output` daemons were excluded:

```rust
pub(crate) fn is_supported(opts: &RunOptions) -> bool {
    opts.ready_output.is_none() && opts.on_output_hook.is_none() && !opts.pty.unwrap_or(false)
}
```

The reason was structural — the supervisor had to read the output to match the pattern — but the consequence is that for those daemons **nothing about 2.19.0 applies**. The supervisor is still the pipe's only reader, so killing it leaves the pipe readerless, the daemon takes SIGPIPE seconds later, and capture dies with it. That is the original [#631](https://github.com/jdx/pitchfork/discussions/631) failure, still live for anyone using a readiness pattern — which is most people running a server.

## The change

The sink gets the pattern (`--ready-pattern`) and does the matching, since it is the process holding the stream. On the first match it **stores and flushes the line, then** reports it to the supervisor over IPC (`SinkReadyMatch`). Ordering matters: the report travels the sink's own queue behind the line itself, so by the time the supervisor hears about it, `collect_startup_logs` and `pitchfork logs` can already see the line that caused it.

Supervisor-side, the reported line is relayed into the very same channel the in-process readers feed. The monitoring task cannot tell the difference, so readiness, `on_ready`, active-port detection and the deadline logic are untouched — the pattern is still matched by the supervisor, so the sink is reporting "look at this line", not asserting readiness itself.

`OutputLine` carries a `persist` flag. In-process lines are written to the store by the monitoring task as before; relayed lines are not, because the sink already wrote them. Verified there is exactly one copy.

Two ordering hazards worth calling out, both handled:

- **Registration precedes the sink.** The channel is created in `run_once` before the sink is spawned, so a daemon whose *first* line matches doesn't report into a void.
- **Withdrawal is ownership-checked.** A retry registers attempt N+1's channel as soon as attempt N reports failure, which can happen before attempt N's monitoring task finishes unwinding. An unconditional `remove` in `Drop` would delete the new attempt's registration and hang it until its readiness timeout. The guard compares `Sender::same_channel` before removing, the same revalidate-before-acting pattern used for monitor tokens.

The relay is also dropped explicitly at process exit, before the post-exit drain: it holds a sender, so leaving it registered would keep the channel open and make every drain wait out its full 5s deadline.

## Still not covered

`on_output` hooks and `pty = true`. Both still use in-process capture and remain crash-vulnerable; the module docs say so. `on_output` is the natural next step — same plumbing, plus debounce — while PTY needs the sink to be handed a terminal master rather than a pipe.

## Tests

- `ready_output is decided by the sink` — asserts a sink process owns the stream, that `start` waited for the line rather than a timer, and that the deciding line is in the store exactly once
- `log capture for a ready_output daemon survives a supervisor crash` — SIGKILL the supervisor, daemon lives, log lines keep accruing

Both were mutation-tested: with `is_supported` reverted to main's version, both fail. 523 unit tests; 96 bats across logs, basic, hooks, port and pty.

---
*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon startup readiness, IPC, and retry ordering; mistakes could mark daemons ready early or miss readiness, but existing supervisor matching is preserved and tokens guard stale sinks.
> 
> **Overview**
> **`ready_output` daemons can use the out-of-process log sink again**, so log capture and readiness no longer force the supervisor to own the output pipe (the gap left after moving logging to sinks).
> 
> The hidden `log-sink` command gains **`--ready-pattern`** and **`--relay-token`**. The sink matches readiness in-process (ANSI stripped, with carry across over-long line splits), **persists the matching line before** reporting via new IPC **`SinkReadyMatch`**. The supervisor relays that line into the same monitoring channel as in-process readers, using **`OutputLine { persist }`** so sink-stored lines are not duplicated.
> 
> **`is_supported`** no longer excludes `ready_output`; **`OutputRelay`** registers per start attempt with token-checked delivery and careful unregister on retry. Integration bats cover sink-owned readiness and supervisor-crash survival for `ready_output`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c0a4116927a6a6db2ca7e7dfa2d8875836305d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->