### PR TITLE
feat(supervisor): expand ~ in daemon dir using effective user's home

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -89,9 +89,20 @@ pub static IPC_JSON: Lazy<bool> = Lazy::new(|| !var_false("IPC_JSON"));
 /// expansions such as `$HOME`. Pitchfork's home resolution accounts for the
 /// original user when running under `sudo`.
 pub fn expand_tilde(path: impl AsRef<std::path::Path>) -> PathBuf {
+    expand_tilde_for_user(path, None)
+}
+
+/// Expand a leading `~` to the home directory of `user`.
+///
+/// When `user` is `None`, empty, or the system lookup fails, falls back to
+/// `HOME_DIR` (the supervisor's home). This matches Unix semantics where `~`
+/// in a process's working directory refers to that process's effective user.
+///
+/// Only `~` and `~/...` are supported — not `~user` or shell expansions.
+pub fn expand_tilde_for_user(path: impl AsRef<std::path::Path>, user: Option<&str>) -> PathBuf {
     let path = path.as_ref();
     match path.strip_prefix("~") {
-        Ok(rest) => HOME_DIR.join(rest),
+        Ok(rest) => home_dir_for_effective_user(user).join(rest),
         Err(_) => path.to_path_buf(),
     }
 }
@@ -128,6 +139,37 @@ fn home_dir_for_user(username: &str) -> Option<PathBuf> {
         .map(|u| u.dir)
 }
 
