### PR TITLE
feat(supervisor): allow disabling client auto-start

### DIFF
--- a/docs/guides/boot-start.md
+++ b/docs/guides/boot-start.md
@@ -41,10 +41,10 @@ The registration mode is determined automatically based on whether the command r
 
 If you need the supervisor to run as root (e.g. to manage system-level processes), use `sudo pitchfork boot enable`.
 
-However, if you still want state files, IPC sockets and daemon processes to belong to a specific user rather than root, set `supervisor.user` in your global config (`/etc/pitchfork/config.toml` or `~/.config/pitchfork/config.toml`):
+However, if you still want state files, IPC sockets and daemon processes to belong to a specific user rather than root, set `settings.supervisor.user` in your global config (`/etc/pitchfork/config.toml` or `~/.config/pitchfork/config.toml`):
 
 ```toml
-[supervisor]
+[settings.supervisor]
 user = "alice"
 ```
 

--- a/docs/guides/boot-start.md
+++ b/docs/guides/boot-start.md
@@ -80,6 +80,22 @@ When boot start is enabled:
 2. Supervisor starts all daemons with `boot_start = true`
 3. Daemons run in the background
 
+### Prevent fallback supervisor starts
+
+When systemd, launchd, or another service manager is the only intended owner of
+the supervisor, disable client-side auto-start in your global configuration:
+
+```toml
+[settings.supervisor]
+auto_start = false
+```
+
+Commands such as `pitchfork list`, the TUI, and shell activation will then
+connect to the managed supervisor without spawning an unmanaged replacement if
+the service is unavailable or still starting. Explicit
+`pitchfork supervisor start` and `pitchfork supervisor run` commands remain
+available.
+
 ## Typical Setup
 
 1. Enable boot start:

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -1083,6 +1083,13 @@
     "SettingsSupervisorPartial": {
       "type": "object",
       "properties": {
+        "auto_start": {
+          "description": "Automatically start the supervisor when a client command needs it",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "cleanup_orphans": {
           "description": "Reconcile orphaned daemon processes when supervisor starts",
           "type": [

--- a/docs/reference/environment-vars.md
+++ b/docs/reference/environment-vars.md
@@ -38,6 +38,22 @@ PITCHFORK_WEB_PORT=19876 pitchfork supervisor start --force
 
 If the specified port is in use, pitchfork tries up to 10 consecutive ports.
 
+## `PITCHFORK_SUPERVISOR_AUTO_START`
+
+Controls whether client commands automatically launch a background supervisor
+when none is running. The default is `true`.
+
+Set it to `false` when systemd, launchd, or another service manager owns the
+supervisor:
+
+```bash
+export PITCHFORK_SUPERVISOR_AUTO_START=false
+```
+
+Client commands then fail with an actionable connection error instead of
+spawning an unmanaged supervisor. Explicit `pitchfork supervisor start` and
+`pitchfork supervisor run` commands are unaffected.
+
 ## Daemon Process Variables
 
 These environment variables are automatically set for every daemon process and its [lifecycle hooks](/guides/lifecycle-hooks).

--- a/settings.toml
+++ b/settings.toml
@@ -600,6 +600,30 @@ in the TUI before automatically clearing.
 
 [supervisor]
 
+[supervisor.auto_start]
+type = "Bool"
+env = "PITCHFORK_SUPERVISOR_AUTO_START"
+default = "true"
+description = "Automatically start the supervisor when a client command needs it"
+docs = """
+When enabled (default), commands such as `pitchfork start`, `pitchfork list`,
+the TUI, and shell activation start a background supervisor automatically when
+one is not already running.
+
+Disable this when the supervisor is managed by systemd, launchd, or another
+service manager:
+
+```toml
+[settings.supervisor]
+auto_start = false
+```
+
+With auto-start disabled, client commands wait for the configured IPC
+connection attempts and then fail with an actionable error instead of spawning
+an unmanaged supervisor. Explicit `pitchfork supervisor start` and
+`pitchfork supervisor run` commands are unaffected.
+"""
+
 [supervisor.ready_check_interval]
 type = "Duration"
 env = "PITCHFORK_READY_CHECK_INTERVAL"

--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -427,6 +427,7 @@ fn get_tui_value(g: &crate::settings::SettingsTui, field: &str) -> String {
 
 fn get_supervisor_value(g: &crate::settings::SettingsSupervisor, field: &str) -> String {
     match field {
+        "auto_start" => g.auto_start.to_string(),
         "ready_check_interval" => g.ready_check_interval.clone(),
         "file_watch_debounce" => g.file_watch_debounce.clone(),
         "log_flush_interval" => g.log_flush_interval.clone(),
@@ -622,6 +623,7 @@ fn apply_supervisor_value(
     typ: &str,
 ) -> Result<()> {
     match field {
+        "auto_start" => partial.auto_start = Some(parse_bool_value(value)?),
         "ready_check_interval" => partial.ready_check_interval = Some(value.to_string()),
         "file_watch_debounce" => partial.file_watch_debounce = Some(value.to_string()),
         "log_flush_interval" => partial.log_flush_interval = Some(value.to_string()),

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -51,7 +51,7 @@ pub struct IpcClient {
 
 impl IpcClient {
     pub async fn connect(autostart: bool) -> Result<Self> {
-        if autostart {
+        if autostart && settings().supervisor.auto_start {
             supervisor::start_if_not_running()?;
         }
         let id = Uuid::new_v4().to_string();
@@ -126,6 +126,15 @@ impl IpcClient {
     /// whose framing was lost after a failed exchange (see `desynced`).
     async fn open_stream(name: &str) -> Result<(BufReader<RecvHalf>, SendHalf)> {
         let s = settings();
+        let connection_help = || {
+            if s.supervisor.auto_start {
+                "ensure the supervisor is running with: pitchfork supervisor start".to_string()
+            } else {
+                "supervisor auto-start is disabled; start it with your service manager or run: \
+                 pitchfork supervisor start"
+                    .to_string()
+            }
+        };
         let connect_attempts = u32::try_from(s.ipc.connect_attempts).unwrap_or_else(|_| {
             warn!(
                 "ipc.connect_attempts value {} is out of range (0-{}), clamping to 5",
@@ -174,9 +183,7 @@ impl IpcClient {
                             return Err(IpcError::ConnectionFailed {
                                 attempts: connect_attempts,
                                 source: Some(err),
-                                help:
-                                    "ensure the supervisor is running with: pitchfork supervisor start"
-                                        .to_string(),
+                                help: connection_help(),
                             }
                             .into());
                         }
@@ -186,8 +193,7 @@ impl IpcClient {
             Err(IpcError::ConnectionFailed {
                 attempts: connect_attempts,
                 source: None,
-                help: "ensure the supervisor is running with: pitchfork supervisor start"
-                    .to_string(),
+                help: connection_help(),
             }
             .into())
         })
@@ -197,7 +203,8 @@ impl IpcClient {
                 attempts: connect_attempts,
                 source: None,
                 help: format!(
-                    "connection timed out after {connect_timeout:?}; ensure the supervisor is running with: pitchfork supervisor start"
+                    "connection timed out after {connect_timeout:?}; {}",
+                    connection_help()
                 ),
             }
             .into())

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -132,6 +132,7 @@ mod tests {
         assert_eq!(settings.tui.stat_history, 60);
 
         // Test supervisor settings
+        assert!(settings.supervisor.auto_start);
         assert_eq!(settings.supervisor.ready_check_interval, "500ms");
         assert_eq!(settings.supervisor.file_watch_debounce, "1s");
         assert_eq!(settings.supervisor.user, "");
@@ -256,6 +257,7 @@ log_level = "warn"
             std::env::set_var("PITCHFORK_AUTOSTOP_DELAY", "10m");
             std::env::set_var("PITCHFORK_INTERVAL", "5s");
             std::env::set_var("PITCHFORK_IPC_CONNECT_ATTEMPTS", "20");
+            std::env::set_var("PITCHFORK_SUPERVISOR_AUTO_START", "false");
             std::env::set_var("PITCHFORK_WEB_AUTO_START", "true");
         }
 
@@ -266,6 +268,7 @@ log_level = "warn"
         assert_eq!(settings.general.autostop_delay, "10m");
         assert_eq!(settings.general.interval, "5s");
         assert_eq!(settings.ipc.connect_attempts, 20);
+        assert!(!settings.supervisor.auto_start);
         assert!(settings.web.auto_start);
 
         // Fields with no corresponding env var set remain at defaults
@@ -278,6 +281,7 @@ log_level = "warn"
             std::env::remove_var("PITCHFORK_AUTOSTOP_DELAY");
             std::env::remove_var("PITCHFORK_INTERVAL");
             std::env::remove_var("PITCHFORK_IPC_CONNECT_ATTEMPTS");
+            std::env::remove_var("PITCHFORK_SUPERVISOR_AUTO_START");
             std::env::remove_var("PITCHFORK_WEB_AUTO_START");
         }
     }
@@ -512,6 +516,7 @@ auto_start = true
 bind_port = 8080
 
 [settings.supervisor]
+auto_start = false
 user = "postgres"
 "#;
 
@@ -528,6 +533,7 @@ user = "postgres"
         assert_eq!(settings.general.log_level, "debug");
         assert!(settings.web.auto_start);
         assert_eq!(settings.web.bind_port, 8080);
+        assert!(!settings.supervisor.auto_start);
         assert_eq!(settings.supervisor.user, "postgres");
         assert_eq!(settings.general.interval, "10s");
         assert_eq!(settings.ipc.connect_attempts, 5);

--- a/test/errors.bats
+++ b/test/errors.bats
@@ -125,6 +125,27 @@ EOF
   wait_for_status auto_start_test running
 }
 
+@test "CLI does not auto-start supervisor when disabled" {
+  create_pitchfork_toml <<EOF
+[settings.supervisor]
+auto_start = false
+EOF
+
+  pitchfork supervisor stop
+
+  export PITCHFORK_IPC_CONNECT_ATTEMPTS=1
+  export PITCHFORK_IPC_CONNECT_MIN_DELAY=1ms
+  export PITCHFORK_IPC_CONNECT_MAX_DELAY=1ms
+
+  run pitchfork list
+  assert_failure
+  assert_output --partial "supervisor auto-start is disabled"
+  assert_output --partial "service manager"
+
+  run pitchfork supervisor status
+  assert_failure
+}
+
 @test "pitchfork list works with empty config" {
   PITCHFORK_LOG=warn run pitchfork list
   assert_success

--- a/test/errors.bats
+++ b/test/errors.bats
@@ -126,7 +126,7 @@ EOF
 }
 
 @test "CLI does not auto-start supervisor when disabled" {
-  create_pitchfork_toml <<EOF
+  cat > "$PITCHFORK_CONFIG_DIR/config.toml" <<EOF
 [settings.supervisor]
 auto_start = false
 EOF

--- a/test/settings.bats
+++ b/test/settings.bats
@@ -116,6 +116,17 @@ teardown() {
   assert_output --partial "7s"
 }
 
+@test "settings set supports disabling supervisor auto-start" {
+  run pitchfork settings set supervisor.auto_start false
+  assert_success
+  assert_file_contains "pitchfork.toml" 'auto_start = false'
+  assert_file_contains "pitchfork.toml" "\[settings\.supervisor\]"
+
+  run pitchfork settings get supervisor.auto_start
+  assert_success
+  assert_output "false"
+}
+
 # ============================================================================
 # Group C: config precedence
 # ============================================================================


### PR DESCRIPTION
## Summary

- add `supervisor.auto_start` with a backwards-compatible default of `true`
- prevent implicit client launches when the setting is disabled while leaving explicit supervisor commands unchanged
- provide actionable connection errors for service-managed installations
- expose the setting through the settings CLI, environment variables, schema, and documentation

## Root cause

Clients currently call `start_if_not_running()` before connecting to IPC. During
system startup, a shell hook or another client can therefore spawn an unmanaged
supervisor before a systemd- or launchd-managed instance is ready. The unmanaged
process then wins ownership of the supervisor state and socket but lacks any
capabilities configured on the service.

## Validation

- `mise run ci-dev`
  - 553 Rust tests passed
  - 308 Bats tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `settings.supervisor.auto_start` option to control whether client commands automatically start the supervisor.
  * Added `PITCHFORK_SUPERVISOR_AUTO_START` support for configuring this behavior via environment variable.
  * Explicit supervisor start and run commands remain available regardless of the setting.
* **Bug Fixes**
  * When auto-start is disabled, client commands no longer launch an unmanaged supervisor and instead provide actionable connection guidance.
* **Documentation**
  * Updated the boot/start guide and environment variable docs to clarify behavior with external service managers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->