### PR TITLE
feat(start): interactive daemon selection via demand multi-select

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
+dependencies = [
+ "nom 7.1.3",
+ "vte 0.14.1",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +576,8 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
+ "ansi-str",
+ "console",
  "crossterm",
  "unicode-segmentation",
  "unicode-width 0.2.2",
@@ -678,7 +699,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -832,6 +853,20 @@ name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "demand"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7f0bec8d94f8eb4d2efec0325ef991480abab44dc42f2f3cbf10c41aeb73fc"
+dependencies = [
+ "console",
+ "fuzzy-matcher",
+ "itertools 0.15.0",
+ "libc",
+ "signal-hook 0.4.4",
+ "termcolor",
+]
 
 [[package]]
 name = "der-parser"
@@ -2944,6 +2979,7 @@ dependencies = [
  "console",
  "cron",
  "crossterm",
+ "demand",
  "derive_more",
  "dirs",
  "duct",
@@ -3007,7 +3043,7 @@ dependencies = [
  "toml",
  "tower-http 0.7.0",
  "uuid",
- "vte",
+ "vte 0.15.0",
  "windows-sys 0.61.2",
  "x509-parser",
  "xx",
@@ -3872,7 +3908,7 @@ checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
 dependencies = [
  "libc",
  "os_pipe",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -3886,6 +3922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3893,7 +3939,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -4156,6 +4202,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termina"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4164,7 +4219,7 @@ dependencies = [
  "bitflags 2.13.0",
  "parking_lot",
  "rustix",
- "signal-hook",
+ "signal-hook 0.3.18",
  "windows-sys 0.61.2",
 ]
 
@@ -4225,7 +4280,7 @@ dependencies = [
  "pest_derive",
  "phf",
  "sha2 0.10.9",
- "signal-hook",
+ "signal-hook 0.3.18",
  "siphasher",
  "terminfo",
  "termios",
@@ -4718,6 +4773,16 @@ checksum = "80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f"
 dependencies = [
  "itertools 0.14.0",
  "nom 8.0.0",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "arrayvec",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 clap_usage = "4"
 clx = "3"
-comfy-table = "7.1.3"
+comfy-table = { version = "7.1.3", features = ["custom_styling"] }
 console = "0.16"
 cron = "0.17"
 dirs = "6"
@@ -113,6 +113,7 @@ listeners = "0.6"
 lru = "0.18"
 derive_more = { version = "2.1.1", features = ["into", "display", "from", "deref", "as_ref"] }
 vte = { version = "0.15.0", default-features = false }
+demand = "2"
 
 [target.'cfg(unix)'.dependencies]
 exec = "0.3"

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -1,0 +1,60 @@
+//! Interactive daemon selection via multi-select prompt.
+//!
+//! When the user runs `pf start` / `pf stop` / `pf restart` without specifying
+//! any daemon, and stdin/stdout is a TTY, we launch a fuzzy-filterable
+//! multi-select prompt ([`demand::MultiSelect`]) so the user can pick daemons
+//! interactively.
+
+use crate::Result;
+use crate::daemon_id::DaemonId;
+use demand::{DemandOption, MultiSelect};
+use std::io::IsTerminal;
+
+/// If stdout is a TTY, prompt the user to select one or more daemons from
+/// `candidates`. Returns the selected `DaemonId`s.
+///
+/// If stdout is not a TTY (piped/redirected), returns an error instructing the
+/// user to provide daemon IDs explicitly, preserving the original non-interactive
+/// behavior.
+pub(crate) fn select_daemons_interactively(
+    candidates: &[DaemonId],
+    action: &str,
+) -> Result<Vec<DaemonId>> {
+    if candidates.is_empty() {
+        miette::bail!("No daemons available to {action}");
+    }
+
+    if !std::io::stdout().is_terminal() {
+        miette::bail!(
+            "No daemon ID specified. Provide one or more daemon IDs, \
+             or run in an interactive terminal to use the selection prompt."
+        );
+    }
+
+    let title = format!("Select daemon(s) to {action}");
+
+    let mut sorted: Vec<DaemonId> = candidates.to_vec();
+    sorted.sort();
+
+    let mut ms = MultiSelect::new(&title)
+        .filterable(true)
+        .description("Use / to filter, space to toggle, enter to confirm");
+
+    for id in &sorted {
+        ms = ms.option(DemandOption::with_label(id.qualified(), id.clone()));
+    }
+
+    let selected: Vec<DaemonId> = ms.run().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::Interrupted {
+            miette::miette!("Selection cancelled")
+        } else {
+            miette::miette!("Interactive selection failed: {e}")
+        }
+    })?;
+
+    if selected.is_empty() {
+        miette::bail!("No daemons selected");
+    }
+
+    Ok(selected)
+}

--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -10,12 +10,27 @@ use crate::daemon_id::DaemonId;
 use demand::{DemandOption, MultiSelect};
 use std::io::IsTerminal;
 
-/// If stdout is a TTY, prompt the user to select one or more daemons from
-/// `candidates`. Returns the selected `DaemonId`s.
+/// Returns `Ok(())` if both stdin and stdout are TTYs, so the interactive
+/// prompt can read keyboard input and render the UI.
 ///
-/// If stdout is not a TTY (piped/redirected), returns an error instructing the
-/// user to provide daemon IDs explicitly, preserving the original non-interactive
-/// behavior.
+/// Call this before connecting to the supervisor (which may auto-start it)
+/// to avoid side effects when the command is non-interactive.
+pub(crate) fn require_interactive_terminal() -> Result<()> {
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        miette::bail!(
+            "No daemon ID specified. Provide one or more daemon IDs, \
+             or run in an interactive terminal to use the selection prompt."
+        );
+    }
+    Ok(())
+}
+
+/// Prompt the user to select one or more daemons from `candidates` via a
+/// fuzzy-filterable multi-select prompt. Returns the selected `DaemonId`s.
+///
+/// Caller must ensure [`require_interactive_terminal`] has been checked
+/// beforehand if the IPC connection has side effects (e.g. supervisor
+/// auto-start).
 pub(crate) fn select_daemons_interactively(
     candidates: &[DaemonId],
     action: &str,
@@ -24,12 +39,9 @@ pub(crate) fn select_daemons_interactively(
         miette::bail!("No daemons available to {action}");
     }
 
-    if !std::io::stdout().is_terminal() {
-        miette::bail!(
-            "No daemon ID specified. Provide one or more daemon IDs, \
-             or run in an interactive terminal to use the selection prompt."
-        );
-    }
+    // Defense-in-depth: caller should have checked already, but verify again
+    // in case this function is called from a context that didn't.
+    require_interactive_terminal()?;
 
     let title = format!("Select daemon(s) to {action}");
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,7 @@ mod completion;
 mod daemons;
 mod disable;
 mod enable;
+mod interactive;
 pub mod json_output;
 mod list;
 pub mod log_sink;

--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -87,6 +87,10 @@ impl Restart {
         let no_target =
             self.id.is_empty() && self.group.is_none() && !self.local && !self.global && !self.all;
 
+        if no_target {
+            super::interactive::require_interactive_terminal()?;
+        }
+
         let ipc = Arc::new(IpcClient::connect(true).await?);
 
         let ids: Vec<DaemonId> = if self.all {

--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -3,7 +3,6 @@ use crate::daemon_id::DaemonId;
 use crate::ipc::batch::{StartOptions, update_job_with_result};
 use crate::ipc::client::IpcClient;
 use crate::pitchfork_toml::PitchforkToml;
-use miette::ensure;
 use std::sync::Arc;
 
 /// Restarts a daemon (stops then starts it)
@@ -85,10 +84,8 @@ pub struct Restart {
 
 impl Restart {
     pub async fn run(&self) -> Result<()> {
-        ensure!(
-            self.local || self.global || self.all || !self.id.is_empty() || self.group.is_some(),
-            "At least one daemon ID, --group, or one of --all / --local / --global must be provided"
-        );
+        let no_target =
+            self.id.is_empty() && self.group.is_none() && !self.local && !self.global && !self.all;
 
         let ipc = Arc::new(IpcClient::connect(true).await?);
 
@@ -96,6 +93,9 @@ impl Restart {
             ipc.get_running_daemons().await?
         } else if self.global || self.local {
             ipc.get_running_configured_daemons(self.global).await?
+        } else if no_target {
+            let candidates = ipc.get_running_daemons().await?;
+            super::interactive::select_daemons_interactively(&candidates, "restart")?
         } else {
             PitchforkToml::resolve_ids_and_group(&self.id, self.group.as_deref())?
         };

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -112,6 +112,12 @@ impl Start {
         let no_target =
             self.id.is_empty() && self.group.is_none() && !self.local && !self.global && !self.all;
 
+        // When no target is specified, verify we're in an interactive terminal
+        // before connecting to the supervisor (which may auto-start it).
+        if no_target {
+            super::interactive::require_interactive_terminal()?;
+        }
+
         let ipc = Arc::new(IpcClient::connect(true).await?);
 
         // Compute daemon IDs to start

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -6,7 +6,6 @@ use crate::ipc::client::IpcClient;
 use crate::pitchfork_toml::PitchforkToml;
 use crate::settings::settings;
 use crate::ui::style::{ncyan, ndim};
-use miette::ensure;
 use std::sync::Arc;
 
 /// Shared long help for the `start` command and its implicit fallback form.
@@ -110,10 +109,8 @@ pub struct Start {
 
 impl Start {
     pub async fn run(&self) -> Result<()> {
-        ensure!(
-            self.local || self.global || self.all || !self.id.is_empty() || self.group.is_some(),
-            "At least one daemon ID, --group, or one of --all / --local / --global must be provided"
-        );
+        let no_target =
+            self.id.is_empty() && self.group.is_none() && !self.local && !self.global && !self.all;
 
         let ipc = Arc::new(IpcClient::connect(true).await?);
 
@@ -124,6 +121,18 @@ impl Start {
             IpcClient::get_global_configured_daemons()?
         } else if self.local {
             IpcClient::get_local_configured_daemons()?
+        } else if no_target {
+            let all = IpcClient::get_all_configured_daemons()?;
+            // Without --force, exclude daemons that are already running so the
+            // user doesn't accidentally restart them.
+            let candidates = if self.force {
+                all
+            } else {
+                let running: std::collections::HashSet<DaemonId> =
+                    ipc.get_running_daemons().await?.into_iter().collect();
+                all.into_iter().filter(|id| !running.contains(id)).collect()
+            };
+            super::interactive::select_daemons_interactively(&candidates, "start")?
         } else {
             PitchforkToml::resolve_ids_and_group(&self.id, self.group.as_deref())?
         };
@@ -179,8 +188,7 @@ impl Start {
                     let slug_name =
                         PitchforkToml::find_slug_for_daemon_in_registry(id, &global_slugs);
                     if let Some(proxy_url) = build_proxy_url(slug_name.as_deref(), &s) {
-                        let display_name =
-                            id.styled_display_name(None::<std::iter::Empty<&DaemonId>>);
+                        let display_name = id.styled_qualified();
                         println!(
                             "  {} {} {}",
                             ndim("↳"),

--- a/src/cli/stop.rs
+++ b/src/cli/stop.rs
@@ -77,6 +77,10 @@ impl Stop {
         let no_target =
             self.id.is_empty() && self.group.is_none() && !self.local && !self.global && !self.all;
 
+        if no_target {
+            super::interactive::require_interactive_terminal()?;
+        }
+
         let ipc = Arc::new(IpcClient::connect(false).await?);
 
         let ids: Vec<DaemonId> = if self.all {

--- a/src/cli/stop.rs
+++ b/src/cli/stop.rs
@@ -2,7 +2,6 @@ use crate::Result;
 use crate::daemon_id::DaemonId;
 use crate::ipc::client::IpcClient;
 use crate::pitchfork_toml::PitchforkToml;
-use miette::ensure;
 use std::sync::Arc;
 
 /// Sends a stop signal to a daemon
@@ -75,10 +74,8 @@ pub struct Stop {
 
 impl Stop {
     pub async fn run(&self) -> Result<()> {
-        ensure!(
-            self.local || self.global || self.all || !self.id.is_empty() || self.group.is_some(),
-            "At least one daemon ID, --group, or one of --all / --local / --global must be provided"
-        );
+        let no_target =
+            self.id.is_empty() && self.group.is_none() && !self.local && !self.global && !self.all;
 
         let ipc = Arc::new(IpcClient::connect(false).await?);
 
@@ -86,6 +83,9 @@ impl Stop {
             ipc.get_running_daemons().await?
         } else if self.global || self.local {
             ipc.get_running_configured_daemons(self.global).await?
+        } else if no_target {
+            let candidates = ipc.get_running_daemons().await?;
+            super::interactive::select_daemons_interactively(&candidates, "stop")?
         } else {
             PitchforkToml::resolve_ids_and_group(&self.id, self.group.as_deref())?
         };

--- a/src/daemon_id.rs
+++ b/src/daemon_id.rs
@@ -208,26 +208,6 @@ impl DaemonId {
             .join(format!("{safe}.log"))
     }
 
-    /// Returns a styled display name for terminal output (stdout).
-    ///
-    /// The namespace part is displayed in dim color, followed by `/` and the name.
-    /// If `all_ids` is provided and the name is unique, only the name is shown.
-    pub fn styled_display_name<'a, I>(&self, all_ids: Option<I>) -> String
-    where
-        I: Iterator<Item = &'a DaemonId>,
-    {
-        let show_full = match all_ids {
-            Some(ids) => ids.filter(|other| other.name == self.name).count() > 1,
-            None => true,
-        };
-
-        if show_full {
-            self.styled_qualified()
-        } else {
-            self.name.clone()
-        }
-    }
-
     /// Returns the qualified format with dim namespace for terminal output (stdout).
     ///
     /// Format: `<dim>namespace</dim>/name`
@@ -475,31 +455,6 @@ mod tests {
         // Invalid - empty
         assert!(DaemonId::try_new("", "api").is_err());
         assert!(DaemonId::try_new("project", "").is_err());
-    }
-
-    #[test]
-    fn test_daemon_id_styled_display_name() {
-        let id1 = DaemonId::new("project-a", "api");
-        let id2 = DaemonId::new("project-b", "api");
-        let id3 = DaemonId::new("global", "worker");
-
-        let all_ids = [&id1, &id2, &id3];
-
-        // "api" is ambiguous → full qualified ID must appear in the output
-        let out1 = id1.styled_display_name(Some(all_ids.iter().copied()));
-        let out2 = id2.styled_display_name(Some(all_ids.iter().copied()));
-        assert!(
-            out1.contains("project-a") && out1.contains("api"),
-            "ambiguous id1 should show namespace: {out1}"
-        );
-        assert!(
-            out2.contains("project-b") && out2.contains("api"),
-            "ambiguous id2 should show namespace: {out2}"
-        );
-
-        // "worker" is unique → only the short name
-        let out3 = id3.styled_display_name(Some(all_ids.iter().copied()));
-        assert_eq!(out3, "worker", "unique id3 should show only short name");
     }
 
     #[test]

--- a/test/errors.bats
+++ b/test/errors.bats
@@ -51,7 +51,7 @@ EOF
 @test "start with no arguments is rejected" {
   run pitchfork start
   assert_failure
-  assert_output --partial "At least one"
+  assert_output --partial "No daemons available to start"
 }
 
 @test "logs on daemon with no logs returns empty without error" {

--- a/test/errors.bats
+++ b/test/errors.bats
@@ -51,7 +51,7 @@ EOF
 @test "start with no arguments is rejected" {
   run pitchfork start
   assert_failure
-  assert_output --partial "No daemons available to start"
+  assert_output --partial "No daemon ID specified"
 }
 
 @test "logs on daemon with no logs returns empty without error" {


### PR DESCRIPTION
## Summary

When `pf start`, `pf stop`, or `pf restart` is run without specifying any daemon, and stdout is a TTY, launch a fuzzy-filterable multi-select prompt ([demand::MultiSelect](https://github.com/jdx/demand)) so the user can pick daemons interactively.

### Behavior

| Command | No-arg candidates (TTY) | Non-TTY |
|---------|------------------------|---------|
| `pf start` | All configured daemons, excluding already-running (unless `--force`) | Error: provide daemon IDs |
| `pf stop` | Currently running daemons | Error: provide daemon IDs |
| `pf restart` | Currently running daemons | Error: provide daemon IDs |

The prompt uses demand's built-in fuzzy filtering (`/` to filter, space to toggle, enter to confirm). Daemon labels always show the qualified `namespace/name` form.

### Additional fixes

- **Enable `custom_styling` feature on comfy-table**: Without it, `measure_text_width` does not strip ANSI escape codes, causing column misalignment in `pf ls` when cell content contains styled (colored) text like `styled_qualified()`.
- **Remove `DaemonId::styled_display_name`**: This method hid the namespace when the daemon name was unique across the provided ID set. Replaced the sole call site with `styled_qualified()` so the qualified form is always shown, consistent with the picker.

### Files changed

- `Cargo.toml` — add `demand = "2"`, enable `custom_styling` on `comfy-table`
- `src/cli/interactive.rs` — new shared `select_daemons_interactively()` helper
- `src/cli/{start,stop,restart}.rs` — replace `ensure!` hard-fail with interactive fallback
- `src/daemon_id.rs` — remove `styled_display_name` and its test
- `test/errors.bats` — update no-arg assertion

*AI-assisted — Tool: OpenCode; model: astra/glm_5d2_fp8_code; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive daemon selection for `start`, `stop`, and `restart` commands when no target is specified.
  * Search and filter available daemons, select multiple entries, and confirm actions directly in the terminal.
  * Clear guidance is provided when commands are run outside an interactive terminal.
  * Starting daemons automatically excludes those already running unless forced.

* **Bug Fixes**
  * Improved daemon names shown during command output for clearer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->