### PR TITLE
feat(config): expand home-relative paths

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -119,8 +119,7 @@ run = "cd /app && exec node server.js"
 
 ### `dir`
 
-Working directory for the daemon. Relative paths are resolved from the `pitchfork.toml` file location. If not set, defaults to the directory containing the `pitchfork.toml` file.
-Paths beginning with `~` are resolved from the user's home directory.
+Working directory for the daemon. Relative paths are resolved from the `pitchfork.toml` file location. If not set, defaults to the directory containing the `pitchfork.toml` file. A value of `~` or a path beginning with `~/` is resolved from the user's home directory; other shell-style expansions are left unchanged.
 
 ```toml
 # Relative path (resolved from pitchfork.toml location)
@@ -132,11 +131,6 @@ dir = "frontend"
 [daemons.api]
 run = "npm run server"
 dir = "/opt/myapp/api"
-
-# Home-relative path
-[daemons.worker]
-run = "npm run worker"
-dir = "~/projects/myapp"
 ```
 
 ### `env`
@@ -669,7 +663,7 @@ Each slug entry maps to:
 - `dir` — the project directory containing the `pitchfork.toml`
 - `daemon` (optional) — the daemon name within that project. Defaults to the slug name if omitted.
 
-Slug and namespace `dir` values also support a leading `~` for the user's home directory.
+Slug and namespace `dir` values use the same `~` and `~/...` expansion.
 
 Use `pitchfork proxy add` to manage slugs:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -120,6 +120,7 @@ run = "cd /app && exec node server.js"
 ### `dir`
 
 Working directory for the daemon. Relative paths are resolved from the `pitchfork.toml` file location. If not set, defaults to the directory containing the `pitchfork.toml` file.
+Paths beginning with `~` are resolved from the user's home directory.
 
 ```toml
 # Relative path (resolved from pitchfork.toml location)
@@ -131,6 +132,11 @@ dir = "frontend"
 [daemons.api]
 run = "npm run server"
 dir = "/opt/myapp/api"
+
+# Home-relative path
+[daemons.worker]
+run = "npm run worker"
+dir = "~/projects/myapp"
 ```
 
 ### `env`
@@ -662,6 +668,8 @@ docs = { dir = "/home/user/docs-site" }  # defaults daemon = "docs"
 Each slug entry maps to:
 - `dir` — the project directory containing the `pitchfork.toml`
 - `daemon` (optional) — the daemon name within that project. Defaults to the slug name if omitted.
+
+Slug and namespace `dir` values also support a leading `~` for the user's home directory.
 
 Use `pitchfork proxy add` to manage slugs:
 

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -437,7 +437,11 @@ impl Add {
             );
         }
 
-        let dir = self.dir.clone().unwrap_or_else(|| crate::env::CWD.clone());
+        let dir = self
+            .dir
+            .as_ref()
+            .map(crate::env::expand_tilde)
+            .unwrap_or_else(|| crate::env::CWD.clone());
         let dir = dir.canonicalize().unwrap_or(dir);
 
         let daemon = self.daemon.as_deref();