+/// Look up a home directory by username or numeric UID string.
+#[cfg(unix)]
+fn home_dir_by_user_spec(user: &str) -> Option<PathBuf> {
+    if user.chars().all(|c| c.is_ascii_digit()) {
+        let uid = user.parse::<u32>().ok()?;
+        nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+            .ok()
+            .flatten()
+            .map(|u| u.dir)
+    } else {
+        home_dir_for_user(user)
+    }
+}
+
+/// Resolve the home directory for an effective daemon user.
+///
+/// Returns `HOME_DIR` when `user` is `None`, empty, or the lookup fails.
+#[cfg(unix)]
+pub(crate) fn home_dir_for_effective_user(user: Option<&str>) -> PathBuf {
+    let user = user.map(str::trim).filter(|u| !u.is_empty());
+    match user {
+        Some(u) => home_dir_by_user_spec(u).unwrap_or_else(|| HOME_DIR.clone()),
+        None => HOME_DIR.clone(),
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn home_dir_for_effective_user(_user: Option<&str>) -> PathBuf {
+    HOME_DIR.clone()
+}
+
 #[cfg(unix)]
 fn configured_supervisor_user_home_dir() -> Option<PathBuf> {
     let s = crate::settings::settings();
@@ -135,16 +177,7 @@ fn configured_supervisor_user_home_dir() -> Option<PathBuf> {
     if user.is_empty() {
         return None;
     }
-
-    if user.chars().all(|c| c.is_ascii_digit()) {
-        let uid = user.parse::<u32>().ok()?;
-        return nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
-            .ok()
-            .flatten()
-            .map(|u| u.dir);
-    }
-
-    home_dir_for_user(user)
+    home_dir_by_user_spec(user)
 }
 
 #[cfg(test)]
@@ -169,5 +202,34 @@ mod tests {
         );
         assert_eq!(expand_tilde("projects/api"), Path::new("projects/api"));
         assert_eq!(expand_tilde("~other/api"), Path::new("~other/api"));
+    }
+
+    #[test]
+    fn expand_tilde_for_user_none_uses_supervisor_home() {
+        assert_eq!(expand_tilde_for_user("~/data", None), HOME_DIR.join("data"));
+    }
+
+    #[test]
+    fn expand_tilde_for_user_empty_uses_supervisor_home() {
+        assert_eq!(
+            expand_tilde_for_user("~/data", Some("")),
+            HOME_DIR.join("data")
+        );
+    }
+
+    #[test]
+    fn expand_tilde_for_user_nonexistent_falls_back_to_supervisor_home() {
+        assert_eq!(
+            expand_tilde_for_user("~/data", Some("nonexistent_user_xyz")),
+            HOME_DIR.join("data")
+        );
+    }
+
+    #[test]
+    fn expand_tilde_for_user_leaves_non_tilde_unchanged() {
+        assert_eq!(
+            expand_tilde_for_user("/srv/api", Some("postgres")),
+            Path::new("/srv/api")
+        );
     }
 }

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -1093,10 +1093,18 @@ pub fn resolve_config_base_dir(config_path: Option<&Path>) -> PathBuf {
 ///
 /// If `dir` is set in config, resolve it relative to the project base directory.
 /// Otherwise, use the project base directory directly.
-pub fn resolve_daemon_dir(dir: Option<&str>, config_path: Option<&Path>) -> PathBuf {
+///
+/// When `user` is provided, a leading `~` in `dir` expands to that user's home
+/// directory (matching Unix semantics for the daemon's effective user). When
+/// `user` is `None`, `~` expands to the supervisor's home.
+pub fn resolve_daemon_dir(
+    dir: Option<&str>,
+    config_path: Option<&Path>,
+    user: Option<&str>,
+) -> PathBuf {
     let base_dir = resolve_config_base_dir(config_path);
     match dir {
-        Some(d) => base_dir.join(crate::env::expand_tilde(d)),
+        Some(d) => base_dir.join(crate::env::expand_tilde_for_user(d, user)),
         None => base_dir,
     }
 }
@@ -1201,7 +1209,11 @@ mod tests {
     #[test]
     fn test_resolve_daemon_dir_none() {
         // No dir set, config at /projects/myapp/pitchfork.toml -> /projects/myapp
-        let result = resolve_daemon_dir(None, Some(Path::new("/projects/myapp/pitchfork.toml")));
+        let result = resolve_daemon_dir(
+            None,
+            Some(Path::new("/projects/myapp/pitchfork.toml")),
+            None,
+        );
         assert_eq!(result, PathBuf::from("/projects/myapp"));
     }
 
@@ -1211,6 +1223,7 @@ mod tests {
         let result = resolve_daemon_dir(
             Some("frontend"),
             Some(Path::new("/projects/myapp/pitchfork.toml")),
+            None,
         );
         assert_eq!(result, PathBuf::from("/projects/myapp/frontend"));
     }
@@ -1221,6 +1234,7 @@ mod tests {
         let result = resolve_daemon_dir(
             Some("/opt/myapp"),
             Some(Path::new("/projects/myapp/pitchfork.toml")),
+            None,
         );
         assert_eq!(result, PathBuf::from("/opt/myapp"));
     }
@@ -1230,21 +1244,46 @@ mod tests {
         let result = resolve_daemon_dir(
             Some("~/projects/myapp"),
             Some(Path::new("/projects/other/pitchfork.toml")),
+            None,
         );
         assert_eq!(result, crate::env::HOME_DIR.join("projects/myapp"));
     }
 
     #[test]
+    fn test_resolve_daemon_dir_tilde_with_user() {
+        // ~ with a nonexistent user falls back to HOME_DIR.
+        let result = resolve_daemon_dir(
+            Some("~/data"),
+            Some(Path::new("/projects/other/pitchfork.toml")),
+            Some("nonexistent_user_xyz"),
+        );
+        assert_eq!(result, crate::env::HOME_DIR.join("data"));
+    }
+
+    #[test]
+    fn test_resolve_daemon_dir_tilde_with_current_user() {
+        // ~ with the current user expands to their home via passwd lookup.
+        let current_user = std::env::var("USER").unwrap_or_else(|_| "root".to_string());
+        let expected = crate::env::home_dir_for_effective_user(Some(&current_user)).join("data");
+        let result = resolve_daemon_dir(
+            Some("~/data"),
+            Some(Path::new("/projects/other/pitchfork.toml")),
+            Some(&current_user),
+        );
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_resolve_daemon_dir_no_config_path() {
         // No config path -> defaults to CWD
-        let result = resolve_daemon_dir(None, None);
+        let result = resolve_daemon_dir(None, None, None);
         assert_eq!(result, crate::env::CWD.to_path_buf());
     }
 
     #[test]
     fn test_resolve_daemon_dir_relative_no_config_path() {
         // Relative dir but no config path -> relative to CWD
-        let result = resolve_daemon_dir(Some("subdir"), None);
+        let result = resolve_daemon_dir(Some("subdir"), None, None);
         assert_eq!(result, crate::env::CWD.join("subdir"));
     }
 
@@ -1254,6 +1293,7 @@ mod tests {
         let result = resolve_daemon_dir(
             Some("services/api"),
             Some(Path::new("/projects/myapp/pitchfork.toml")),
+            None,
         );
         assert_eq!(result, PathBuf::from("/projects/myapp/services/api"));
     }
@@ -1264,6 +1304,7 @@ mod tests {
         let result = resolve_daemon_dir(
             None,
             Some(Path::new("/projects/myapp/.config/pitchfork.toml")),
+            None,
         );
         assert_eq!(
             result,
@@ -1278,6 +1319,7 @@ mod tests {
         let result = resolve_daemon_dir(
             None,
             Some(Path::new("/projects/myapp/.config/pitchfork.local.toml")),
+            None,
         );
         assert_eq!(
             result,
@@ -1292,6 +1334,7 @@ mod tests {
         let result = resolve_daemon_dir(
             Some("frontend"),
             Some(Path::new("/projects/myapp/.config/pitchfork.toml")),
+            None,
         );
         assert_eq!(
             result,
@@ -1306,6 +1349,7 @@ mod tests {
         let result = resolve_daemon_dir(
             Some("frontend"),
             Some(Path::new("/projects/myapp/.config/pitchfork.local.toml")),
+            None,
         );
         assert_eq!(
             result,
@@ -1320,6 +1364,7 @@ mod tests {
         let result = resolve_daemon_dir(
             Some("/opt/service"),
             Some(Path::new("/projects/myapp/.config/pitchfork.toml")),
+            None,
         );
         assert_eq!(
             result,
@@ -1334,6 +1379,7 @@ mod tests {
         let result = resolve_daemon_dir(
             Some("/opt/service"),
             Some(Path::new("/projects/myapp/.config/pitchfork.local.toml")),
+            None,
         );
         assert_eq!(
             result,
@@ -1346,7 +1392,7 @@ mod tests {
     fn test_resolve_daemon_dir_global_config_normal() {
         // Global config (~/.config/pitchfork/config.toml) should use normal resolution (parent)
         let global_path = env::PITCHFORK_GLOBAL_CONFIG_USER.as_path();
-        let result = resolve_daemon_dir(None, Some(global_path));
+        let result = resolve_daemon_dir(None, Some(global_path), None);
         assert_eq!(
             result,
             global_path.parent().unwrap(),

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -1665,6 +1665,22 @@ pub struct PitchforkTomlDaemon {
 }
 
 impl PitchforkTomlDaemon {
+    /// Effective user for this daemon: per-daemon `user` overrides `settings.supervisor.user`.
+    ///
+    /// Returns `None` when neither is set (inherit the supervisor's user).
+    pub fn effective_user(&self) -> Option<String> {
+        let daemon_user = self
+            .user
+            .as_deref()
+            .map(str::trim)
+            .filter(|u| !u.is_empty());
+        daemon_user.map(str::to_owned).or_else(|| {
+            let s = crate::settings::settings();
+            let su = s.supervisor.user.trim();
+            (!su.is_empty()).then(|| su.to_owned())
+        })
+    }
+
     /// Build RunOptions from this daemon configuration.
     ///
     /// Carries over all config fields and resolves the working directory.
@@ -1676,7 +1692,12 @@ impl PitchforkTomlDaemon {
     ) -> crate::daemon::RunOptions {
         use crate::daemon::RunOptions;
 
-        let dir = crate::ipc::batch::resolve_daemon_dir(self.dir.as_deref(), self.path.as_deref());
+        let effective_user = self.effective_user();
+        let dir = crate::ipc::batch::resolve_daemon_dir(
+            self.dir.as_deref(),
+            self.path.as_deref(),
+            effective_user.as_deref(),
+        );
         let slug = crate::pitchfork_toml::PitchforkToml::read_global_slugs()
             .into_iter()
             .find(|(slug, entry)| {

--- a/src/template.rs
+++ b/src/template.rs
@@ -65,9 +65,11 @@ impl TemplateContext {
         daemon_configs: &IndexMap<DaemonId, PitchforkTomlDaemon>,
     ) -> Self {
         let global_slugs = crate::pitchfork_toml::PitchforkToml::read_global_slugs();
+        let effective_user = daemon_config.effective_user();
         let dir = crate::ipc::batch::resolve_daemon_dir(
             daemon_config.dir.as_deref(),
             daemon_config.path.as_deref(),
+            effective_user.as_deref(),
         );
 
         let self_state = DaemonTemplateState {
@@ -85,9 +87,11 @@ impl TemplateContext {
         let mut daemon_states = HashMap::new();
         for (dep_id, ports) in resolved_daemons {
             if let Some(config) = daemon_configs.get(dep_id) {
+                let dep_effective_user = config.effective_user();
                 let dep_dir = crate::ipc::batch::resolve_daemon_dir(
                     config.dir.as_deref(),
                     config.path.as_deref(),
+                    dep_effective_user.as_deref(),
                 );
                 let state = DaemonTemplateState {
                     ports: ports.clone(),


### PR DESCRIPTION
## Summary

When a daemon configures both `dir = "~/data"` and `user = "postgres"`, `~` now expands to postgres's home directory instead of the supervisor's home. This matches Unix semantics where `~` refers to the process's effective user.

The effective user is resolved as `daemon.user` overriding `settings.supervisor.user`, consistent with the existing run-identity resolution in `lifecycle.rs`.

## Changes

- **`src/env.rs`**: Add `expand_tilde_for_user(path, user)` — looks up the given user's home via the system password database (supports both username and numeric UID), falls back to `HOME_DIR` when `user` is `None`/empty/lookup fails. Also adds `home_dir_by_user_spec` and `home_dir_for_effective_user` helpers, and refactors `configured_supervisor_user_home_dir` to reuse the shared logic.
- **`src/ipc/batch.rs`**: `resolve_daemon_dir` gains a `user: Option<&str>` parameter.
- **`src/pitchfork_toml.rs`**: New `PitchforkTomlDaemon::effective_user()` method centralizes the daemon-user-overrides-supervisor-user resolution; `to_run_options` passes it to `resolve_daemon_dir`.
- **`src/template.rs`**: Both `resolve_daemon_dir` call sites pass the effective user.

## Test plan

- [x] `mise run ci-dev` — 593 unit tests + 308 bats integration tests pass
- [x] New unit tests: `expand_tilde_for_user` with `None`/empty/nonexistent user falls back to supervisor home; non-tilde paths unchanged
- [x] New unit tests: `resolve_daemon_dir` with user param — nonexistent user falls back, current user resolves via passwd lookup
- [x] Existing `test_resolve_daemon_dir_tilde` and `test_registry_dirs_expand_tilde` still pass (unchanged behavior with `user = None`)

*AI-assisted — Tool: opencode; model: astra/glm_5d2_fp8_code; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `~` path expansion for specific users, including usernames and numeric user IDs.
  * Daemon and dependency directories now resolve using the configured effective user.
  * Added fallback handling when user information is missing, invalid, or unavailable.

* **Bug Fixes**
  * Corrected home-directory resolution for supervised daemons and user-specific configurations.
  * Preserved expected behavior for non-tilde paths and existing directory settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->