### PR TITLE
ci: run perf jobs on bamboo

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - bamboo-perf

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
 
 jobs:
   measure:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -32,6 +32,7 @@ env:
 jobs:
   measure:
     name: Compare instruction counts
+    if: github.event.pull_request.user.login == 'jdx'
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
@@ -138,7 +139,7 @@ jobs:
   report:
     name: Report and gate
     needs: measure
-    if: always()
+    if: always() && github.event.pull_request.user.login == 'jdx'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -27,6 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
 
 jobs:
   measure:
@@ -35,7 +36,7 @@ jobs:
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
     # the report would say "nothing was compared" instead of anything useful.
-    runs-on: ubuntu-latest
+    runs-on: bamboo-perf
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
 
 jobs:
   measure:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,6 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
 
 jobs:
   measure:
@@ -34,7 +35,7 @@ jobs:
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
     # that wanders between runners is unreadable.
-    runs-on: ubuntu-latest
+    runs-on: bamboo-perf
     timeout-minutes: 30
     permissions:
       contents: write # pushing refs/notes/tak is a write to this repository


### PR DESCRIPTION
## Summary

- run Tak measurement jobs on the isolated `bamboo-perf` runner
- identify the Bamboo image/toolchain as a distinct Tak runner class
- leave report and publish jobs on hosted runners

## Validation

- `actionlint` (with `bamboo-perf` registered as the expected custom label)
- `git diff --check`
- trusted `main` baseline queued on the disposable runner

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI infrastructure and perf baseline comparability; misconfigured runners or `TAK_RUNNER` mismatch could break measurements or comparisons, but scope is limited to workflows and a temporary author gate on perf-pr.
> 
> **Overview**
> Tak **measure** jobs in `perf.yml` and `perf-pr.yml` now run on the self-hosted **`bamboo-perf`** label instead of `ubuntu-latest`, with workflow **`TAK_RUNNER`** set to the Bamboo image/toolchain id so comparisons stay within one runner class. **actionlint** registers `bamboo-perf` as an allowed self-hosted label.
> 
> **`perf-pr`** temporarily limits **`measure`** and **`report`** to PRs opened by **`jdx`**; the **`report`** job still uses **`ubuntu-latest`** (no project code execution).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531174f2afe97ca01df099d6d4df57df82180026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated performance testing workflows to use a dedicated performance environment.
  * Standardized runner settings for more consistent and reliable performance measurements.
  * Added validation for performance workflow runner configuration.
  * Restricted pull request performance reporting to designated performance runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->