### PR TITLE
chore: release v2.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.22.0](https://github.com/jdx/pitchfork/compare/v2.21.0...v2.22.0) - 2026-08-17
+
+### Added
+
+- *(config)* auto-discover daemons in git worktrees and jj workspaces ([#737](https://github.com/jdx/pitchfork/pull/737))
+- *(tui)* add namespace scoping to tui and list ([#736](https://github.com/jdx/pitchfork/pull/736))
+
+### Fixed
+
+- *(proxy)* release config lock before hosts sync to avoid self-deadlock ([#739](https://github.com/jdx/pitchfork/pull/739))
+- *(cli)* render command examples as code blocks in generated docs ([#738](https://github.com/jdx/pitchfork/pull/738))
+- *(deps)* update rust crate comfy-table to v8 ([#734](https://github.com/jdx/pitchfork/pull/734))
+
+### Other
+
+- *(supervisor)* throttle full process-table refreshes with TTL cache ([#728](https://github.com/jdx/pitchfork/pull/728))
+
 ## [2.21.0](https://github.com/jdx/pitchfork/compare/v2.20.0...v2.21.0) - 2026-08-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,7 +2940,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.21.0"
+version = "2.22.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.21.0"
+version = "2.22.0"
 edition = "2024"
 resolver = "3"
 rust-version = "1.88"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3272,7 +3272,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.21.0",
+  "version": "2.22.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.21.0
+**Version**: 2.22.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name pitchfork
 bin pitchfork
-version "2.21.0"
+version "2.22.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" effect=read {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.21.0 -> 2.22.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.22.0](https://github.com/jdx/pitchfork/compare/v2.21.0...v2.22.0) - 2026-08-17

### Added

- *(config)* auto-discover daemons in git worktrees and jj workspaces ([#737](https://github.com/jdx/pitchfork/pull/737))
- *(tui)* add namespace scoping to tui and list ([#736](https://github.com/jdx/pitchfork/pull/736))

### Fixed

- *(proxy)* release config lock before hosts sync to avoid self-deadlock ([#739](https://github.com/jdx/pitchfork/pull/739))
- *(cli)* render command examples as code blocks in generated docs ([#738](https://github.com/jdx/pitchfork/pull/738))
- *(deps)* update rust crate comfy-table to v8 ([#734](https://github.com/jdx/pitchfork/pull/734))

### Other

- *(supervisor)* throttle full process-table refreshes with TTL cache ([#728](https://github.com/jdx/pitchfork/pull/728))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical release-only diff (versions + changelog/docs); no runtime code changes in this PR.
> 
> **Overview**
> Cuts **pitchfork-cli 2.22.0** by bumping the crate version in `Cargo.toml` / `Cargo.lock` and syncing the reported version in generated CLI metadata (`pitchfork.usage.kdl`, `docs/cli/commands.json`, `docs/cli/index.md`).
> 
> **CHANGELOG** moves the **[2.22.0]** notes out of `[Unreleased]` and documents what ships in this tag: worktree/jj daemon auto-discovery, namespace scoping for `list` and `tui`, a proxy deadlock fix (release config lock before hosts sync), CLI doc example formatting, `comfy-table` v8, and supervisor process-table refresh throttling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dcac95745f8e39402d46cf1ada540451e43b52f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->