### PR TITLE
chore: release v2.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.20.0](https://github.com/jdx/pitchfork/compare/v2.19.0...v2.20.0) - 2026-08-02
+
+### Added
+
+- *(supervisor)* expand ~ in daemon dir using effective user's home ([#708](https://github.com/jdx/pitchfork/pull/708))
+- *(boot)* auto-heal stale boot registration on supervisor startup ([#707](https://github.com/jdx/pitchfork/pull/707))
+- *(web)* structured log display with filters in webui ([#630](https://github.com/jdx/pitchfork/pull/630))
+- *(supervisor)* allow disabling client auto-start ([#678](https://github.com/jdx/pitchfork/pull/678))
+- *(supervisor)* add --json flag to supervisor status ([#601](https://github.com/jdx/pitchfork/pull/601))
+- *(config)* expand home-relative paths ([#675](https://github.com/jdx/pitchfork/pull/675))
+- *(logs)* let the sink serve on_output hooks ([#668](https://github.com/jdx/pitchfork/pull/668))
+- *(usage)* declare what each command does to the world ([#666](https://github.com/jdx/pitchfork/pull/666))
+- *(logs)* let the sink decide ready_output ([#667](https://github.com/jdx/pitchfork/pull/667))
+
+### Fixed
+
+- deterministic IPC response attribution and whole-group stop wait ([#606](https://github.com/jdx/pitchfork/pull/606))
+- *(config)* include registries in schema ([#671](https://github.com/jdx/pitchfork/pull/671))
+
+### Other
+
+- *(deps)* update rust crate libc to v0.2.189 ([#703](https://github.com/jdx/pitchfork/pull/703))
+- *(deps)* update rust crate clap to v4.6.4 ([#702](https://github.com/jdx/pitchfork/pull/702))
+- *(deps)* update rust crate glob to v0.3.4 ([#701](https://github.com/jdx/pitchfork/pull/701))
+- *(deps)* update rust crate tokio-util to v0.7.19 ([#699](https://github.com/jdx/pitchfork/pull/699))
+- *(deps)* update rust crate libc to v0.2.188 ([#698](https://github.com/jdx/pitchfork/pull/698))
+- *(deps)* update rust crate syn to v3 ([#697](https://github.com/jdx/pitchfork/pull/697))
+- *(deps)* update rust crate hyper to v1.11.0 ([#695](https://github.com/jdx/pitchfork/pull/695))
+- *(deps)* update rust crate tokio to v1.53.1 ([#692](https://github.com/jdx/pitchfork/pull/692))
+- *(deps)* update rust crate thiserror to v2.0.19 ([#691](https://github.com/jdx/pitchfork/pull/691))
+- *(deps)* update rust crate serde to v1.0.229 ([#689](https://github.com/jdx/pitchfork/pull/689))
+- *(deps)* update rust crate quote to v1.0.47 ([#687](https://github.com/jdx/pitchfork/pull/687))
+- *(deps)* update rust crate serde_json to v1.0.151 ([#690](https://github.com/jdx/pitchfork/pull/690))
+- *(deps)* update rust crate libc to v0.2.187 ([#685](https://github.com/jdx/pitchfork/pull/685))
+- *(deps)* update rust crate proc-macro2 to v1.0.107 ([#686](https://github.com/jdx/pitchfork/pull/686))
+- *(deps)* update rust crate clx to v3.0.2 ([#684](https://github.com/jdx/pitchfork/pull/684))
+- *(deps)* update rust crate clap to v4.6.3 ([#683](https://github.com/jdx/pitchfork/pull/683))
+- *(deps)* use rust-aware cargo resolver ([#677](https://github.com/jdx/pitchfork/pull/677))
+- *(deps)* update clx ([#672](https://github.com/jdx/pitchfork/pull/672))
+
 ## [2.19.0](https://github.com/jdx/pitchfork/compare/v2.18.0...v2.19.0) - 2026-07-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,7 +2931,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.19.0"
+version = "2.20.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.19.0"
+version = "2.20.0"
 edition = "2024"
 resolver = "3"
 rust-version = "1.88"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3204,7 +3204,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.19.0",
+  "version": "2.20.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.19.0
+**Version**: 2.20.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name pitchfork
 bin pitchfork
-version "2.19.0"
+version "2.20.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" effect=read {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.19.0 -> 2.20.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.20.0](https://github.com/jdx/pitchfork/compare/v2.19.0...v2.20.0) - 2026-08-02

### Added

- *(supervisor)* expand ~ in daemon dir using effective user's home ([#708](https://github.com/jdx/pitchfork/pull/708))
- *(boot)* auto-heal stale boot registration on supervisor startup ([#707](https://github.com/jdx/pitchfork/pull/707))
- *(web)* structured log display with filters in webui ([#630](https://github.com/jdx/pitchfork/pull/630))
- *(supervisor)* allow disabling client auto-start ([#678](https://github.com/jdx/pitchfork/pull/678))
- *(supervisor)* add --json flag to supervisor status ([#601](https://github.com/jdx/pitchfork/pull/601))
- *(config)* expand home-relative paths ([#675](https://github.com/jdx/pitchfork/pull/675))
- *(logs)* let the sink serve on_output hooks ([#668](https://github.com/jdx/pitchfork/pull/668))
- *(usage)* declare what each command does to the world ([#666](https://github.com/jdx/pitchfork/pull/666))
- *(logs)* let the sink decide ready_output ([#667](https://github.com/jdx/pitchfork/pull/667))

### Fixed

- deterministic IPC response attribution and whole-group stop wait ([#606](https://github.com/jdx/pitchfork/pull/606))
- *(config)* include registries in schema ([#671](https://github.com/jdx/pitchfork/pull/671))

### Other

- *(deps)* update rust crate libc to v0.2.189 ([#703](https://github.com/jdx/pitchfork/pull/703))
- *(deps)* update rust crate clap to v4.6.4 ([#702](https://github.com/jdx/pitchfork/pull/702))
- *(deps)* update rust crate glob to v0.3.4 ([#701](https://github.com/jdx/pitchfork/pull/701))
- *(deps)* update rust crate tokio-util to v0.7.19 ([#699](https://github.com/jdx/pitchfork/pull/699))
- *(deps)* update rust crate libc to v0.2.188 ([#698](https://github.com/jdx/pitchfork/pull/698))
- *(deps)* update rust crate syn to v3 ([#697](https://github.com/jdx/pitchfork/pull/697))
- *(deps)* update rust crate hyper to v1.11.0 ([#695](https://github.com/jdx/pitchfork/pull/695))
- *(deps)* update rust crate tokio to v1.53.1 ([#692](https://github.com/jdx/pitchfork/pull/692))
- *(deps)* update rust crate thiserror to v2.0.19 ([#691](https://github.com/jdx/pitchfork/pull/691))
- *(deps)* update rust crate serde to v1.0.229 ([#689](https://github.com/jdx/pitchfork/pull/689))
- *(deps)* update rust crate quote to v1.0.47 ([#687](https://github.com/jdx/pitchfork/pull/687))
- *(deps)* update rust crate serde_json to v1.0.151 ([#690](https://github.com/jdx/pitchfork/pull/690))
- *(deps)* update rust crate libc to v0.2.187 ([#685](https://github.com/jdx/pitchfork/pull/685))
- *(deps)* update rust crate proc-macro2 to v1.0.107 ([#686](https://github.com/jdx/pitchfork/pull/686))
- *(deps)* update rust crate clx to v3.0.2 ([#684](https://github.com/jdx/pitchfork/pull/684))
- *(deps)* update rust crate clap to v4.6.3 ([#683](https://github.com/jdx/pitchfork/pull/683))
- *(deps)* use rust-aware cargo resolver ([#677](https://github.com/jdx/pitchfork/pull/677))
- *(deps)* update clx ([#672](https://github.com/jdx/pitchfork/pull/672))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump and changelog; no behavioral changes in the diff itself.
> 
> **Overview**
> Bumps **pitchfork-cli** from **2.19.0** to **2.20.0** in `Cargo.toml`, `Cargo.lock`, and generated CLI metadata (`pitchfork.usage.kdl`, `docs/cli/commands.json`, `docs/cli/index.md`).
> 
> Adds a **CHANGELOG** section for **2.20.0** that records what shipped since 2.19.0 (supervisor path expansion, boot auto-heal, web UI log filters, IPC/stop fixes, config schema, dependency updates, etc.). This PR does not implement those features—it only publishes the release notes and version strings for tagging/publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d9c08b3ef6ee65bf6e54f4973bff967dcbba79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->