### PR TITLE
feat(boot): auto-heal stale boot registration on supervisor startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auto-launcher"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db744910f720c02fc6db1cbf6ce1f06013d135f245ee0b97fafb6272f64da846"
+checksum = "6893c4ab0c1ca350937fab72d6bb90403b6a8e89d1979baf9a96868e84382c91"
 dependencies = [
  "dirs",
  "nix 0.31.3",
@@ -1014,7 +1014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2751,7 +2751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3543,7 +3543,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3608,7 +3608,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3902,7 +3902,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 
@@ -4143,7 +4143,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4947,7 +4947,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default = ["proxy-tls"]
 proxy-tls = ["rcgen", "tokio-rustls", "rustls-pemfile", "x509-parser"]
 
 [dependencies]
-auto-launcher = "1.0.3"
+auto-launcher = "1.1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 clap_usage = "4"

--- a/src/boot_manager.rs
+++ b/src/boot_manager.rs
@@ -250,11 +250,10 @@ mod imp {
                 re-registering with current path '{current_bin}'"
             );
 
-            // Re-register: disable then enable to overwrite the stale registration.
-            if let Err(e) = self.current.disable() {
-                warn!("failed to disable stale boot registration: {e}");
-                return;
-            }
+            // Re-register by overwriting the existing registration file.
+            // Calling enable() directly (without disable first) ensures that
+            // if it fails, the stale registration is still present rather than
+            // missing entirely — a stale path is better than no path.
             if let Err(e) = self.current.enable() {
                 warn!("failed to re-register boot start with current path: {e}");
                 return;

--- a/src/boot_manager.rs
+++ b/src/boot_manager.rs
@@ -220,6 +220,48 @@ mod imp {
             }
             Ok(())
         }
+
+        /// Check whether the registered boot binary path matches the current
+        /// `PITCHFORK_BIN`. If stale (binary moved after a package-manager upgrade),
+        /// re-register at the current privilege level so the next boot uses the
+        /// correct path.
+        ///
+        /// This is a no-op when boot start is not enabled, or when the registered
+        /// path already matches. Errors are logged and swallowed — this is a
+        /// best-effort self-heal that must not block supervisor startup.
+        pub fn check_and_reregister_if_stale(&self) {
+            let current_bin = env::PITCHFORK_BIN.to_string_lossy().to_string();
+
+            let registered = match self.current.get_registered_app_path() {
+                Ok(Some(path)) => path,
+                Ok(None) => return, // not registered, nothing to do
+                Err(e) => {
+                    warn!("failed to read registered boot path: {e}");
+                    return;
+                }
+            };
+
+            if registered == current_bin {
+                return; // path matches, all good
+            }
+
+            info!(
+                "boot registration points to stale binary path '{registered}', \
+                re-registering with current path '{current_bin}'"
+            );
+
+            // Re-register: disable then enable to overwrite the stale registration.
+            if let Err(e) = self.current.disable() {
+                warn!("failed to disable stale boot registration: {e}");
+                return;
+            }
+            if let Err(e) = self.current.enable() {
+                warn!("failed to re-register boot start with current path: {e}");
+                return;
+            }
+
+            info!("boot registration updated to current binary path");
+        }
     }
 }
 

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -379,6 +379,15 @@ impl Supervisor {
         #[cfg(unix)]
         fix_state_dir_permissions();
 
+        // Self-heal: if the boot registration points to a stale binary path
+        // (e.g. after a brew/mise upgrade), re-register with the current path.
+        // Runs in the background — must not block or fail supervisor startup.
+        tokio::task::spawn_blocking(|| {
+            if let Ok(boot_manager) = crate::boot_manager::BootManager::new() {
+                boot_manager.check_and_reregister_if_stale();
+            }
+        });
+
         // If the previous supervisor died uncleanly, its daemon child processes
         // may still be alive (orphaned, re-parented to init).  Terminate them
         // before starting replacements so we don't end up with duplicate


### PR DESCRIPTION
## Problem

When the binary path changes after a package-manager upgrade (e.g. `brew cleanup`, `mise install`), the launchd plist or systemd unit still points to the old version-specific path, causing the supervisor to fail on next boot with `EX_CONFIG (78)` on macOS or a missing binary on Linux.

See [discussion #544](https://github.com/jdx/pitchfork/discussions/544) for details.

## Solution

On supervisor startup, check whether the registered boot binary path matches the current `PITCHFORK_BIN`. If stale, re-register with the current path.

This runs in a background `spawn_blocking` task and is best-effort: errors are logged and swallowed, never blocking startup.

### Changes

- **`Cargo.toml`**: upgrade `auto-launcher` from 1.0.3 to 1.1
- **`src/boot_manager.rs`**: add `check_and_reregister_if_stale()` which reads the registered path back from disk via `auto_launcher::AutoLaunch::get_registered_app_path()` (new in 1.1), compares to `PITCHFORK_BIN`, and re-registers by `disable()` + `enable()` when stale
- **`src/supervisor/mod.rs`**: call the check in `Supervisor::start()` via `tokio::task::spawn_blocking`, fire-and-forget

### Why not just use a stable path?

mise shims are shell scripts that require `MISE_*` environment variables which launchd/systemd minimal environments cannot provide. Detect-and-re-register avoids this issue entirely and works across all package managers.

### auto-launcher dependency

This PR requires `auto-launcher` 1.1, which adds `get_registered_app_path()` — a new API that reads the binary path back from the on-disk launch file (plist/systemd unit/registry). See [auto-launcher PR #7](https://github.com/gaojunran/auto-launcher/pull/7).

Closes #544

*AI-assisted — Tool: opencode; model: astra/glm_5d2_fp8_code; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot registration reliability by automatically detecting and correcting outdated launcher paths.
  * Boot registration issues are handled gracefully without interrupting application startup.

* **Maintenance**
  * Updated the automatic launch support to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->