### PR TITLE
ci: build perf binaries on bamboo

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -57,8 +57,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache: false

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache: false


### PR DESCRIPTION
## Summary

- compile benchmark binaries from scratch inside each disposable Bamboo VM
- prevent a cached `target/` built on Namespace from being measured and labeled as Bamboo
- document the runner-class integrity requirement beside the build setup

## Validation

- `actionlint` on the affected performance workflows
- `git diff --check`

Generated with AI assistance and manually validated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that drops Rust build caching on perf jobs; no application, auth, or data-path changes.
> 
> **Overview**
> **Bamboo perf workflows now compile benchmarks locally instead of restoring `target/` from cache.**
> 
> `Swatinem/rust-cache` is removed from `perf.yml` and `perf-pr.yml` so each disposable Bamboo VM builds the binary that gets measured. Comments beside the `mise-action` step explain that a cached artifact from another runner class could be mislabeled as a Bamboo measurement and break instruction-count comparisons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a84b80730bfb717c8e96efea5598bc17bd0536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance workflows to compile within each disposable test environment.
  * Improved performance measurement consistency by preventing reuse of binaries built on different runner types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->