### PR TITLE
chore: release v2.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.21.0](https://github.com/jdx/pitchfork/compare/v2.20.0...v2.21.0) - 2026-08-10
+
+### Added
+
+- *(config)* add mtime-based cache for config parsing ([#711](https://github.com/jdx/pitchfork/pull/711))
+- *(start)* interactive daemon selection via demand multi-select ([#709](https://github.com/jdx/pitchfork/pull/709))
+
+### Fixed
+
+- *(deps)* update rust crate rmcp to v3 ([#725](https://github.com/jdx/pitchfork/pull/725))
+- *(deps)* update rust crate clap_usage to v5 ([#724](https://github.com/jdx/pitchfork/pull/724))
+
+### Other
+
+- *(deps)* lock file maintenance ([#727](https://github.com/jdx/pitchfork/pull/727))
+- *(deps)* simplify cargo version requirements ([#726](https://github.com/jdx/pitchfork/pull/726))
+- *(deps)* update rust crate tera to v2.1.0 ([#722](https://github.com/jdx/pitchfork/pull/722))
+- *(deps)* update rust crate schemars to v1.2.2 ([#716](https://github.com/jdx/pitchfork/pull/716))
+- *(deps)* update rust crate tokio-stream to v0.1.19 ([#717](https://github.com/jdx/pitchfork/pull/717))
+- *(deps)* update rust crate mdns-sd to v0.20.3 ([#715](https://github.com/jdx/pitchfork/pull/715))
+
 ## [2.20.0](https://github.com/jdx/pitchfork/compare/v2.19.0...v2.20.0) - 2026-08-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,7 +2940,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.20.0"
+version = "2.21.0"
 edition = "2024"
 resolver = "3"
 rust-version = "1.88"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3204,7 +3204,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.20.0",
+  "version": "2.21.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.20.0
+**Version**: 2.21.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name pitchfork
 bin pitchfork
-version "2.20.0"
+version "2.21.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" effect=read {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.20.0 -> 2.21.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.21.0](https://github.com/jdx/pitchfork/compare/v2.20.0...v2.21.0) - 2026-08-10

### Added

- *(config)* add mtime-based cache for config parsing ([#711](https://github.com/jdx/pitchfork/pull/711))
- *(start)* interactive daemon selection via demand multi-select ([#709](https://github.com/jdx/pitchfork/pull/709))

### Fixed

- *(deps)* update rust crate rmcp to v3 ([#725](https://github.com/jdx/pitchfork/pull/725))
- *(deps)* update rust crate clap_usage to v5 ([#724](https://github.com/jdx/pitchfork/pull/724))

### Other

- *(deps)* lock file maintenance ([#727](https://github.com/jdx/pitchfork/pull/727))
- *(deps)* simplify cargo version requirements ([#726](https://github.com/jdx/pitchfork/pull/726))
- *(deps)* update rust crate tera to v2.1.0 ([#722](https://github.com/jdx/pitchfork/pull/722))
- *(deps)* update rust crate schemars to v1.2.2 ([#716](https://github.com/jdx/pitchfork/pull/716))
- *(deps)* update rust crate tokio-stream to v0.1.19 ([#717](https://github.com/jdx/pitchfork/pull/717))
- *(deps)* update rust crate mdns-sd to v0.20.3 ([#715](https://github.com/jdx/pitchfork/pull/715))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical release-plz version and documentation sync with no runtime code changes in the PR diff.
> 
> **Overview**
> **Release v2.21.0** — bumps `pitchfork-cli` from **2.20.0** to **2.21.0** and records the release in `CHANGELOG.md`.
> 
> Version strings are updated in `Cargo.toml`, `Cargo.lock`, and generated CLI metadata (`pitchfork.usage.kdl`, `docs/cli/commands.json`, `docs/cli/index.md`). The changelog entry for this tag highlights **mtime-based config parse caching**, **interactive multi-select daemon selection on `start`**, and several **dependency updates** (including `rmcp` v3 and `clap_usage` v5) that shipped in the underlying feature PRs—not new logic in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be079e50ba24263a8b97e79be8ba48ba631ce63b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->