### PR TITLE
chore: re-render the usage file for clap_usage 4

### DIFF
--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -335,11 +335,19 @@ every descendant holding the write end have gone.
         arg <LOG_FORMAT>
     }
     flag --ready-pattern help="Regex whose first match means the daemon is ready" {
-        long_help "Regex whose first match means the daemon is ready\n\nSet for a daemon configured with `ready_output`. The supervisor cannot match it itself — this process holds the output — so the match is reported back over IPC."
+        long_help #"""
+Regex whose first match means the daemon is ready
+
+Set for a daemon configured with `ready_output`. The supervisor cannot match it itself — this process holds the output — so the match is reported back over IPC.
+"""#
         arg <READY_PATTERN>
     }
     flag --relay-token help="Token identifying the start attempt this sink belongs to" default="0" {
-        long_help "Token identifying the start attempt this sink belongs to\n\nQuoted back when reporting a match. The supervisor drops reports whose token is no longer current, so a sink still draining a failed attempt cannot mark that daemon's retry ready."
+        long_help #"""
+Token identifying the start attempt this sink belongs to
+
+Quoted back when reporting a match. The supervisor drops reports whose token is no longer current, so a sink still draining a failed attempt cannot mark that daemon's retry ready.
+"""#
         arg <RELAY_TOKEN>
     }
 }


### PR DESCRIPTION
Fixes the `build` job on `main`, failing since f161795 with `'mise run render' produced changes`.

## Cause

[#666](https://github.com/jdx/pitchfork/pull/666) bumped `clap_usage` 2 → 4 (`usage-lib` 2.18.2 → 4.0.0). The new major version serializes a multi-paragraph `long_help` as a KDL raw string rather than one quoted line with escaped newlines.

The only two flags in the CLI with a multi-paragraph `long_help` are `--ready-pattern` and `--relay-token`, on the hidden `log-sink` command — both added by [#667](https://github.com/jdx/pitchfork/pull/667), merged twelve minutes before #666. Each PR rendered cleanly against the tree it was tested on; the combination existed for the first time on `main`, and `pitchfork.usage.kdl` has been stale since.

## This PR

`mise run render`, nothing else. Generated output, no source changes:

```
 pitchfork.usage.kdl | 12 ++++++++++--
```

## Worth noting

`mise.toml` pins `usage = "latest"` for the CLI-side renderer, while `clap_usage` is a pinned crate dependency. The two can drift apart without any PR touching `Cargo.toml`, so this failure mode can recur on an unrelated commit. Pinning the tool would remove that.

---
*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated documentation-only change with no runtime or CLI logic impact.
> 
> **Overview**
> Regenerates **`pitchfork.usage.kdl`** so it matches **clap_usage 4** output. No Rust or CLI behavior changes.
> 
> On the hidden **`log-sink`** command, **`--ready-pattern`** and **`--relay-token`** now use KDL **raw-string** `long_help` blocks (`#"""..."""#`) instead of one quoted line with `\n` escapes. The help text is unchanged; only serialization format differs after the **clap_usage** major bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 573b184ccb6c7ad64540cd57b486c84257884760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->