--- a/src/env.rs
+++ b/src/env.rs
@@ -83,8 +83,21 @@ pub static IPC_SOCK_MAIN: Lazy<PathBuf> = Lazy::new(|| IPC_SOCK_DIR.join("main.s
 pub static ORIGINAL_PATH: Lazy<Option<String>> = Lazy::new(|| var("PATH").ok());
 pub static IPC_JSON: Lazy<bool> = Lazy::new(|| !var_false("IPC_JSON"));
 
+/// Expand a leading `~` path component to the current Pitchfork user's home.
+///
+/// This intentionally supports only `~` and `~/...`, not `~user` or shell
+/// expansions such as `$HOME`. Pitchfork's home resolution accounts for the
+/// original user when running under `sudo`.
+pub fn expand_tilde(path: impl AsRef<std::path::Path>) -> PathBuf {
+    let path = path.as_ref();
+    match path.strip_prefix("~") {
+        Ok(rest) => HOME_DIR.join(rest),
+        Err(_) => path.to_path_buf(),
+    }
+}
+
 fn var_path(name: &str) -> Option<PathBuf> {
-    var(name).map(PathBuf::from).ok()
+    var(name).map(expand_tilde).ok()
 }
 
 fn var_log_level(name: &str) -> Option<log::LevelFilter> {
@@ -132,4 +145,29 @@ fn configured_supervisor_user_home_dir() -> Option<PathBuf> {
     }
 
     home_dir_for_user(user)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn expand_tilde_replaces_home_prefix() {
+        assert_eq!(
+            expand_tilde("~/projects/api"),
+            HOME_DIR.join("projects/api")
+        );
+        assert_eq!(expand_tilde("~"), *HOME_DIR);
+    }
+
+    #[test]
+    fn expand_tilde_leaves_other_paths_unchanged() {
+        assert_eq!(
+            expand_tilde("/srv/projects/api"),
+            Path::new("/srv/projects/api")
+        );
+        assert_eq!(expand_tilde("projects/api"), Path::new("projects/api"));
+        assert_eq!(expand_tilde("~other/api"), Path::new("~other/api"));
+    }
 }

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -1079,7 +1079,7 @@ pub fn resolve_config_base_dir(config_path: Option<&Path>) -> PathBuf {
 pub fn resolve_daemon_dir(dir: Option<&str>, config_path: Option<&Path>) -> PathBuf {
     let base_dir = resolve_config_base_dir(config_path);
     match dir {
-        Some(d) => base_dir.join(d),
+        Some(d) => base_dir.join(crate::env::expand_tilde(d)),
         None => base_dir,
     }
 }
@@ -1206,6 +1206,15 @@ mod tests {
             Some(Path::new("/projects/myapp/pitchfork.toml")),
         );
         assert_eq!(result, PathBuf::from("/opt/myapp"));
+    }
+
+    #[test]
+    fn test_resolve_daemon_dir_tilde() {
+        let result = resolve_daemon_dir(
+            Some("~/projects/myapp"),
+            Some(Path::new("/projects/other/pitchfork.toml")),
+        );
+        assert_eq!(result, crate::env::HOME_DIR.join("projects/myapp"));
     }
 
     #[test]

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -1134,7 +1134,7 @@ impl PitchforkToml {
             pt.slugs.insert(
                 slug,
                 SlugEntry {
-                    dir: entry.dir.map(PathBuf::from),
+                    dir: entry.dir.map(env::expand_tilde),
                     namespace: entry.namespace,
                     daemon: entry.daemon,
                 },
@@ -1146,7 +1146,7 @@ impl PitchforkToml {
             pt.namespaces.insert(
                 name,
                 NamespaceEntry {
-                    dir: PathBuf::from(entry.dir),
+                    dir: env::expand_tilde(entry.dir),
                 },
             );
         }
@@ -1549,7 +1549,7 @@ impl PitchforkToml {
         pt.namespaces.insert(
             name.to_string(),
             NamespaceEntry {
-                dir: PathBuf::from(dir),
+                dir: env::expand_tilde(dir),
             },
         );
         pt.write_unlocked()?;
@@ -1791,6 +1791,30 @@ user = "postgres"
             .get(&DaemonId::new("test-project", "api"))
             .unwrap();
         assert_eq!(daemon.user.as_deref(), Some("postgres"));
+    }
+
+    #[test]
+    fn test_registry_dirs_expand_tilde() {
+        let pt = PitchforkToml::parse_str(
+            r#"
+[slugs.api]
+dir = "~/projects/api"
+
+[namespaces.web]
+dir = "~/projects/web"
+"#,
+            Path::new("/tmp/config.toml"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            pt.slugs["api"].dir,
+            Some(crate::env::HOME_DIR.join("projects/api"))
+        );
+        assert_eq!(
+            pt.namespaces["web"].dir,
+            crate::env::HOME_DIR.join("projects/web")
+        );
     }
 
     #[test]

--- a/src/web/routes/api/namespaces.rs
+++ b/src/web/routes/api/namespaces.rs
@@ -1,6 +1,5 @@
 use axum::{extract::Path, response::Json};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
 
 use crate::pitchfork_toml::PitchforkToml;
 
@@ -29,7 +28,7 @@ pub async fn list() -> Json<Vec<ApiNamespaceEntry>> {
 pub async fn register(
     Json(req): Json<RegisterNamespaceReq>,
 ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
-    let dir = PathBuf::from(&req.dir);
+    let dir = crate::env::expand_tilde(&req.dir);
     let name = match PitchforkToml::namespace_for_dir(&dir) {
         Ok(ns) => ns,
         Err(e) => {
@@ -39,7 +38,7 @@ pub async fn register(
             ));
         }
     };
-    match PitchforkToml::register_namespace(&name, &req.dir) {
+    match PitchforkToml::register_namespace(&name, &dir.to_string_lossy()) {
         Ok(()) => Ok(Json(serde_json::json!({"ok": true, "name": name}))),
         Err(e) => {
             log::error!("Failed to register namespace {}: {e}", name);


### PR DESCRIPTION
## Summary

- expand leading `~` components in daemon, slug, and namespace directory paths
- use Pitchfork’s existing home resolution so elevated invocations retain the original user’s home
- support the same expansion for path-valued Pitchfork environment overrides and proxy namespace registration
- document the behavior and cover expanded and unchanged path forms

## Why

TOML paths were converted directly to filesystem paths, so `~/projects/app` was treated as a literal relative path. This adds explicit, mise-style tilde expansion without enabling broader shell interpolation such as `$VAR`, `~user`, globs, or command substitution.

## Validation

- `mise run ci-dev`
- 559 Rust tests passed
- 303 Bats tests passed (documented slow and SQLite-dependent tests skipped by the suite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent support for `~` and `~/...` directory paths across configuration loading, daemon dir resolution, proxy slug mappings, global slug/namespace registry parsing, and namespace registration.
  - Ensures home-relative paths are expanded to the user’s home directory, while non-`~` and `~other/...` forms remain unchanged.

- **Bug Fixes**
  - Fixed cases where tilde-prefixed `dir` values were previously treated as literal paths.

- **Documentation**
  - Updated configuration reference to clarify `~`/`~/...` behavior for daemon `dir`, slugs, and namespaces.

- **Tests**
  - Added unit tests covering tilde expansion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->