### PR TITLE
fix(cli): render command examples as code blocks in generated docs

### DIFF
--- a/docs/cli/activate.md
+++ b/docs/cli/activate.md
@@ -12,14 +12,15 @@ directories. Required for auto-start/stop features in pitchfork.toml.
 Supported shells: bash, zsh, fish
 
 Add to your shell config:
-  bash (~/.bashrc):
-    eval "$(pitchfork activate bash)"
 
-  zsh (~/.zshrc):
-    eval "$(pitchfork activate zsh)"
+    bash (~/.bashrc):
+      eval "$(pitchfork activate bash)"
 
-  fish (~/.config/fish/config.fish):
-    pitchfork activate fish | source
+    zsh (~/.zshrc):
+      eval "$(pitchfork activate zsh)"
+
+    fish (~/.config/fish/config.fish):
+      pitchfork activate fish | source
 
 ## Arguments
 

--- a/docs/cli/boot.md
+++ b/docs/cli/boot.md
@@ -11,12 +11,14 @@ boots. Uses platform-specific mechanisms (launchd on macOS, systemd on Linux).
 
 When run as root (or via sudo), registers a system-level entry that starts
 pitchfork for all users:
-  macOS: /Library/LaunchDaemons/pitchfork.plist
-  Linux: /etc/systemd/system/pitchfork.service
+
+    macOS: /Library/LaunchDaemons/pitchfork.plist
+    Linux: /etc/systemd/system/pitchfork.service
 
 When run as a normal user, registers a user-level entry:
-  macOS: ~/Library/LaunchAgents/pitchfork.plist
-  Linux: ~/.config/systemd/user/pitchfork.service
+
+    macOS: ~/Library/LaunchAgents/pitchfork.plist
+    Linux: ~/.config/systemd/user/pitchfork.service
 
 To run the supervisor as root but keep state files and IPC sockets in a
 specific user's home directory, set `settings.supervisor.user` in the global
@@ -24,15 +26,17 @@ pitchfork configuration (~/.config/pitchfork/config.toml or
 /etc/pitchfork/config.toml).
 
 Subcommands:
-  enable    Register pitchfork to start on boot
-  disable   Remove pitchfork from boot startup
-  status    Check if boot start is currently enabled
+
+    enable    Register pitchfork to start on boot
+    disable   Remove pitchfork from boot startup
+    status    Check if boot start is currently enabled
 
 Examples:
-  pitchfork boot enable           Start pitchfork on system boot (user-level)
-  sudo pitchfork boot enable      Start pitchfork on system boot (system-level)
-  pitchfork boot disable          Don't start pitchfork on boot
-  pitchfork boot status           Check boot start status
+
+    pitchfork boot enable           Start pitchfork on system boot (user-level)
+    sudo pitchfork boot enable      Start pitchfork on system boot (system-level)
+    pitchfork boot disable          Don't start pitchfork on boot
+    pitchfork boot status           Check boot start status
 
 ## Subcommands
 

--- a/docs/cli/boot/enable.md
+++ b/docs/cli/boot/enable.md
@@ -9,12 +9,14 @@ Enable boot start for pitchfork supervisor
 Registers pitchfork to start automatically when the system boots.
 
 When run as root (or via sudo): creates a system-level entry
-  macOS: /Library/LaunchDaemons/pitchfork.plist
-  Linux: /etc/systemd/system/pitchfork.service
+
+    macOS: /Library/LaunchDaemons/pitchfork.plist
+    Linux: /etc/systemd/system/pitchfork.service
 
 When run as a normal user: creates a user-level entry
-  macOS: ~/Library/LaunchAgents/pitchfork.plist
-  Linux: ~/.config/systemd/user/pitchfork.service
+
+    macOS: ~/Library/LaunchAgents/pitchfork.plist
+    Linux: ~/.config/systemd/user/pitchfork.service
 
 If you want the supervisor to run as root but keep state files and IPC sockets
 under a specific user's home directory, configure `settings.supervisor.user`

--- a/docs/cli/clean.md
+++ b/docs/cli/clean.md
@@ -14,5 +14,6 @@ Use this to clear out old entries after stopping daemons manually or
 after daemons have failed.
 
 Examples:
-  pitchfork clean                 Remove all stopped/failed entries
-  pitchfork c                     Alias for 'clean'
+
+    pitchfork clean                 Remove all stopped/failed entries
+    pitchfork c                     Alias for 'clean'

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -27,7 +27,7 @@
         "effect": "read",
         "hide": false,
         "help": "Activate pitchfork in your shell session",
-        "help_long": "Activate pitchfork in your shell session\n\nGenerates shell code that enables automatic daemon management when changing\ndirectories. Required for auto-start/stop features in pitchfork.toml.\n\nSupported shells: bash, zsh, fish\n\nAdd to your shell config:\n  bash (~/.bashrc):\n    eval \"$(pitchfork activate bash)\"\n\n  zsh (~/.zshrc):\n    eval \"$(pitchfork activate zsh)\"\n\n  fish (~/.config/fish/config.fish):\n    pitchfork activate fish | source",
+        "help_long": "Activate pitchfork in your shell session\n\nGenerates shell code that enables automatic daemon management when changing\ndirectories. Required for auto-start/stop features in pitchfork.toml.\n\nSupported shells: bash, zsh, fish\n\nAdd to your shell config:\n\n    bash (~/.bashrc):\n      eval \"$(pitchfork activate bash)\"\n\n    zsh (~/.zshrc):\n      eval \"$(pitchfork activate zsh)\"\n\n    fish (~/.config/fish/config.fish):\n      pitchfork activate fish | source",
         "name": "activate",
         "aliases": [],
         "hidden_aliases": [],
@@ -69,7 +69,7 @@
             "effect": "write",
             "hide": false,
             "help": "Enable boot start for pitchfork supervisor",
-            "help_long": "Enable boot start for pitchfork supervisor\n\nRegisters pitchfork to start automatically when the system boots.\n\nWhen run as root (or via sudo): creates a system-level entry\n  macOS: /Library/LaunchDaemons/pitchfork.plist\n  Linux: /etc/systemd/system/pitchfork.service\n\nWhen run as a normal user: creates a user-level entry\n  macOS: ~/Library/LaunchAgents/pitchfork.plist\n  Linux: ~/.config/systemd/user/pitchfork.service\n\nIf you want the supervisor to run as root but keep state files and IPC sockets\nunder a specific user's home directory, configure `settings.supervisor.user`\nin your pitchfork configuration.",
+            "help_long": "Enable boot start for pitchfork supervisor\n\nRegisters pitchfork to start automatically when the system boots.\n\nWhen run as root (or via sudo): creates a system-level entry\n\n    macOS: /Library/LaunchDaemons/pitchfork.plist\n    Linux: /etc/systemd/system/pitchfork.service\n\nWhen run as a normal user: creates a user-level entry\n\n    macOS: ~/Library/LaunchAgents/pitchfork.plist\n    Linux: ~/.config/systemd/user/pitchfork.service\n\nIf you want the supervisor to run as root but keep state files and IPC sockets\nunder a specific user's home directory, configure `settings.supervisor.user`\nin your pitchfork configuration.",
             "name": "enable",
             "aliases": [],
             "hidden_aliases": [],
@@ -121,7 +121,7 @@
         "hide": false,
         "subcommand_required": true,
         "help": "Enable or disable boot start",
-        "help_long": "Enable or disable boot start\n\nManages whether pitchfork supervisor starts automatically when the system\nboots. Uses platform-specific mechanisms (launchd on macOS, systemd on Linux).\n\nWhen run as root (or via sudo), registers a system-level entry that starts\npitchfork for all users:\n  macOS: /Library/LaunchDaemons/pitchfork.plist\n  Linux: /etc/systemd/system/pitchfork.service\n\nWhen run as a normal user, registers a user-level entry:\n  macOS: ~/Library/LaunchAgents/pitchfork.plist\n  Linux: ~/.config/systemd/user/pitchfork.service\n\nTo run the supervisor as root but keep state files and IPC sockets in a\nspecific user's home directory, set `settings.supervisor.user` in the global\npitchfork configuration (~/.config/pitchfork/config.toml or\n/etc/pitchfork/config.toml).\n\nSubcommands:\n  enable    Register pitchfork to start on boot\n  disable   Remove pitchfork from boot startup\n  status    Check if boot start is currently enabled\n\nExamples:\n  pitchfork boot enable           Start pitchfork on system boot (user-level)\n  sudo pitchfork boot enable      Start pitchfork on system boot (system-level)\n  pitchfork boot disable          Don't start pitchfork on boot\n  pitchfork boot status           Check boot start status",
+        "help_long": "Enable or disable boot start\n\nManages whether pitchfork supervisor starts automatically when the system\nboots. Uses platform-specific mechanisms (launchd on macOS, systemd on Linux).\n\nWhen run as root (or via sudo), registers a system-level entry that starts\npitchfork for all users:\n\n    macOS: /Library/LaunchDaemons/pitchfork.plist\n    Linux: /etc/systemd/system/pitchfork.service\n\nWhen run as a normal user, registers a user-level entry:\n\n    macOS: ~/Library/LaunchAgents/pitchfork.plist\n    Linux: ~/.config/systemd/user/pitchfork.service\n\nTo run the supervisor as root but keep state files and IPC sockets in a\nspecific user's home directory, set `settings.supervisor.user` in the global\npitchfork configuration (~/.config/pitchfork/config.toml or\n/etc/pitchfork/config.toml).\n\nSubcommands:\n\n    enable    Register pitchfork to start on boot\n    disable   Remove pitchfork from boot startup\n    status    Check if boot start is currently enabled\n\nExamples:\n\n    pitchfork boot enable           Start pitchfork on system boot (user-level)\n    sudo pitchfork boot enable      Start pitchfork on system boot (system-level)\n    pitchfork boot disable          Don't start pitchfork on boot\n    pitchfork boot status           Check boot start status",
         "name": "boot",
         "aliases": [],
         "hidden_aliases": [],
@@ -174,7 +174,7 @@
         "effect": "write",
         "hide": false,
         "help": "Removes stopped/failed daemons from `pitchfork list`",
-        "help_long": "Removes stopped/failed daemons from `pitchfork list`\n\nCleans up the daemon list by removing entries for daemons that are no\nlonger running. Does not affect running daemons or their configurations.\n\nUse this to clear out old entries after stopping daemons manually or\nafter daemons have failed.\n\nExamples:\n  pitchfork clean                 Remove all stopped/failed entries\n  pitchfork c                     Alias for 'clean'",
+        "help_long": "Removes stopped/failed daemons from `pitchfork list`\n\nCleans up the daemon list by removing entries for daemons that are no\nlonger running. Does not affect running daemons or their configurations.\n\nUse this to clear out old entries after stopping daemons manually or\nafter daemons have failed.\n\nExamples:\n\n    pitchfork clean                 Remove all stopped/failed entries\n    pitchfork c                     Alias for 'clean'",
         "name": "clean",
         "aliases": [
           "c"
@@ -690,7 +690,7 @@
             "effect": "write",
             "hide": false,
             "help": "Add a new daemon to pitchfork.toml",
-            "help_long": "Add a new daemon to pitchfork.toml\n\nCreates a new daemon configuration section in the pitchfork.toml file.\nThe daemon will be added to the nearest pitchfork.toml found in the\nfilesystem hierarchy starting from the current directory.\n\nExamples:\n  pitchfork daemons add api bun run server\n                                 Add daemon using positional args\n  pitchfork daemons add api --run 'npm start'\n                                 Add daemon with explicit run command\n  pitchfork daemons add api -- bun run server\n                                 Add daemon with explicit args after --\n  pitchfork daemons add api --run 'npm start' --retry 3\n                                 Add with retry policy\n  pitchfork daemons add api --run 'npm start' --watch 'src/**/*.ts'\n                                 Add with file watching\n  pitchfork daemons add api --run 'npm start' --autostart --autostop\n                                 Add with auto start/stop hooks\n  pitchfork daemons add worker --run './worker' --depends api\n                                 Add with daemon dependency\n  pitchfork daemons add api --run 'npm start' --local\n                                  Add to pitchfork.local.toml instead\n  pitchfork daemons add api --run 'npm start' --global\n                                  Add to ~/.config/pitchfork/config.toml instead\n  pitchfork daemons add worker --run './worker' --cron-schedule '0 * * * *' --cron-immediate\n                                  Add cron daemon that triggers immediately\n",
+            "help_long": "Add a new daemon to pitchfork.toml\n\nCreates a new daemon configuration section in the pitchfork.toml file.\nThe daemon will be added to the nearest pitchfork.toml found in the\nfilesystem hierarchy starting from the current directory.\n\nExamples:\n\n    pitchfork daemons add api bun run server\n                                     Add daemon using positional args\n    pitchfork daemons add api --run 'npm start'\n                                     Add daemon with explicit run command\n    pitchfork daemons add api -- bun run server\n                                     Add daemon with explicit args after --\n    pitchfork daemons add api --run 'npm start' --retry 3\n                                     Add with retry policy\n    pitchfork daemons add api --run 'npm start' --watch 'src/**/*.ts'\n                                     Add with file watching\n    pitchfork daemons add api --run 'npm start' --autostart --autostop\n                                     Add with auto start/stop hooks\n    pitchfork daemons add worker --run './worker' --depends api\n                                     Add with daemon dependency\n    pitchfork daemons add api --run 'npm start' --local\n                                   Add to pitchfork.local.toml instead\n    pitchfork daemons add api --run 'npm start' --global\n                                  Add to ~/.config/pitchfork/config.toml instead\n    pitchfork daemons add worker --run './worker' --cron-schedule '0 * * * *' --cron-immediate\n                                  Add cron daemon that triggers immediately\n",
             "name": "add",
             "aliases": [
               "a"
@@ -814,7 +814,7 @@
         "effect": "read",
         "hide": false,
         "help": "Generates shell completion scripts",
-        "help_long": "Generates shell completion scripts\n\nCreates tab-completion scripts for your shell. Requires the 'usage' CLI tool.\n\nSupported shells: bash, zsh, fish\n\nInstallation:\n  bash:\n    pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork\n\n  zsh:\n    pitchfork completion zsh > ~/.zfunc/_pitchfork\n\n  fish:\n    pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish",
+        "help_long": "Generates shell completion scripts\n\nCreates tab-completion scripts for your shell. Requires the 'usage' CLI tool.\n\nSupported shells: bash, zsh, fish\n\nInstallation:\n\n    bash:\n      pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork\n\n    zsh:\n      pitchfork completion zsh > ~/.zfunc/_pitchfork\n\n    fish:\n      pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish",
         "name": "completion",
         "aliases": [],
         "hidden_aliases": [],
@@ -842,7 +842,7 @@
         "effect": "write",
         "hide": false,
         "help": "Prevent a daemon from restarting",
-        "help_long": "Prevent a daemon from restarting\n\nDisables a daemon to prevent it from being started automatically or manually.\nThe daemon will remain disabled until 'pitchfork enable' is called.\nUseful for temporarily stopping a service without removing it from config.\n\nExamples:\n  pitchfork disable api           Prevent daemon from starting\n  pitchfork d api                 Alias for 'disable'\n  pitchfork list                  Shows 'disabled' status in output",
+        "help_long": "Prevent a daemon from restarting\n\nDisables a daemon to prevent it from being started automatically or manually.\nThe daemon will remain disabled until `pitchfork enable` is called.\nUseful for temporarily stopping a service without removing it from config.\n\nExamples:\n\n    pitchfork disable api           Prevent daemon from starting\n    pitchfork d api                 Alias for 'disable'\n    pitchfork list                  Shows 'disabled' status in output",
         "name": "disable",
         "aliases": [
           "d"
@@ -872,7 +872,7 @@
         "effect": "write",
         "hide": false,
         "help": "Allow a daemon to start",
-        "help_long": "Allow a daemon to start\n\nRe-enables a previously disabled daemon, allowing it to be started manually\nor automatically. Use this after 'pitchfork disable' to restore normal operation.\n\nExamples:\n  pitchfork enable api            Enable a disabled daemon\n  pitchfork e api                 Alias for 'enable'",
+        "help_long": "Allow a daemon to start\n\nRe-enables a previously disabled daemon, allowing it to be started manually\nor automatically. Use this after `pitchfork disable` to restore normal\noperation.\n\nExamples:\n\n    pitchfork enable api            Enable a disabled daemon\n    pitchfork e api                 Alias for 'enable'",
         "name": "enable",
         "aliases": [
           "e"
@@ -983,7 +983,7 @@
         "effect": "read",
         "hide": false,
         "help": "List all daemons",
-        "help_long": "List all daemons\n\nDisplays a table of all tracked daemons with their PIDs, status,\nwhether they are disabled, and any error messages.\n\nThis command shows both:\n- Active daemons (currently running or stopped)\n- Available daemons (defined in config but not yet started)\n\nExample:\n  pitchfork list\n  pitchfork ls                    Alias for 'list'\n  pitchfork list --hide-header    Output without column headers\n  pitchfork list --status running  Show only running daemons\n  pitchfork ls --status available --status stopped\n                                  Show daemons that are available OR stopped\n  pitchfork list --namespace frontend\n                                  Show only daemons in the 'frontend' namespace\n  pitchfork list --project        Show only the current project's daemons\n\nOutput:\n  Name    Status\n  api     running    https://api.localhost\n  worker  available\n  db      errored    exit code 127",
+        "help_long": "List all daemons\n\nDisplays a table of all tracked daemons with their PIDs, status,\nwhether they are disabled, and any error messages.\n\nThis command shows both:\n- Active daemons (currently running or stopped)\n- Available daemons (defined in config but not yet started)\n\nExample:\n\n    pitchfork list\n    pitchfork ls                    Alias for 'list'\n    pitchfork list --hide-header    Output without column headers\n    pitchfork list --status running  Show only running daemons\n    pitchfork ls --status available --status stopped\n                                    Show daemons that are available OR stopped\n    pitchfork list --namespace frontend\n                                    Show only daemons in the 'frontend' namespace\n    pitchfork list --project        Show only the current project's daemons\n\nOutput:\n\n    Name    Status\n    api     running    https://api.localhost\n    worker  available\n    db      errored    exit code 127",
         "name": "list",
         "aliases": [
           "ls"
@@ -1447,7 +1447,7 @@
         "effect": "read",
         "hide": false,
         "help": "Displays logs for daemon(s)",
-        "help_long": "Displays logs for daemon(s)\n\nShows logs from managed daemons. Logs are stored in the pitchfork logs directory\nand include timestamps for filtering.\n\nExamples:\n  pitchfork logs api              Show all logs for 'api' (paged if needed)\n  pitchfork logs api worker       Show logs for multiple daemons\n  pitchfork logs                  Show logs for all daemons\n  pitchfork logs api -n 50        Show last 50 lines\n  pitchfork logs api --follow     Follow logs in real-time\n  pitchfork logs api --since '2024-01-15 10:00:00'\n                                  Show logs since a specific time (forward)\n  pitchfork logs api --since '10:30:00'\n                                  Show logs since 10:30:00 today\n  pitchfork logs api --since '10:30' --until '12:00'\n                                  Show logs since 10:30:00 until 12:00:00 today\n  pitchfork logs api --since 5min Show logs from last 5 minutes\n  pitchfork logs api --raw        Output raw log lines without formatting\n  pitchfork logs api --raw -n 100 Output last 100 raw log lines\n  pitchfork logs api --clear      Delete logs for 'api'\n  pitchfork logs --clear          Delete logs for all daemons",
+        "help_long": "Displays logs for daemon(s)\n\nShows logs from managed daemons. Logs are stored in the pitchfork logs directory\nand include timestamps for filtering.\n\nExamples:\n\n    pitchfork logs api              Show all logs for 'api' (paged if needed)\n    pitchfork logs api worker       Show logs for multiple daemons\n    pitchfork logs                  Show logs for all daemons\n    pitchfork logs api -n 50        Show last 50 lines\n    pitchfork logs api --follow     Follow logs in real-time\n    pitchfork logs api --since '2024-01-15 10:00:00'\n                                    Show logs since a specific time (forward)\n    pitchfork logs api --since '10:30:00'\n                                    Show logs since 10:30:00 today\n    pitchfork logs api --since '10:30' --until '12:00'\n                                    Show logs since 10:30:00 until 12:00:00 today\n    pitchfork logs api --since 5min Show logs from last 5 minutes\n    pitchfork logs api --raw        Output raw log lines without formatting\n    pitchfork logs api --raw -n 100 Output last 100 raw log lines\n    pitchfork logs api --clear      Delete logs for 'api'\n    pitchfork logs --clear          Delete logs for all daemons",
         "name": "logs",
         "aliases": [
           "l"
@@ -1466,11 +1466,11 @@
         "mounts": [],
         "hide": false,
         "help": "Runs a Model Context Protocol (MCP) server over stdin/stdout",
-        "help_long": "Runs a Model Context Protocol (MCP) server over stdin/stdout\n\nThis command starts an MCP server that exposes pitchfork daemon management\nto AI assistants (Claude, Cursor, etc.) over stdin/stdout using JSON-RPC.\n\nTypically used as a subprocess by an MCP-aware AI agent.\n\nExamples:\n  # In claude_desktop_config.json or similar:\n  {\n    \"mcpServers\": {\n      \"pitchfork\": {\n        \"command\": \"pitchfork\",\n        \"args\": [\"mcp\"]\n      }\n    }\n  }\n\nTools provided:\n  pitchfork_status    List all daemons and their state\n  pitchfork_start     Start a named daemon\n  pitchfork_stop      Stop a named daemon\n  pitchfork_restart   Restart a named daemon\n  pitchfork_logs      Return recent log output for a daemon",
+        "help_long": "Runs a Model Context Protocol (MCP) server over stdin/stdout\n\nThis command starts an MCP server that exposes pitchfork daemon management\nto AI assistants (Claude, Cursor, etc.) over stdin/stdout using JSON-RPC.\n\nTypically used as a subprocess by an MCP-aware AI agent.\n\nExamples:\n\n    # In claude_desktop_config.json or similar:\n    {\n        \"mcpServers\": {\n            \"pitchfork\": {\n                \"command\": \"pitchfork\",\n                \"args\": [\"mcp\"]\n            }\n        }\n    }\n\nTools provided:\n\n    pitchfork_status    List all daemons and their state\n    pitchfork_start     Start a named daemon\n    pitchfork_stop      Stop a named daemon\n    pitchfork_restart   Restart a named daemon\n    pitchfork_logs      Return recent log output for a daemon",
         "name": "mcp",
         "aliases": [],
         "hidden_aliases": [],
-        "after_help_long": "Examples:\n\n  # Start the MCP server (used by AI assistant tools)\n  $ pitchfork mcp\n\n  # Claude Desktop configuration (claude_desktop_config.json):\n  {\n    \"mcpServers\": {\n      \"pitchfork\": {\n        \"command\": \"pitchfork\",\n        \"args\": [\"mcp\"]\n      }\n    }\n  }\n\n  # Interactive testing with JSON-RPC:\n  $ echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}' | pitchfork mcp\n\n  # Available tools:\n  - pitchfork_status  - List all daemons and their state\n  - pitchfork_start   - Start daemon(s) by name\n  - pitchfork_stop    - Stop daemon(s) by name\n  - pitchfork_restart - Restart daemon(s) by name\n  - pitchfork_logs    - Return recent log output for daemon(s)\n",
+        "after_help_long": "Examples:\n\n    # Start the MCP server (used by AI assistant tools)\n    $ pitchfork mcp\n\n    # Claude Desktop configuration (claude_desktop_config.json):\n    {\n      \"mcpServers\": {\n        \"pitchfork\": {\n          \"command\": \"pitchfork\",\n          \"args\": [\"mcp\"]\n        }\n      }\n    }\n\n    # Interactive testing with JSON-RPC:\n    $ echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}' | pitchfork mcp\n\n# Available tools:\n- pitchfork_status  - List all daemons and their state\n- pitchfork_start   - Start daemon(s) by name\n- pitchfork_stop    - Stop daemon(s) by name\n- pitchfork_restart - Restart daemon(s) by name\n- pitchfork_logs    - Return recent log output for daemon(s)\n",
         "examples": []
       },
       "proxy": {
@@ -1512,7 +1512,7 @@
             "effect": "write",
             "hide": false,
             "help": "Install the proxy's self-signed TLS certificate into the system trust store",
-            "help_long": "Install the proxy's self-signed TLS certificate into the system trust store\n\nThis command installs pitchfork's auto-generated TLS certificate into your\nsystem's trust store so that browsers and tools trust HTTPS proxy URLs\nwithout certificate warnings.\n\nOn macOS, this installs the certificate into the current user's login\nkeychain. No `sudo` required.\n\nOn Linux, the appropriate CA certificate directory and update command are\ndetected automatically based on the running distribution:\n  - Debian/Ubuntu: /usr/local/share/ca-certificates/ + update-ca-certificates\n  - RHEL/Fedora/CentOS: /etc/pki/ca-trust/source/anchors/ + update-ca-trust\n  - Arch Linux: /etc/ca-certificates/trust-source/anchors/ + trust extract-compat\n  - openSUSE: /etc/pki/trust/anchors/ + update-ca-certificates\n\nThis DOES require sudo on Linux.\n\nExample:\n  pitchfork proxy trust\n  sudo pitchfork proxy trust    # Linux only",
+            "help_long": "Install the proxy's self-signed TLS certificate into the system trust store\n\nThis command installs pitchfork's auto-generated TLS certificate into your\nsystem's trust store so that browsers and tools trust HTTPS proxy URLs\nwithout certificate warnings.\n\nOn macOS, this installs the certificate into the current user's login\nkeychain. No `sudo` required.\n\nOn Linux, the appropriate CA certificate directory and update command are\ndetected automatically based on the running distribution:\n  - Debian/Ubuntu: /usr/local/share/ca-certificates/ + update-ca-certificates\n  - RHEL/Fedora/CentOS: /etc/pki/ca-trust/source/anchors/ + update-ca-trust\n  - Arch Linux: /etc/ca-certificates/trust-source/anchors/ + trust extract-compat\n  - openSUSE: /etc/pki/trust/anchors/ + update-ca-certificates\n\nThis DOES require sudo on Linux.\n\nExample:\n\n```text\npitchfork proxy trust\nsudo pitchfork proxy trust    # Linux only\n```",
             "name": "trust",
             "aliases": [],
             "hidden_aliases": [],
@@ -1551,7 +1551,7 @@
             "effect": "write",
             "hide": false,
             "help": "Remove the proxy's TLS certificate from the system trust store",
-            "help_long": "Remove the proxy's TLS certificate from the system trust store\n\nRemoves the pitchfork CA certificate that was previously installed by\n`pitchfork proxy trust` or auto-trust.\n\nOn macOS, removes the certificate from the login keychain and system keychain.\nOn Linux, removes the certificate from the distro-specific CA directory\nand runs the appropriate update command.\n\nExample:\n  pitchfork proxy untrust\n  sudo pitchfork proxy untrust    # Linux only",
+            "help_long": "Remove the proxy's TLS certificate from the system trust store\n\nRemoves the pitchfork CA certificate that was previously installed by\n`pitchfork proxy trust` or auto-trust.\n\nOn macOS, removes the certificate from the login keychain and system keychain.\nOn Linux, removes the certificate from the distro-specific CA directory\nand runs the appropriate update command.\n\nExample:\n\n```text\npitchfork proxy untrust\nsudo pitchfork proxy untrust    # Linux only\n```",
             "name": "untrust",
             "aliases": [],
             "hidden_aliases": [],
@@ -1670,7 +1670,7 @@
             "effect": "write",
             "hide": false,
             "help": "Add a slug mapping to the global config",
-            "help_long": "Add a slug mapping to the global config\n\nRegisters a slug in ~/.config/pitchfork/config.toml that maps to a project\ndirectory and daemon name. The proxy uses this to route requests.\n\nIf --dir is not specified, uses the current directory.\nIf --daemon is not specified, defaults to the slug name.\n\nExample:\n  pitchfork proxy add api\n  pitchfork proxy add api --daemon server\n  pitchfork proxy add api --dir /home/user/my-api --daemon server",
+            "help_long": "Add a slug mapping to the global config\n\nRegisters a slug in ~/.config/pitchfork/config.toml that maps to a project\ndirectory and daemon name. The proxy uses this to route requests.\n\nIf --dir is not specified, uses the current directory.\nIf --daemon is not specified, defaults to the slug name.\n\nExample:\n\n```text\npitchfork proxy add api\npitchfork proxy add api --daemon server\npitchfork proxy add api --dir /home/user/my-api --daemon server\n```",
             "name": "add",
             "aliases": [],
             "hidden_aliases": [],
@@ -1699,7 +1699,7 @@
             "effect": "destructive",
             "hide": false,
             "help": "Remove a slug mapping from the global config",
-            "help_long": "Remove a slug mapping from the global config\n\nExample:\n  pitchfork proxy remove api",
+            "help_long": "Remove a slug mapping from the global config\n\nExample:\n\n```text\npitchfork proxy remove api\n```",
             "name": "remove",
             "aliases": [
               "rm"
@@ -1715,7 +1715,7 @@
         "hide": false,
         "subcommand_required": true,
         "help": "Manage the pitchfork reverse proxy",
-        "help_long": "Manage the pitchfork reverse proxy\n\nThe reverse proxy routes requests from stable slug-based URLs like:\n  https://myapp.localhost\n\nto the daemon's actual listening port (e.g. localhost:3000).\n\nSlugs are defined in the global config (~/.config/pitchfork/config.toml)\nunder [slugs]. Each slug maps to a project directory and daemon name.\n\nEnable the proxy in your pitchfork.toml or settings:\n  [settings.proxy]\n  enable = true\n\nSubcommands:\n  trust     Install the proxy's TLS certificate into the system trust store\n  untrust   Remove the proxy's TLS certificate from the system trust store\n  add       Add a slug mapping to the global config\n  remove    Remove a slug mapping from the global config\n  status    Show all registered slugs and their current state",
+        "help_long": "Manage the pitchfork reverse proxy\n\nThe reverse proxy routes requests from stable slug-based URLs like\n`https://myapp.localhost` to the daemon's actual listening port (e.g.\nlocalhost:3000).\n\nSlugs are defined in the global config (~/.config/pitchfork/config.toml)\nunder [slugs]. Each slug maps to a project directory and daemon name.\n\nEnable the proxy in your pitchfork.toml or settings:\n\n    [settings.proxy]\n    enable = true\n\nSubcommands:\n\n    trust     Install the proxy's TLS certificate into the system trust store\n    untrust   Remove the proxy's TLS certificate from the system trust store\n    add       Add a slug mapping to the global config\n    remove    Remove a slug mapping from the global config\n    status    Show all registered slugs and their current state",
         "name": "proxy",
         "aliases": [],
         "hidden_aliases": [],
@@ -1870,7 +1870,7 @@
             "effect": "read",
             "hide": false,
             "help": "List tracked project sessions.",
-            "help_long": "List tracked project sessions\n\nDisplays a table of active project sessions with their host PID, directory,\nliveness status, and recorded process title.\n\nExample:\n  pitchfork project list\n  pitchfork project list --json",
+            "help_long": "List tracked project sessions\n\nDisplays a table of active project sessions with their host PID, directory,\nliveness status, and recorded process title.\n\nExample:\n\n    pitchfork project list\n    pitchfork project list --json",
             "name": "list",
             "aliases": [],
             "hidden_aliases": [],
@@ -2084,7 +2084,7 @@
         "mounts": [],
         "hide": false,
         "help": "Restarts a daemon (stops then starts it)",
-        "help_long": "Restarts a daemon (stops then starts it)\n\nEquivalent to 'start --force' - stops the daemon (SIGTERM) then starts it again\nfrom the pitchfork.toml configuration with dependency resolution.\n\nExamples:\n  pitchfork restart api           Restart a single daemon\n  pitchfork restart api worker    Restart multiple daemons\n  pitchfork restart --group backend Restart all daemons in the 'backend' group\n  pitchfork restart --all         Restart all running daemons\n  pitchfork restart -l            Restart all local daemons in pitchfork.toml\n  pitchfork restart -g            Restart all global daemons in config.toml\n  pitchfork restart api --delay 5 Wait 5 seconds for daemon to be ready",
+        "help_long": "Restarts a daemon (stops then starts it)\n\nEquivalent to `start --force` - stops the daemon (SIGTERM) then starts it again\nfrom the pitchfork.toml configuration with dependency resolution.\n\nExamples:\n\n    pitchfork restart api           Restart a single daemon\n    pitchfork restart api worker    Restart multiple daemons\n    pitchfork restart --group backend Restart all daemons in the 'backend' group\n    pitchfork restart --all         Restart all running daemons\n    pitchfork restart -l            Restart all local daemons in pitchfork.toml\n    pitchfork restart -g            Restart all global daemons in config.toml\n    pitchfork restart api --delay 5 Wait 5 seconds for daemon to be ready",
         "name": "restart",
         "aliases": [],
         "hidden_aliases": [],
@@ -2310,7 +2310,7 @@
         "mounts": [],
         "hide": false,
         "help": "Runs a one-off daemon",
-        "help_long": "Runs a one-off daemon\n\nRuns a command as a managed daemon without needing a pitchfork.toml.\nThe daemon is tracked by pitchfork and can be monitored with 'pitchfork status'.\n\nExamples:\n  pitchfork run api -- npm run dev\n                                Run npm as daemon named 'api'\n  pitchfork run api -f -- npm run dev\n                                Force restart if 'api' is running\n  pitchfork run api --retry 3 -- ./server\n                                Restart up to 3 times on failure\n  pitchfork run api -d 5 -- ./server\n                                Wait 5 seconds for ready check\n  pitchfork run api -o 'Listening' -- ./server\n                                Wait for output pattern before ready\n  pitchfork run api --http http://localhost:8080/health -- ./server\n                                Wait for HTTP endpoint to return 2xx\n  pitchfork run api --port 8080 -- ./server\n                                Wait for TCP port to be listening",
+        "help_long": "Runs a one-off daemon\n\nRuns a command as a managed daemon without needing a pitchfork.toml.\nThe daemon is tracked by pitchfork and can be monitored with `pitchfork status`.\n\nExamples:\n\n    pitchfork run api -- npm run dev\n                                  Run npm as daemon named 'api'\n    pitchfork run api -f -- npm run dev\n                                  Force restart if 'api' is running\n    pitchfork run api --retry 3 -- ./server\n                                  Restart up to 3 times on failure\n    pitchfork run api -d 5 -- ./server\n                                  Wait 5 seconds for ready check\n    pitchfork run api -o 'Listening' -- ./server\n                                  Wait for output pattern before ready\n    pitchfork run api --http http://localhost:8080/health -- ./server\n                                  Wait for HTTP endpoint to return 2xx\n    pitchfork run api --port 8080 -- ./server\n                                  Wait for TCP port to be listening",
         "name": "run",
         "aliases": [
           "r"
@@ -2528,7 +2528,7 @@
         "effect": "read",
         "hide": false,
         "help": "View and modify pitchfork settings",
-        "help_long": "View and modify pitchfork settings\n\nSettings can be configured in multiple ways (in order of precedence):\n1. Environment variables (highest priority)\n2. Project-level pitchfork.toml or pitchfork.local.toml in [settings] section\n3. User-level ~/.config/pitchfork/config.toml in [settings] section\n4. System-level /etc/pitchfork/config.toml in [settings] section\n5. Built-in defaults (lowest priority)\n\nSubcommands:\n  list    List all available settings with types and defaults\n  get     Get the current value of a setting\n  set     Set a setting value in a config file\n\nExamples:\n  pitchfork settings                        Show all current settings\n  pitchfork settings list                   List all available settings\n  pitchfork settings get general.log_level  Get a specific setting\n  pitchfork settings set general.log_level debug\n  pitchfork settings set web.auto_start true --global\n  pitchfork settings set supervisor.stop_timeout 10s --local\n  pitchfork settings set supervisor.stop_timeout 10s --project",
+        "help_long": "View and modify pitchfork settings\n\nSettings can be configured in multiple ways (in order of precedence):\n1. Environment variables (highest priority)\n2. Project-level pitchfork.toml or pitchfork.local.toml in [settings] section\n3. User-level ~/.config/pitchfork/config.toml in [settings] section\n4. System-level /etc/pitchfork/config.toml in [settings] section\n5. Built-in defaults (lowest priority)\n\nSubcommands:\n\n    list    List all available settings with types and defaults\n    get     Get the current value of a setting\n    set     Set a setting value in a config file\n\nExamples:\n\n    pitchfork settings                        Show all current settings\n    pitchfork settings list                   List all available settings\n    pitchfork settings get general.log_level  Get a specific setting\n    pitchfork settings set general.log_level debug\n    pitchfork settings set web.auto_start true --global\n    pitchfork settings set supervisor.stop_timeout 10s --local\n    pitchfork settings set supervisor.stop_timeout 10s --project",
         "name": "settings",
         "aliases": [
           "setting"
@@ -2818,7 +2818,7 @@
         "mounts": [],
         "hide": false,
         "help": "Starts a daemon from a pitchfork.toml file",
-        "help_long": "Starts a daemon from a pitchfork.toml file\n\nDaemons are defined in pitchfork.toml with a `[daemons.<name>]` section.\nThe command waits for the daemon to be ready before returning.\n\nExamples:\n  pitchfork start api           Start a single daemon\n  pitchfork start api worker    Start multiple daemons\n  pitchfork start --group backend Start all daemons in the 'backend' group\n  pitchfork start -l            Start all local daemons in pitchfork.toml\n  pitchfork start -g            Start all global daemons in config.toml\n  pitchfork start -a            Start all daemons (local and global)\n  pitchfork start api -f        Restart daemon if already running\n  pitchfork start api --delay 5 Wait 5 seconds for daemon to be ready\n  pitchfork start api --output 'Listening on'\n                                Wait for output pattern before ready\n  pitchfork start api --http http://localhost:8080/health\n                                Wait for HTTP endpoint to return 2xx\n  pitchfork start api --port 8080\n                                Wait for TCP port to be listening",
+        "help_long": "Starts a daemon from a pitchfork.toml file\n\nDaemons are defined in pitchfork.toml with a `[daemons.<name>]` section.\nThe command waits for the daemon to be ready before returning.\n\nExamples:\n\n    pitchfork start api           Start a single daemon\n    pitchfork start api worker    Start multiple daemons\n    pitchfork start --group backend Start all daemons in the 'backend' group\n    pitchfork start -l            Start all local daemons in pitchfork.toml\n    pitchfork start -g            Start all global daemons in config.toml\n    pitchfork start -a            Start all daemons (local and global)\n    pitchfork start api -f        Restart daemon if already running\n    pitchfork start api --delay 5 Wait 5 seconds for daemon to be ready\n    pitchfork start api --output 'Listening on'\n                                  Wait for output pattern before ready\n    pitchfork start api --http http://localhost:8080/health\n                                  Wait for HTTP endpoint to return 2xx\n    pitchfork start api --port 8080\n                                  Wait for TCP port to be listening",
         "name": "start",
         "aliases": [
           "s"
@@ -2861,7 +2861,7 @@
         "effect": "read",
         "hide": false,
         "help": "Display the status of a daemon",
-        "help_long": "Display the status of a daemon\n\nShows detailed information about a single daemon including its PID and\ncurrent status (running, stopped, failed, etc.).\n\nExample:\n  pitchfork status api\n\nOutput:\n  Name: api\n  PID: 12345\n  Status: running",
+        "help_long": "Display the status of a daemon\n\nShows detailed information about a single daemon including its PID and\ncurrent status (running, stopped, failed, etc.).\n\nExample:\n\n    pitchfork status api\n\nOutput:\n\n    Name: api\n    PID: 12345\n    Status: running",
         "name": "status",
         "aliases": [
           "stat"
@@ -2956,7 +2956,7 @@
         "effect": "write",
         "hide": false,
         "help": "Sends a stop signal to a daemon",
-        "help_long": "Sends a stop signal to a daemon\n\nUses a graceful shutdown strategy:\n1. Send SIGTERM and wait up to ~3 seconds for the process to exit (fast 10ms checks initially, then 50ms)\n2. If still running, send SIGKILL to force termination\n\nMost processes will exit immediately after the first SIGTERM. The escalation\nensures stubborn processes are eventually terminated while giving well-behaved\nprocesses time to clean up resources.\n\nWhen using --all/--local/--global, daemons are stopped in reverse dependency order:\ndependents are stopped before the daemons they depend on.\n\nExamples:\n  pitchfork stop api           Stop a single daemon\n  pitchfork stop api worker    Stop multiple daemons\n  pitchfork stop --group backend Stop all daemons in the 'backend' group\n  pitchfork stop --all         Stop all running daemons in dependency order\n  pitchfork stop -l            Stop all local daemons in pitchfork.toml\n  pitchfork stop -g            Stop all global daemons in config.toml\n  pitchfork kill api           Same as 'stop' (alias)",
+        "help_long": "Sends a stop signal to a daemon\n\nUses a graceful shutdown strategy:\n1. Send SIGTERM and wait up to ~3 seconds for the process to exit (fast 10ms checks initially, then 50ms)\n2. If still running, send SIGKILL to force termination\n\nMost processes will exit immediately after the first SIGTERM. The escalation\nensures stubborn processes are eventually terminated while giving well-behaved\nprocesses time to clean up resources.\n\nWhen using --all/--local/--global, daemons are stopped in reverse dependency order:\ndependents are stopped before the daemons they depend on.\n\nExamples:\n\n    pitchfork stop api           Stop a single daemon\n    pitchfork stop api worker    Stop multiple daemons\n    pitchfork stop --group backend Stop all daemons in the 'backend' group\n    pitchfork stop --all         Stop all running daemons in dependency order\n    pitchfork stop -l            Stop all local daemons in pitchfork.toml\n    pitchfork stop -g            Stop all global daemons in config.toml\n    pitchfork kill api           Same as 'stop' (alias)",
         "name": "stop",
         "aliases": [
           "kill"
@@ -3205,7 +3205,7 @@
         "mounts": [],
         "hide": false,
         "help": "Launch the interactive TUI dashboard",
-        "help_long": "Launch the interactive TUI dashboard\n\nShows live daemon status with fuzzy search, sorting, batch operations,\nlog viewing, and a config editor.\n\nThe dashboard can be scoped to one or more namespaces; the fuzzy search\n(`/`) then operates within the scoped set.\n\nExample:\n  pitchfork tui\n  pitchfork tui --namespace frontend\n                                  Show only daemons in the 'frontend' namespace\n  pitchfork tui --project         Show only the current project's daemons",
+        "help_long": "Launch the interactive TUI dashboard\n\nShows live daemon status with fuzzy search, sorting, batch operations,\nlog viewing, and a config editor.\n\nThe dashboard can be scoped to one or more namespaces; the fuzzy search\n(`/`) then operates within the scoped set.\n\nExample:\n\n    pitchfork tui\n    pitchfork tui --namespace frontend\n                                    Show only daemons in the 'frontend' namespace\n    pitchfork tui --project         Show only the current project's daemons",
         "name": "tui",
         "aliases": [],
         "hidden_aliases": [],
@@ -3251,7 +3251,7 @@
         "effect": "read",
         "hide": false,
         "help": "Wait for a daemon to stop, tailing the logs along the way",
-        "help_long": "Wait for a daemon to stop, tailing the logs along the way\n\nBlocks until the specified daemon stops running, while displaying its\nlog output in real-time. Exits with the same status code as the daemon.\n\nUseful in scripts that need to wait for a daemon to complete.\n\nExamples:\n  pitchfork wait api              Wait for 'api' to stop\n  pitchfork w api                 Alias for 'wait'\n  pitchfork wait api && echo done Run command after daemon stops",
+        "help_long": "Wait for a daemon to stop, tailing the logs along the way\n\nBlocks until the specified daemon stops running, while displaying its\nlog output in real-time. Exits with the same status code as the daemon.\n\nUseful in scripts that need to wait for a daemon to complete.\n\nExamples:\n\n    pitchfork wait api              Wait for 'api' to stop\n    pitchfork w api                 Alias for 'wait'\n    pitchfork wait api && echo done Run command after daemon stops",
         "name": "wait",
         "aliases": [
           "w"

--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -11,14 +11,15 @@ Creates tab-completion scripts for your shell. Requires the 'usage' CLI tool.
 Supported shells: bash, zsh, fish
 
 Installation:
-  bash:
-    pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork
 
-  zsh:
-    pitchfork completion zsh > ~/.zfunc/_pitchfork
+    bash:
+      pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork
 
-  fish:
-    pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish
+    zsh:
+      pitchfork completion zsh > ~/.zfunc/_pitchfork
+
+    fish:
+      pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish
 
 ## Arguments
 

--- a/docs/cli/daemons/add.md
+++ b/docs/cli/daemons/add.md
@@ -12,25 +12,26 @@ The daemon will be added to the nearest pitchfork.toml found in the
 filesystem hierarchy starting from the current directory.
 
 Examples:
-  pitchfork daemons add api bun run server
-                                 Add daemon using positional args
-  pitchfork daemons add api --run 'npm start'
-                                 Add daemon with explicit run command
-  pitchfork daemons add api -- bun run server
-                                 Add daemon with explicit args after --
-  pitchfork daemons add api --run 'npm start' --retry 3
-                                 Add with retry policy
-  pitchfork daemons add api --run 'npm start' --watch 'src/**/*.ts'
-                                 Add with file watching
-  pitchfork daemons add api --run 'npm start' --autostart --autostop
-                                 Add with auto start/stop hooks
-  pitchfork daemons add worker --run './worker' --depends api
-                                 Add with daemon dependency
-  pitchfork daemons add api --run 'npm start' --local
-                                  Add to pitchfork.local.toml instead
-  pitchfork daemons add api --run 'npm start' --global
+
+    pitchfork daemons add api bun run server
+                                     Add daemon using positional args
+    pitchfork daemons add api --run 'npm start'
+                                     Add daemon with explicit run command
+    pitchfork daemons add api -- bun run server
+                                     Add daemon with explicit args after --
+    pitchfork daemons add api --run 'npm start' --retry 3
+                                     Add with retry policy
+    pitchfork daemons add api --run 'npm start' --watch 'src/**/*.ts'
+                                     Add with file watching
+    pitchfork daemons add api --run 'npm start' --autostart --autostop
+                                     Add with auto start/stop hooks
+    pitchfork daemons add worker --run './worker' --depends api
+                                     Add with daemon dependency
+    pitchfork daemons add api --run 'npm start' --local
+                                   Add to pitchfork.local.toml instead
+    pitchfork daemons add api --run 'npm start' --global
                                   Add to ~/.config/pitchfork/config.toml instead
-  pitchfork daemons add worker --run './worker' --cron-schedule '0 * * * *' --cron-immediate
+    pitchfork daemons add worker --run './worker' --cron-schedule '0 * * * *' --cron-immediate
                                   Add cron daemon that triggers immediately
 
 ## Arguments

--- a/docs/cli/disable.md
+++ b/docs/cli/disable.md
@@ -8,13 +8,14 @@
 Prevent a daemon from restarting
 
 Disables a daemon to prevent it from being started automatically or manually.
-The daemon will remain disabled until 'pitchfork enable' is called.
+The daemon will remain disabled until `pitchfork enable` is called.
 Useful for temporarily stopping a service without removing it from config.
 
 Examples:
-  pitchfork disable api           Prevent daemon from starting
-  pitchfork d api                 Alias for 'disable'
-  pitchfork list                  Shows 'disabled' status in output
+
+    pitchfork disable api           Prevent daemon from starting
+    pitchfork d api                 Alias for 'disable'
+    pitchfork list                  Shows 'disabled' status in output
 
 ## Arguments
 

--- a/docs/cli/enable.md
+++ b/docs/cli/enable.md
@@ -8,11 +8,13 @@
 Allow a daemon to start
 
 Re-enables a previously disabled daemon, allowing it to be started manually
-or automatically. Use this after 'pitchfork disable' to restore normal operation.
+or automatically. Use this after `pitchfork disable` to restore normal
+operation.
 
 Examples:
-  pitchfork enable api            Enable a disabled daemon
-  pitchfork e api                 Alias for 'enable'
+
+    pitchfork enable api            Enable a disabled daemon
+    pitchfork e api                 Alias for 'enable'
 
 ## Arguments
 

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -15,21 +15,23 @@ This command shows both:
 - Available daemons (defined in config but not yet started)
 
 Example:
-  pitchfork list
-  pitchfork ls                    Alias for 'list'
-  pitchfork list --hide-header    Output without column headers
-  pitchfork list --status running  Show only running daemons
-  pitchfork ls --status available --status stopped
-                                  Show daemons that are available OR stopped
-  pitchfork list --namespace frontend
-                                  Show only daemons in the 'frontend' namespace
-  pitchfork list --project        Show only the current project's daemons
+
+    pitchfork list
+    pitchfork ls                    Alias for 'list'
+    pitchfork list --hide-header    Output without column headers
+    pitchfork list --status running  Show only running daemons
+    pitchfork ls --status available --status stopped
+                                    Show daemons that are available OR stopped
+    pitchfork list --namespace frontend
+                                    Show only daemons in the 'frontend' namespace
+    pitchfork list --project        Show only the current project's daemons
 
 Output:
-  Name    Status
-  api     running    https://api.localhost
-  worker  available
-  db      errored    exit code 127
+
+    Name    Status
+    api     running    https://api.localhost
+    worker  available
+    db      errored    exit code 127
 
 ## Flags
 

--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -11,22 +11,23 @@ Shows logs from managed daemons. Logs are stored in the pitchfork logs directory
 and include timestamps for filtering.
 
 Examples:
-  pitchfork logs api              Show all logs for 'api' (paged if needed)
-  pitchfork logs api worker       Show logs for multiple daemons
-  pitchfork logs                  Show logs for all daemons
-  pitchfork logs api -n 50        Show last 50 lines
-  pitchfork logs api --follow     Follow logs in real-time
-  pitchfork logs api --since '2024-01-15 10:00:00'
-                                  Show logs since a specific time (forward)
-  pitchfork logs api --since '10:30:00'
-                                  Show logs since 10:30:00 today
-  pitchfork logs api --since '10:30' --until '12:00'
-                                  Show logs since 10:30:00 until 12:00:00 today
-  pitchfork logs api --since 5min Show logs from last 5 minutes
-  pitchfork logs api --raw        Output raw log lines without formatting
-  pitchfork logs api --raw -n 100 Output last 100 raw log lines
-  pitchfork logs api --clear      Delete logs for 'api'
-  pitchfork logs --clear          Delete logs for all daemons
+
+    pitchfork logs api              Show all logs for 'api' (paged if needed)
+    pitchfork logs api worker       Show logs for multiple daemons
+    pitchfork logs                  Show logs for all daemons
+    pitchfork logs api -n 50        Show last 50 lines
+    pitchfork logs api --follow     Follow logs in real-time
+    pitchfork logs api --since '2024-01-15 10:00:00'
+                                    Show logs since a specific time (forward)
+    pitchfork logs api --since '10:30:00'
+                                    Show logs since 10:30:00 today
+    pitchfork logs api --since '10:30' --until '12:00'
+                                    Show logs since 10:30:00 until 12:00:00 today
+    pitchfork logs api --since 5min Show logs from last 5 minutes
+    pitchfork logs api --raw        Output raw log lines without formatting
+    pitchfork logs api --raw -n 100 Output last 100 raw log lines
+    pitchfork logs api --clear      Delete logs for 'api'
+    pitchfork logs --clear          Delete logs for all daemons
 
 ## Arguments
 

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -11,44 +11,46 @@ to AI assistants (Claude, Cursor, etc.) over stdin/stdout using JSON-RPC.
 Typically used as a subprocess by an MCP-aware AI agent.
 
 Examples:
-  # In claude_desktop_config.json or similar:
-  {
-    "mcpServers": {
-      "pitchfork": {
-        "command": "pitchfork",
-        "args": ["mcp"]
-      }
+
+    # In claude_desktop_config.json or similar:
+    {
+        "mcpServers": {
+            "pitchfork": {
+                "command": "pitchfork",
+                "args": ["mcp"]
+            }
+        }
     }
-  }
 
 Tools provided:
-  pitchfork_status    List all daemons and their state
-  pitchfork_start     Start a named daemon
-  pitchfork_stop      Stop a named daemon
-  pitchfork_restart   Restart a named daemon
-  pitchfork_logs      Return recent log output for a daemon
+
+    pitchfork_status    List all daemons and their state
+    pitchfork_start     Start a named daemon
+    pitchfork_stop      Stop a named daemon
+    pitchfork_restart   Restart a named daemon
+    pitchfork_logs      Return recent log output for a daemon
 
 Examples:
 
-  # Start the MCP server (used by AI assistant tools)
-  $ pitchfork mcp
+    # Start the MCP server (used by AI assistant tools)
+    $ pitchfork mcp
 
-  # Claude Desktop configuration (claude_desktop_config.json):
-  {
-    "mcpServers": {
-      "pitchfork": {
-        "command": "pitchfork",
-        "args": ["mcp"]
+    # Claude Desktop configuration (claude_desktop_config.json):
+    {
+      "mcpServers": {
+        "pitchfork": {
+          "command": "pitchfork",
+          "args": ["mcp"]
+        }
       }
     }
-  }
 
-  # Interactive testing with JSON-RPC:
-  $ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | pitchfork mcp
+    # Interactive testing with JSON-RPC:
+    $ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | pitchfork mcp
 
-  # Available tools:
-  - pitchfork_status  - List all daemons and their state
-  - pitchfork_start   - Start daemon(s) by name
-  - pitchfork_stop    - Stop daemon(s) by name
-  - pitchfork_restart - Restart daemon(s) by name
-  - pitchfork_logs    - Return recent log output for daemon(s)
+# Available tools:
+- pitchfork_status  - List all daemons and their state
+- pitchfork_start   - Start daemon(s) by name
+- pitchfork_stop    - Stop daemon(s) by name
+- pitchfork_restart - Restart daemon(s) by name
+- pitchfork_logs    - Return recent log output for daemon(s)

--- a/docs/cli/project/list.md
+++ b/docs/cli/project/list.md
@@ -10,8 +10,9 @@ Displays a table of active project sessions with their host PID, directory,
 liveness status, and recorded process title.
 
 Example:
-  pitchfork project list
-  pitchfork project list --json
+
+    pitchfork project list
+    pitchfork project list --json
 
 ## Flags
 

--- a/docs/cli/proxy.md
+++ b/docs/cli/proxy.md
@@ -6,24 +6,25 @@
 
 Manage the pitchfork reverse proxy
 
-The reverse proxy routes requests from stable slug-based URLs like:
-  https://myapp.localhost
-
-to the daemon's actual listening port (e.g. localhost:3000).
+The reverse proxy routes requests from stable slug-based URLs like
+`https://myapp.localhost` to the daemon's actual listening port (e.g.
+localhost:3000).
 
 Slugs are defined in the global config (~/.config/pitchfork/config.toml)
 under [slugs]. Each slug maps to a project directory and daemon name.
 
 Enable the proxy in your pitchfork.toml or settings:
-  [settings.proxy]
-  enable = true
+
+    [settings.proxy]
+    enable = true
 
 Subcommands:
-  trust     Install the proxy's TLS certificate into the system trust store
-  untrust   Remove the proxy's TLS certificate from the system trust store
-  add       Add a slug mapping to the global config
-  remove    Remove a slug mapping from the global config
-  status    Show all registered slugs and their current state
+
+    trust     Install the proxy's TLS certificate into the system trust store
+    untrust   Remove the proxy's TLS certificate from the system trust store
+    add       Add a slug mapping to the global config
+    remove    Remove a slug mapping from the global config
+    status    Show all registered slugs and their current state
 
 ## Subcommands
 

--- a/docs/cli/proxy/add.md
+++ b/docs/cli/proxy/add.md
@@ -13,9 +13,12 @@ If --dir is not specified, uses the current directory.
 If --daemon is not specified, defaults to the slug name.
 
 Example:
-  pitchfork proxy add api
-  pitchfork proxy add api --daemon server
-  pitchfork proxy add api --dir /home/user/my-api --daemon server
+
+```text
+pitchfork proxy add api
+pitchfork proxy add api --daemon server
+pitchfork proxy add api --dir /home/user/my-api --daemon server
+```
 
 ## Arguments
 

--- a/docs/cli/proxy/remove.md
+++ b/docs/cli/proxy/remove.md
@@ -8,7 +8,10 @@
 Remove a slug mapping from the global config
 
 Example:
-  pitchfork proxy remove api
+
+```text
+pitchfork proxy remove api
+```
 
 ## Arguments
 

--- a/docs/cli/proxy/trust.md
+++ b/docs/cli/proxy/trust.md
@@ -23,8 +23,11 @@ detected automatically based on the running distribution:
 This DOES require sudo on Linux.
 
 Example:
-  pitchfork proxy trust
-  sudo pitchfork proxy trust    # Linux only
+
+```text
+pitchfork proxy trust
+sudo pitchfork proxy trust    # Linux only
+```
 
 ## Flags
 

--- a/docs/cli/proxy/untrust.md
+++ b/docs/cli/proxy/untrust.md
@@ -14,8 +14,11 @@ On Linux, removes the certificate from the distro-specific CA directory
 and runs the appropriate update command.
 
 Example:
-  pitchfork proxy untrust
-  sudo pitchfork proxy untrust    # Linux only
+
+```text
+pitchfork proxy untrust
+sudo pitchfork proxy untrust    # Linux only
+```
 
 ## Flags
 

--- a/docs/cli/restart.md
+++ b/docs/cli/restart.md
@@ -5,17 +5,18 @@
 
 Restarts a daemon (stops then starts it)
 
-Equivalent to 'start --force' - stops the daemon (SIGTERM) then starts it again
+Equivalent to `start --force` - stops the daemon (SIGTERM) then starts it again
 from the pitchfork.toml configuration with dependency resolution.
 
 Examples:
-  pitchfork restart api           Restart a single daemon
-  pitchfork restart api worker    Restart multiple daemons
-  pitchfork restart --group backend Restart all daemons in the 'backend' group
-  pitchfork restart --all         Restart all running daemons
-  pitchfork restart -l            Restart all local daemons in pitchfork.toml
-  pitchfork restart -g            Restart all global daemons in config.toml
-  pitchfork restart api --delay 5 Wait 5 seconds for daemon to be ready
+
+    pitchfork restart api           Restart a single daemon
+    pitchfork restart api worker    Restart multiple daemons
+    pitchfork restart --group backend Restart all daemons in the 'backend' group
+    pitchfork restart --all         Restart all running daemons
+    pitchfork restart -l            Restart all local daemons in pitchfork.toml
+    pitchfork restart -g            Restart all global daemons in config.toml
+    pitchfork restart api --delay 5 Wait 5 seconds for daemon to be ready
 
 ## Arguments
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -7,23 +7,24 @@
 Runs a one-off daemon
 
 Runs a command as a managed daemon without needing a pitchfork.toml.
-The daemon is tracked by pitchfork and can be monitored with 'pitchfork status'.
+The daemon is tracked by pitchfork and can be monitored with `pitchfork status`.
 
 Examples:
-  pitchfork run api -- npm run dev
-                                Run npm as daemon named 'api'
-  pitchfork run api -f -- npm run dev
-                                Force restart if 'api' is running
-  pitchfork run api --retry 3 -- ./server
-                                Restart up to 3 times on failure
-  pitchfork run api -d 5 -- ./server
-                                Wait 5 seconds for ready check
-  pitchfork run api -o 'Listening' -- ./server
-                                Wait for output pattern before ready
-  pitchfork run api --http http://localhost:8080/health -- ./server
-                                Wait for HTTP endpoint to return 2xx
-  pitchfork run api --port 8080 -- ./server
-                                Wait for TCP port to be listening
+
+    pitchfork run api -- npm run dev
+                                  Run npm as daemon named 'api'
+    pitchfork run api -f -- npm run dev
+                                  Force restart if 'api' is running
+    pitchfork run api --retry 3 -- ./server
+                                  Restart up to 3 times on failure
+    pitchfork run api -d 5 -- ./server
+                                  Wait 5 seconds for ready check
+    pitchfork run api -o 'Listening' -- ./server
+                                  Wait for output pattern before ready
+    pitchfork run api --http http://localhost:8080/health -- ./server
+                                  Wait for HTTP endpoint to return 2xx
+    pitchfork run api --port 8080 -- ./server
+                                  Wait for TCP port to be listening
 
 ## Arguments
 

--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -15,18 +15,20 @@ Settings can be configured in multiple ways (in order of precedence):
 5. Built-in defaults (lowest priority)
 
 Subcommands:
-  list    List all available settings with types and defaults
-  get     Get the current value of a setting
-  set     Set a setting value in a config file
+
+    list    List all available settings with types and defaults
+    get     Get the current value of a setting
+    set     Set a setting value in a config file
 
 Examples:
-  pitchfork settings                        Show all current settings
-  pitchfork settings list                   List all available settings
-  pitchfork settings get general.log_level  Get a specific setting
-  pitchfork settings set general.log_level debug
-  pitchfork settings set web.auto_start true --global
-  pitchfork settings set supervisor.stop_timeout 10s --local
-  pitchfork settings set supervisor.stop_timeout 10s --project
+
+    pitchfork settings                        Show all current settings
+    pitchfork settings list                   List all available settings
+    pitchfork settings get general.log_level  Get a specific setting
+    pitchfork settings set general.log_level debug
+    pitchfork settings set web.auto_start true --global
+    pitchfork settings set supervisor.stop_timeout 10s --local
+    pitchfork settings set supervisor.stop_timeout 10s --project
 
 ## Flags
 

--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -10,20 +10,21 @@ Daemons are defined in pitchfork.toml with a `[daemons.<name>]` section.
 The command waits for the daemon to be ready before returning.
 
 Examples:
-  pitchfork start api           Start a single daemon
-  pitchfork start api worker    Start multiple daemons
-  pitchfork start --group backend Start all daemons in the 'backend' group
-  pitchfork start -l            Start all local daemons in pitchfork.toml
-  pitchfork start -g            Start all global daemons in config.toml
-  pitchfork start -a            Start all daemons (local and global)
-  pitchfork start api -f        Restart daemon if already running
-  pitchfork start api --delay 5 Wait 5 seconds for daemon to be ready
-  pitchfork start api --output 'Listening on'
-                                Wait for output pattern before ready
-  pitchfork start api --http http://localhost:8080/health
-                                Wait for HTTP endpoint to return 2xx
-  pitchfork start api --port 8080
-                                Wait for TCP port to be listening
+
+    pitchfork start api           Start a single daemon
+    pitchfork start api worker    Start multiple daemons
+    pitchfork start --group backend Start all daemons in the 'backend' group
+    pitchfork start -l            Start all local daemons in pitchfork.toml
+    pitchfork start -g            Start all global daemons in config.toml
+    pitchfork start -a            Start all daemons (local and global)
+    pitchfork start api -f        Restart daemon if already running
+    pitchfork start api --delay 5 Wait 5 seconds for daemon to be ready
+    pitchfork start api --output 'Listening on'
+                                  Wait for output pattern before ready
+    pitchfork start api --http http://localhost:8080/health
+                                  Wait for HTTP endpoint to return 2xx
+    pitchfork start api --port 8080
+                                  Wait for TCP port to be listening
 
 ## Arguments
 

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -11,12 +11,14 @@ Shows detailed information about a single daemon including its PID and
 current status (running, stopped, failed, etc.).
 
 Example:
-  pitchfork status api
+
+    pitchfork status api
 
 Output:
-  Name: api
-  PID: 12345
-  Status: running
+
+    Name: api
+    PID: 12345
+    Status: running
 
 ## Arguments
 

--- a/docs/cli/stop.md
+++ b/docs/cli/stop.md
@@ -19,13 +19,14 @@ When using --all/--local/--global, daemons are stopped in reverse dependency ord
 dependents are stopped before the daemons they depend on.
 
 Examples:
-  pitchfork stop api           Stop a single daemon
-  pitchfork stop api worker    Stop multiple daemons
-  pitchfork stop --group backend Stop all daemons in the 'backend' group
-  pitchfork stop --all         Stop all running daemons in dependency order
-  pitchfork stop -l            Stop all local daemons in pitchfork.toml
-  pitchfork stop -g            Stop all global daemons in config.toml
-  pitchfork kill api           Same as 'stop' (alias)
+
+    pitchfork stop api           Stop a single daemon
+    pitchfork stop api worker    Stop multiple daemons
+    pitchfork stop --group backend Stop all daemons in the 'backend' group
+    pitchfork stop --all         Stop all running daemons in dependency order
+    pitchfork stop -l            Stop all local daemons in pitchfork.toml
+    pitchfork stop -g            Stop all global daemons in config.toml
+    pitchfork kill api           Same as 'stop' (alias)
 
 ## Arguments
 

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -12,10 +12,11 @@ The dashboard can be scoped to one or more namespaces; the fuzzy search
 (`/`) then operates within the scoped set.
 
 Example:
-  pitchfork tui
-  pitchfork tui --namespace frontend
-                                  Show only daemons in the 'frontend' namespace
-  pitchfork tui --project         Show only the current project's daemons
+
+    pitchfork tui
+    pitchfork tui --namespace frontend
+                                    Show only daemons in the 'frontend' namespace
+    pitchfork tui --project         Show only the current project's daemons
 
 ## Flags
 

--- a/docs/cli/wait.md
+++ b/docs/cli/wait.md
@@ -13,9 +13,10 @@ log output in real-time. Exits with the same status code as the daemon.
 Useful in scripts that need to wait for a daemon to complete.
 
 Examples:
-  pitchfork wait api              Wait for 'api' to stop
-  pitchfork w api                 Alias for 'wait'
-  pitchfork wait api && echo done Run command after daemon stops
+
+    pitchfork wait api              Wait for 'api' to stop
+    pitchfork w api                 Alias for 'wait'
+    pitchfork wait api && echo done Run command after daemon stops
 
 ## Arguments
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -15,14 +15,15 @@ directories. Required for auto-start/stop features in pitchfork.toml.
 Supported shells: bash, zsh, fish
 
 Add to your shell config:
-  bash (~/.bashrc):
-    eval "$(pitchfork activate bash)"
 
-  zsh (~/.zshrc):
-    eval "$(pitchfork activate zsh)"
+    bash (~/.bashrc):
+      eval "$(pitchfork activate bash)"
 
-  fish (~/.config/fish/config.fish):
-    pitchfork activate fish | source
+    zsh (~/.zshrc):
+      eval "$(pitchfork activate zsh)"
+
+    fish (~/.config/fish/config.fish):
+      pitchfork activate fish | source
 """#
     arg <SHELL> help="Shell to activate (bash, zsh, fish)"
 }
@@ -36,12 +37,14 @@ boots. Uses platform-specific mechanisms (launchd on macOS, systemd on Linux).
 
 When run as root (or via sudo), registers a system-level entry that starts
 pitchfork for all users:
-  macOS: /Library/LaunchDaemons/pitchfork.plist
-  Linux: /etc/systemd/system/pitchfork.service
+
+    macOS: /Library/LaunchDaemons/pitchfork.plist
+    Linux: /etc/systemd/system/pitchfork.service
 
 When run as a normal user, registers a user-level entry:
-  macOS: ~/Library/LaunchAgents/pitchfork.plist
-  Linux: ~/.config/systemd/user/pitchfork.service
+
+    macOS: ~/Library/LaunchAgents/pitchfork.plist
+    Linux: ~/.config/systemd/user/pitchfork.service
 
 To run the supervisor as root but keep state files and IPC sockets in a
 specific user's home directory, set `settings.supervisor.user` in the global
@@ -49,15 +52,17 @@ pitchfork configuration (~/.config/pitchfork/config.toml or
 /etc/pitchfork/config.toml).
 
 Subcommands:
-  enable    Register pitchfork to start on boot
-  disable   Remove pitchfork from boot startup
-  status    Check if boot start is currently enabled
+
+    enable    Register pitchfork to start on boot
+    disable   Remove pitchfork from boot startup
+    status    Check if boot start is currently enabled
 
 Examples:
-  pitchfork boot enable           Start pitchfork on system boot (user-level)
-  sudo pitchfork boot enable      Start pitchfork on system boot (system-level)
-  pitchfork boot disable          Don't start pitchfork on boot
-  pitchfork boot status           Check boot start status
+
+    pitchfork boot enable           Start pitchfork on system boot (user-level)
+    sudo pitchfork boot enable      Start pitchfork on system boot (system-level)
+    pitchfork boot disable          Don't start pitchfork on boot
+    pitchfork boot status           Check boot start status
 """#
     cmd enable help="Enable boot start for pitchfork supervisor" effect=write {
         long_help #"""
@@ -66,12 +71,14 @@ Enable boot start for pitchfork supervisor
 Registers pitchfork to start automatically when the system boots.
 
 When run as root (or via sudo): creates a system-level entry
-  macOS: /Library/LaunchDaemons/pitchfork.plist
-  Linux: /etc/systemd/system/pitchfork.service
+
+    macOS: /Library/LaunchDaemons/pitchfork.plist
+    Linux: /etc/systemd/system/pitchfork.service
 
 When run as a normal user: creates a user-level entry
-  macOS: ~/Library/LaunchAgents/pitchfork.plist
-  Linux: ~/.config/systemd/user/pitchfork.service
+
+    macOS: ~/Library/LaunchAgents/pitchfork.plist
+    Linux: ~/.config/systemd/user/pitchfork.service
 
 If you want the supervisor to run as root but keep state files and IPC sockets
 under a specific user's home directory, configure `settings.supervisor.user`
@@ -111,8 +118,9 @@ Use this to clear out old entries after stopping daemons manually or
 after daemons have failed.
 
 Examples:
-  pitchfork clean                 Remove all stopped/failed entries
-  pitchfork c                     Alias for 'clean'
+
+    pitchfork clean                 Remove all stopped/failed entries
+    pitchfork c                     Alias for 'clean'
 """#
 }
 cmd daemons help="List configured daemons from all merged config files." effect=read {
@@ -128,25 +136,26 @@ The daemon will be added to the nearest pitchfork.toml found in the
 filesystem hierarchy starting from the current directory.
 
 Examples:
-  pitchfork daemons add api bun run server
-                                 Add daemon using positional args
-  pitchfork daemons add api --run 'npm start'
-                                 Add daemon with explicit run command
-  pitchfork daemons add api -- bun run server
-                                 Add daemon with explicit args after --
-  pitchfork daemons add api --run 'npm start' --retry 3
-                                 Add with retry policy
-  pitchfork daemons add api --run 'npm start' --watch 'src/**/*.ts'
-                                 Add with file watching
-  pitchfork daemons add api --run 'npm start' --autostart --autostop
-                                 Add with auto start/stop hooks
-  pitchfork daemons add worker --run './worker' --depends api
-                                 Add with daemon dependency
-  pitchfork daemons add api --run 'npm start' --local
-                                  Add to pitchfork.local.toml instead
-  pitchfork daemons add api --run 'npm start' --global
+
+    pitchfork daemons add api bun run server
+                                     Add daemon using positional args
+    pitchfork daemons add api --run 'npm start'
+                                     Add daemon with explicit run command
+    pitchfork daemons add api -- bun run server
+                                     Add daemon with explicit args after --
+    pitchfork daemons add api --run 'npm start' --retry 3
+                                     Add with retry policy
+    pitchfork daemons add api --run 'npm start' --watch 'src/**/*.ts'
+                                     Add with file watching
+    pitchfork daemons add api --run 'npm start' --autostart --autostop
+                                     Add with auto start/stop hooks
+    pitchfork daemons add worker --run './worker' --depends api
+                                     Add with daemon dependency
+    pitchfork daemons add api --run 'npm start' --local
+                                   Add to pitchfork.local.toml instead
+    pitchfork daemons add api --run 'npm start' --global
                                   Add to ~/.config/pitchfork/config.toml instead
-  pitchfork daemons add worker --run './worker' --cron-schedule '0 * * * *' --cron-immediate
+    pitchfork daemons add worker --run './worker' --cron-schedule '0 * * * *' --cron-immediate
                                   Add cron daemon that triggers immediately
 
 """#
@@ -237,14 +246,15 @@ Creates tab-completion scripts for your shell. Requires the 'usage' CLI tool.
 Supported shells: bash, zsh, fish
 
 Installation:
-  bash:
-    pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork
 
-  zsh:
-    pitchfork completion zsh > ~/.zfunc/_pitchfork
+    bash:
+      pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork
 
-  fish:
-    pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish
+    zsh:
+      pitchfork completion zsh > ~/.zfunc/_pitchfork
+
+    fish:
+      pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish
 """#
     arg <SHELL> help="Shell to generate completions for (bash, zsh, fish)"
 }
@@ -254,13 +264,14 @@ cmd disable help="Prevent a daemon from restarting" effect=write {
 Prevent a daemon from restarting
 
 Disables a daemon to prevent it from being started automatically or manually.
-The daemon will remain disabled until 'pitchfork enable' is called.
+The daemon will remain disabled until `pitchfork enable` is called.
 Useful for temporarily stopping a service without removing it from config.
 
 Examples:
-  pitchfork disable api           Prevent daemon from starting
-  pitchfork d api                 Alias for 'disable'
-  pitchfork list                  Shows 'disabled' status in output
+
+    pitchfork disable api           Prevent daemon from starting
+    pitchfork d api                 Alias for 'disable'
+    pitchfork list                  Shows 'disabled' status in output
 """#
     arg <ID> help="Name of the daemon to disable"
 }
@@ -270,11 +281,13 @@ cmd enable help="Allow a daemon to start" effect=write {
 Allow a daemon to start
 
 Re-enables a previously disabled daemon, allowing it to be started manually
-or automatically. Use this after 'pitchfork disable' to restore normal operation.
+or automatically. Use this after `pitchfork disable` to restore normal
+operation.
 
 Examples:
-  pitchfork enable api            Enable a disabled daemon
-  pitchfork e api                 Alias for 'enable'
+
+    pitchfork enable api            Enable a disabled daemon
+    pitchfork e api                 Alias for 'enable'
 """#
     arg <ID> help="Name of the daemon to enable"
 }
@@ -291,21 +304,23 @@ This command shows both:
 - Available daemons (defined in config but not yet started)
 
 Example:
-  pitchfork list
-  pitchfork ls                    Alias for 'list'
-  pitchfork list --hide-header    Output without column headers
-  pitchfork list --status running  Show only running daemons
-  pitchfork ls --status available --status stopped
-                                  Show daemons that are available OR stopped
-  pitchfork list --namespace frontend
-                                  Show only daemons in the 'frontend' namespace
-  pitchfork list --project        Show only the current project's daemons
+
+    pitchfork list
+    pitchfork ls                    Alias for 'list'
+    pitchfork list --hide-header    Output without column headers
+    pitchfork list --status running  Show only running daemons
+    pitchfork ls --status available --status stopped
+                                    Show daemons that are available OR stopped
+    pitchfork list --namespace frontend
+                                    Show only daemons in the 'frontend' namespace
+    pitchfork list --project        Show only the current project's daemons
 
 Output:
-  Name    Status
-  api     running    https://api.localhost
-  worker  available
-  db      errored    exit code 127
+
+    Name    Status
+    api     running    https://api.localhost
+    worker  available
+    db      errored    exit code 127
 """#
     flag --hide-header help="Hide the table header row"
     flag --json help="Output in JSON format"
@@ -389,22 +404,23 @@ Shows logs from managed daemons. Logs are stored in the pitchfork logs directory
 and include timestamps for filtering.
 
 Examples:
-  pitchfork logs api              Show all logs for 'api' (paged if needed)
-  pitchfork logs api worker       Show logs for multiple daemons
-  pitchfork logs                  Show logs for all daemons
-  pitchfork logs api -n 50        Show last 50 lines
-  pitchfork logs api --follow     Follow logs in real-time
-  pitchfork logs api --since '2024-01-15 10:00:00'
-                                  Show logs since a specific time (forward)
-  pitchfork logs api --since '10:30:00'
-                                  Show logs since 10:30:00 today
-  pitchfork logs api --since '10:30' --until '12:00'
-                                  Show logs since 10:30:00 until 12:00:00 today
-  pitchfork logs api --since 5min Show logs from last 5 minutes
-  pitchfork logs api --raw        Output raw log lines without formatting
-  pitchfork logs api --raw -n 100 Output last 100 raw log lines
-  pitchfork logs api --clear      Delete logs for 'api'
-  pitchfork logs --clear          Delete logs for all daemons
+
+    pitchfork logs api              Show all logs for 'api' (paged if needed)
+    pitchfork logs api worker       Show logs for multiple daemons
+    pitchfork logs                  Show logs for all daemons
+    pitchfork logs api -n 50        Show last 50 lines
+    pitchfork logs api --follow     Follow logs in real-time
+    pitchfork logs api --since '2024-01-15 10:00:00'
+                                    Show logs since a specific time (forward)
+    pitchfork logs api --since '10:30:00'
+                                    Show logs since 10:30:00 today
+    pitchfork logs api --since '10:30' --until '12:00'
+                                    Show logs since 10:30:00 until 12:00:00 today
+    pitchfork logs api --since 5min Show logs from last 5 minutes
+    pitchfork logs api --raw        Output raw log lines without formatting
+    pitchfork logs api --raw -n 100 Output last 100 raw log lines
+    pitchfork logs api --clear      Delete logs for 'api'
+    pitchfork logs --clear          Delete logs for all daemons
 """#
     flag "-c --clear" help="Delete logs" effect=destructive
     flag -n help="Show last N lines of logs" {
@@ -484,48 +500,50 @@ to AI assistants (Claude, Cursor, etc.) over stdin/stdout using JSON-RPC.
 Typically used as a subprocess by an MCP-aware AI agent.
 
 Examples:
-  # In claude_desktop_config.json or similar:
-  {
-    "mcpServers": {
-      "pitchfork": {
-        "command": "pitchfork",
-        "args": ["mcp"]
-      }
+
+    # In claude_desktop_config.json or similar:
+    {
+        "mcpServers": {
+            "pitchfork": {
+                "command": "pitchfork",
+                "args": ["mcp"]
+            }
+        }
     }
-  }
 
 Tools provided:
-  pitchfork_status    List all daemons and their state
-  pitchfork_start     Start a named daemon
-  pitchfork_stop      Stop a named daemon
-  pitchfork_restart   Restart a named daemon
-  pitchfork_logs      Return recent log output for a daemon
+
+    pitchfork_status    List all daemons and their state
+    pitchfork_start     Start a named daemon
+    pitchfork_stop      Stop a named daemon
+    pitchfork_restart   Restart a named daemon
+    pitchfork_logs      Return recent log output for a daemon
 """#
     after_long_help #"""
 Examples:
 
-  # Start the MCP server (used by AI assistant tools)
-  $ pitchfork mcp
+    # Start the MCP server (used by AI assistant tools)
+    $ pitchfork mcp
 
-  # Claude Desktop configuration (claude_desktop_config.json):
-  {
-    "mcpServers": {
-      "pitchfork": {
-        "command": "pitchfork",
-        "args": ["mcp"]
+    # Claude Desktop configuration (claude_desktop_config.json):
+    {
+      "mcpServers": {
+        "pitchfork": {
+          "command": "pitchfork",
+          "args": ["mcp"]
+        }
       }
     }
-  }
 
-  # Interactive testing with JSON-RPC:
-  $ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | pitchfork mcp
+    # Interactive testing with JSON-RPC:
+    $ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | pitchfork mcp
 
-  # Available tools:
-  - pitchfork_status  - List all daemons and their state
-  - pitchfork_start   - Start daemon(s) by name
-  - pitchfork_stop    - Stop daemon(s) by name
-  - pitchfork_restart - Restart daemon(s) by name
-  - pitchfork_logs    - Return recent log output for daemon(s)
+# Available tools:
+- pitchfork_status  - List all daemons and their state
+- pitchfork_start   - Start daemon(s) by name
+- pitchfork_stop    - Stop daemon(s) by name
+- pitchfork_restart - Restart daemon(s) by name
+- pitchfork_logs    - Return recent log output for daemon(s)
 
 """#
 }
@@ -533,24 +551,25 @@ cmd proxy subcommand_required=#true help="Manage the pitchfork reverse proxy" ef
     long_help #"""
 Manage the pitchfork reverse proxy
 
-The reverse proxy routes requests from stable slug-based URLs like:
-  https://myapp.localhost
-
-to the daemon's actual listening port (e.g. localhost:3000).
+The reverse proxy routes requests from stable slug-based URLs like
+`https://myapp.localhost` to the daemon's actual listening port (e.g.
+localhost:3000).
 
 Slugs are defined in the global config (~/.config/pitchfork/config.toml)
 under [slugs]. Each slug maps to a project directory and daemon name.
 
 Enable the proxy in your pitchfork.toml or settings:
-  [settings.proxy]
-  enable = true
+
+    [settings.proxy]
+    enable = true
 
 Subcommands:
-  trust     Install the proxy's TLS certificate into the system trust store
-  untrust   Remove the proxy's TLS certificate from the system trust store
-  add       Add a slug mapping to the global config
-  remove    Remove a slug mapping from the global config
-  status    Show all registered slugs and their current state
+
+    trust     Install the proxy's TLS certificate into the system trust store
+    untrust   Remove the proxy's TLS certificate from the system trust store
+    add       Add a slug mapping to the global config
+    remove    Remove a slug mapping from the global config
+    status    Show all registered slugs and their current state
 """#
     cmd trust help="Install the proxy's self-signed TLS certificate into the system trust store" effect=write {
         long_help #"""
@@ -573,8 +592,11 @@ detected automatically based on the running distribution:
 This DOES require sudo on Linux.
 
 Example:
-  pitchfork proxy trust
-  sudo pitchfork proxy trust    # Linux only
+
+```text
+pitchfork proxy trust
+sudo pitchfork proxy trust    # Linux only
+```
 """#
         flag --cert help="Path to the certificate file to trust (defaults to pitchfork's auto-generated cert)" {
             arg <CERT>
@@ -592,8 +614,11 @@ On Linux, removes the certificate from the distro-specific CA directory
 and runs the appropriate update command.
 
 Example:
-  pitchfork proxy untrust
-  sudo pitchfork proxy untrust    # Linux only
+
+```text
+pitchfork proxy untrust
+sudo pitchfork proxy untrust    # Linux only
+```
 """#
         flag --cert help="Path to the certificate file (defaults to pitchfork's auto-generated cert)" {
             arg <CERT>
@@ -619,9 +644,12 @@ If --dir is not specified, uses the current directory.
 If --daemon is not specified, defaults to the slug name.
 
 Example:
-  pitchfork proxy add api
-  pitchfork proxy add api --daemon server
-  pitchfork proxy add api --dir /home/user/my-api --daemon server
+
+```text
+pitchfork proxy add api
+pitchfork proxy add api --daemon server
+pitchfork proxy add api --dir /home/user/my-api --daemon server
+```
 """#
         flag --dir help="Project directory (defaults to current directory)" {
             arg <DIR>
@@ -640,7 +668,10 @@ Example:
 Remove a slug mapping from the global config
 
 Example:
-  pitchfork proxy remove api
+
+```text
+pitchfork proxy remove api
+```
 """#
         arg <SLUG> help="The slug name to remove"
     }
@@ -677,8 +708,9 @@ Displays a table of active project sessions with their host PID, directory,
 liveness status, and recorded process title.
 
 Example:
-  pitchfork project list
-  pitchfork project list --json
+
+    pitchfork project list
+    pitchfork project list --json
 """#
         flag --json help="Output in JSON format"
     }
@@ -687,17 +719,18 @@ cmd restart help="Restarts a daemon (stops then starts it)" {
     long_help #"""
 Restarts a daemon (stops then starts it)
 
-Equivalent to 'start --force' - stops the daemon (SIGTERM) then starts it again
+Equivalent to `start --force` - stops the daemon (SIGTERM) then starts it again
 from the pitchfork.toml configuration with dependency resolution.
 
 Examples:
-  pitchfork restart api           Restart a single daemon
-  pitchfork restart api worker    Restart multiple daemons
-  pitchfork restart --group backend Restart all daemons in the 'backend' group
-  pitchfork restart --all         Restart all running daemons
-  pitchfork restart -l            Restart all local daemons in pitchfork.toml
-  pitchfork restart -g            Restart all global daemons in config.toml
-  pitchfork restart api --delay 5 Wait 5 seconds for daemon to be ready
+
+    pitchfork restart api           Restart a single daemon
+    pitchfork restart api worker    Restart multiple daemons
+    pitchfork restart --group backend Restart all daemons in the 'backend' group
+    pitchfork restart --all         Restart all running daemons
+    pitchfork restart -l            Restart all local daemons in pitchfork.toml
+    pitchfork restart -g            Restart all global daemons in config.toml
+    pitchfork restart api --delay 5 Wait 5 seconds for daemon to be ready
 """#
     flag --group help="Restart all daemons in the named group" {
         arg <GROUP>
@@ -729,23 +762,24 @@ cmd run help="Runs a one-off daemon" {
 Runs a one-off daemon
 
 Runs a command as a managed daemon without needing a pitchfork.toml.
-The daemon is tracked by pitchfork and can be monitored with 'pitchfork status'.
+The daemon is tracked by pitchfork and can be monitored with `pitchfork status`.
 
 Examples:
-  pitchfork run api -- npm run dev
-                                Run npm as daemon named 'api'
-  pitchfork run api -f -- npm run dev
-                                Force restart if 'api' is running
-  pitchfork run api --retry 3 -- ./server
-                                Restart up to 3 times on failure
-  pitchfork run api -d 5 -- ./server
-                                Wait 5 seconds for ready check
-  pitchfork run api -o 'Listening' -- ./server
-                                Wait for output pattern before ready
-  pitchfork run api --http http://localhost:8080/health -- ./server
-                                Wait for HTTP endpoint to return 2xx
-  pitchfork run api --port 8080 -- ./server
-                                Wait for TCP port to be listening
+
+    pitchfork run api -- npm run dev
+                                  Run npm as daemon named 'api'
+    pitchfork run api -f -- npm run dev
+                                  Force restart if 'api' is running
+    pitchfork run api --retry 3 -- ./server
+                                  Restart up to 3 times on failure
+    pitchfork run api -d 5 -- ./server
+                                  Wait 5 seconds for ready check
+    pitchfork run api -o 'Listening' -- ./server
+                                  Wait for output pattern before ready
+    pitchfork run api --http http://localhost:8080/health -- ./server
+                                  Wait for HTTP endpoint to return 2xx
+    pitchfork run api --port 8080 -- ./server
+                                  Wait for TCP port to be listening
 """#
     flag "-f --force" help="Stop the daemon if it is already running"
     flag --retry help="Number of times to retry on error exit" default="0" {
@@ -790,18 +824,20 @@ Settings can be configured in multiple ways (in order of precedence):
 5. Built-in defaults (lowest priority)
 
 Subcommands:
-  list    List all available settings with types and defaults
-  get     Get the current value of a setting
-  set     Set a setting value in a config file
+
+    list    List all available settings with types and defaults
+    get     Get the current value of a setting
+    set     Set a setting value in a config file
 
 Examples:
-  pitchfork settings                        Show all current settings
-  pitchfork settings list                   List all available settings
-  pitchfork settings get general.log_level  Get a specific setting
-  pitchfork settings set general.log_level debug
-  pitchfork settings set web.auto_start true --global
-  pitchfork settings set supervisor.stop_timeout 10s --local
-  pitchfork settings set supervisor.stop_timeout 10s --project
+
+    pitchfork settings                        Show all current settings
+    pitchfork settings list                   List all available settings
+    pitchfork settings get general.log_level  Get a specific setting
+    pitchfork settings set general.log_level debug
+    pitchfork settings set web.auto_start true --global
+    pitchfork settings set supervisor.stop_timeout 10s --local
+    pitchfork settings set supervisor.stop_timeout 10s --project
 """#
     flag --json help="Output in JSON format"
     cmd list help="List all available settings with types and defaults" effect=read {
@@ -833,20 +869,21 @@ Daemons are defined in pitchfork.toml with a `[daemons.<name>]` section.
 The command waits for the daemon to be ready before returning.
 
 Examples:
-  pitchfork start api           Start a single daemon
-  pitchfork start api worker    Start multiple daemons
-  pitchfork start --group backend Start all daemons in the 'backend' group
-  pitchfork start -l            Start all local daemons in pitchfork.toml
-  pitchfork start -g            Start all global daemons in config.toml
-  pitchfork start -a            Start all daemons (local and global)
-  pitchfork start api -f        Restart daemon if already running
-  pitchfork start api --delay 5 Wait 5 seconds for daemon to be ready
-  pitchfork start api --output 'Listening on'
-                                Wait for output pattern before ready
-  pitchfork start api --http http://localhost:8080/health
-                                Wait for HTTP endpoint to return 2xx
-  pitchfork start api --port 8080
-                                Wait for TCP port to be listening
+
+    pitchfork start api           Start a single daemon
+    pitchfork start api worker    Start multiple daemons
+    pitchfork start --group backend Start all daemons in the 'backend' group
+    pitchfork start -l            Start all local daemons in pitchfork.toml
+    pitchfork start -g            Start all global daemons in config.toml
+    pitchfork start -a            Start all daemons (local and global)
+    pitchfork start api -f        Restart daemon if already running
+    pitchfork start api --delay 5 Wait 5 seconds for daemon to be ready
+    pitchfork start api --output 'Listening on'
+                                  Wait for output pattern before ready
+    pitchfork start api --http http://localhost:8080/health
+                                  Wait for HTTP endpoint to return 2xx
+    pitchfork start api --port 8080
+                                  Wait for TCP port to be listening
 """#
     flag --group help="Start all daemons in the named group" {
         arg <GROUP>
@@ -891,12 +928,14 @@ Shows detailed information about a single daemon including its PID and
 current status (running, stopped, failed, etc.).
 
 Example:
-  pitchfork status api
+
+    pitchfork status api
 
 Output:
-  Name: api
-  PID: 12345
-  Status: running
+
+    Name: api
+    PID: 12345
+    Status: running
 """#
     flag --json help="Output in JSON format"
     arg <ID> help="Name of the daemon to check"
@@ -918,13 +957,14 @@ When using --all/--local/--global, daemons are stopped in reverse dependency ord
 dependents are stopped before the daemons they depend on.
 
 Examples:
-  pitchfork stop api           Stop a single daemon
-  pitchfork stop api worker    Stop multiple daemons
-  pitchfork stop --group backend Stop all daemons in the 'backend' group
-  pitchfork stop --all         Stop all running daemons in dependency order
-  pitchfork stop -l            Stop all local daemons in pitchfork.toml
-  pitchfork stop -g            Stop all global daemons in config.toml
-  pitchfork kill api           Same as 'stop' (alias)
+
+    pitchfork stop api           Stop a single daemon
+    pitchfork stop api worker    Stop multiple daemons
+    pitchfork stop --group backend Stop all daemons in the 'backend' group
+    pitchfork stop --all         Stop all running daemons in dependency order
+    pitchfork stop -l            Stop all local daemons in pitchfork.toml
+    pitchfork stop -g            Stop all global daemons in config.toml
+    pitchfork kill api           Same as 'stop' (alias)
 """#
     flag --group help="Stop all daemons in the named group" {
         arg <GROUP>
@@ -966,10 +1006,11 @@ The dashboard can be scoped to one or more namespaces; the fuzzy search
 (`/`) then operates within the scoped set.
 
 Example:
-  pitchfork tui
-  pitchfork tui --namespace frontend
-                                  Show only daemons in the 'frontend' namespace
-  pitchfork tui --project         Show only the current project's daemons
+
+    pitchfork tui
+    pitchfork tui --namespace frontend
+                                    Show only daemons in the 'frontend' namespace
+    pitchfork tui --project         Show only the current project's daemons
 """#
     flag --namespace help="Only show daemons in this namespace (repeatable for OR logic)" var=#true {
         arg <NAMESPACE>
@@ -1000,9 +1041,10 @@ log output in real-time. Exits with the same status code as the daemon.
 Useful in scripts that need to wait for a daemon to complete.
 
 Examples:
-  pitchfork wait api              Wait for 'api' to stop
-  pitchfork w api                 Alias for 'wait'
-  pitchfork wait api && echo done Run command after daemon stops
+
+    pitchfork wait api              Wait for 'api' to stop
+    pitchfork w api                 Alias for 'wait'
+    pitchfork wait api && echo done Run command after daemon stops
 """#
     arg <ID> help="The name of the daemon to wait for"
 }

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -16,14 +16,15 @@ directories. Required for auto-start/stop features in pitchfork.toml.
 Supported shells: bash, zsh, fish
 
 Add to your shell config:
-  bash (~/.bashrc):
-    eval \"$(pitchfork activate bash)\"
 
-  zsh (~/.zshrc):
-    eval \"$(pitchfork activate zsh)\"
+    bash (~/.bashrc):
+      eval \"$(pitchfork activate bash)\"
 
-  fish (~/.config/fish/config.fish):
-    pitchfork activate fish | source"
+    zsh (~/.zshrc):
+      eval \"$(pitchfork activate zsh)\"
+
+    fish (~/.config/fish/config.fish):
+      pitchfork activate fish | source"
 )]
 pub struct Activate {
     /// Shell to activate (bash, zsh, fish)

--- a/src/cli/boot.rs
+++ b/src/cli/boot.rs
@@ -13,12 +13,14 @@ boots. Uses platform-specific mechanisms (launchd on macOS, systemd on Linux).
 
 When run as root (or via sudo), registers a system-level entry that starts
 pitchfork for all users:
-  macOS: /Library/LaunchDaemons/pitchfork.plist
-  Linux: /etc/systemd/system/pitchfork.service
+
+    macOS: /Library/LaunchDaemons/pitchfork.plist
+    Linux: /etc/systemd/system/pitchfork.service
 
 When run as a normal user, registers a user-level entry:
-  macOS: ~/Library/LaunchAgents/pitchfork.plist
-  Linux: ~/.config/systemd/user/pitchfork.service
+
+    macOS: ~/Library/LaunchAgents/pitchfork.plist
+    Linux: ~/.config/systemd/user/pitchfork.service
 
 To run the supervisor as root but keep state files and IPC sockets in a
 specific user's home directory, set `settings.supervisor.user` in the global
@@ -26,15 +28,17 @@ pitchfork configuration (~/.config/pitchfork/config.toml or
 /etc/pitchfork/config.toml).
 
 Subcommands:
-  enable    Register pitchfork to start on boot
-  disable   Remove pitchfork from boot startup
-  status    Check if boot start is currently enabled
+
+    enable    Register pitchfork to start on boot
+    disable   Remove pitchfork from boot startup
+    status    Check if boot start is currently enabled
 
 Examples:
-  pitchfork boot enable           Start pitchfork on system boot (user-level)
-  sudo pitchfork boot enable      Start pitchfork on system boot (system-level)
-  pitchfork boot disable          Don't start pitchfork on boot
-  pitchfork boot status           Check boot start status"
+
+    pitchfork boot enable           Start pitchfork on system boot (user-level)
+    sudo pitchfork boot enable      Start pitchfork on system boot (system-level)
+    pitchfork boot disable          Don't start pitchfork on boot
+    pitchfork boot status           Check boot start status"
 )]
 pub struct Boot {
     #[clap(subcommand)]
@@ -50,12 +54,14 @@ Enable boot start for pitchfork supervisor
 Registers pitchfork to start automatically when the system boots.
 
 When run as root (or via sudo): creates a system-level entry
-  macOS: /Library/LaunchDaemons/pitchfork.plist
-  Linux: /etc/systemd/system/pitchfork.service
+
+    macOS: /Library/LaunchDaemons/pitchfork.plist
+    Linux: /etc/systemd/system/pitchfork.service
 
 When run as a normal user: creates a user-level entry
-  macOS: ~/Library/LaunchAgents/pitchfork.plist
-  Linux: ~/.config/systemd/user/pitchfork.service
+
+    macOS: ~/Library/LaunchAgents/pitchfork.plist
+    Linux: ~/.config/systemd/user/pitchfork.service
 
 If you want the supervisor to run as root but keep state files and IPC sockets
 under a specific user's home directory, configure `settings.supervisor.user`

--- a/src/cli/clean.rs
+++ b/src/cli/clean.rs
@@ -16,8 +16,9 @@ Use this to clear out old entries after stopping daemons manually or
 after daemons have failed.
 
 Examples:
-  pitchfork clean                 Remove all stopped/failed entries
-  pitchfork c                     Alias for 'clean'"
+
+    pitchfork clean                 Remove all stopped/failed entries
+    pitchfork c                     Alias for 'clean'"
 )]
 pub struct Clean {}
 

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -14,14 +14,15 @@ Creates tab-completion scripts for your shell. Requires the 'usage' CLI tool.
 Supported shells: bash, zsh, fish
 
 Installation:
-  bash:
-    pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork
 
-  zsh:
-    pitchfork completion zsh > ~/.zfunc/_pitchfork
+    bash:
+      pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork
 
-  fish:
-    pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish"
+    zsh:
+      pitchfork completion zsh > ~/.zfunc/_pitchfork
+
+    fish:
+      pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish"
 )]
 pub struct Completion {
     /// Shell to generate completions for (bash, zsh, fish)

--- a/src/cli/daemons/add.rs
+++ b/src/cli/daemons/add.rs
@@ -23,25 +23,26 @@ The daemon will be added to the nearest pitchfork.toml found in the
 filesystem hierarchy starting from the current directory.
 
 Examples:
-  pitchfork daemons add api bun run server
-                                 Add daemon using positional args
-  pitchfork daemons add api --run 'npm start'
-                                 Add daemon with explicit run command
-  pitchfork daemons add api -- bun run server
-                                 Add daemon with explicit args after --
-  pitchfork daemons add api --run 'npm start' --retry 3
-                                 Add with retry policy
-  pitchfork daemons add api --run 'npm start' --watch 'src/**/*.ts'
-                                 Add with file watching
-  pitchfork daemons add api --run 'npm start' --autostart --autostop
-                                 Add with auto start/stop hooks
-  pitchfork daemons add worker --run './worker' --depends api
-                                 Add with daemon dependency
-  pitchfork daemons add api --run 'npm start' --local
-                                  Add to pitchfork.local.toml instead
-  pitchfork daemons add api --run 'npm start' --global
+
+    pitchfork daemons add api bun run server
+                                     Add daemon using positional args
+    pitchfork daemons add api --run 'npm start'
+                                     Add daemon with explicit run command
+    pitchfork daemons add api -- bun run server
+                                     Add daemon with explicit args after --
+    pitchfork daemons add api --run 'npm start' --retry 3
+                                     Add with retry policy
+    pitchfork daemons add api --run 'npm start' --watch 'src/**/*.ts'
+                                     Add with file watching
+    pitchfork daemons add api --run 'npm start' --autostart --autostop
+                                     Add with auto start/stop hooks
+    pitchfork daemons add worker --run './worker' --depends api
+                                     Add with daemon dependency
+    pitchfork daemons add api --run 'npm start' --local
+                                   Add to pitchfork.local.toml instead
+    pitchfork daemons add api --run 'npm start' --global
                                   Add to ~/.config/pitchfork/config.toml instead
-  pitchfork daemons add worker --run './worker' --cron-schedule '0 * * * *' --cron-immediate
+    pitchfork daemons add worker --run './worker' --cron-schedule '0 * * * *' --cron-immediate
                                   Add cron daemon that triggers immediately
 "
 )]

--- a/src/cli/disable.rs
+++ b/src/cli/disable.rs
@@ -11,13 +11,14 @@ use crate::pitchfork_toml::PitchforkToml;
 Prevent a daemon from restarting
 
 Disables a daemon to prevent it from being started automatically or manually.
-The daemon will remain disabled until 'pitchfork enable' is called.
+The daemon will remain disabled until `pitchfork enable` is called.
 Useful for temporarily stopping a service without removing it from config.
 
 Examples:
-  pitchfork disable api           Prevent daemon from starting
-  pitchfork d api                 Alias for 'disable'
-  pitchfork list                  Shows 'disabled' status in output"
+
+    pitchfork disable api           Prevent daemon from starting
+    pitchfork d api                 Alias for 'disable'
+    pitchfork list                  Shows 'disabled' status in output"
 )]
 pub struct Disable {
     /// Name of the daemon to disable

--- a/src/cli/enable.rs
+++ b/src/cli/enable.rs
@@ -11,11 +11,13 @@ use crate::pitchfork_toml::PitchforkToml;
 Allow a daemon to start
 
 Re-enables a previously disabled daemon, allowing it to be started manually
-or automatically. Use this after 'pitchfork disable' to restore normal operation.
+or automatically. Use this after `pitchfork disable` to restore normal
+operation.
 
 Examples:
-  pitchfork enable api            Enable a disabled daemon
-  pitchfork e api                 Alias for 'enable'"
+
+    pitchfork enable api            Enable a disabled daemon
+    pitchfork e api                 Alias for 'enable'"
 )]
 pub struct Enable {
     /// Name of the daemon to enable

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -43,21 +43,23 @@ This command shows both:
 - Available daemons (defined in config but not yet started)
 
 Example:
-  pitchfork list
-  pitchfork ls                    Alias for 'list'
-  pitchfork list --hide-header    Output without column headers
-  pitchfork list --status running  Show only running daemons
-  pitchfork ls --status available --status stopped
-                                  Show daemons that are available OR stopped
-  pitchfork list --namespace frontend
-                                  Show only daemons in the 'frontend' namespace
-  pitchfork list --project        Show only the current project's daemons
+
+    pitchfork list
+    pitchfork ls                    Alias for 'list'
+    pitchfork list --hide-header    Output without column headers
+    pitchfork list --status running  Show only running daemons
+    pitchfork ls --status available --status stopped
+                                    Show daemons that are available OR stopped
+    pitchfork list --namespace frontend
+                                    Show only daemons in the 'frontend' namespace
+    pitchfork list --project        Show only the current project's daemons
 
 Output:
-  Name    Status
-  api     running    https://api.localhost
-  worker  available
-  db      errored    exit code 127"
+
+    Name    Status
+    api     running    https://api.localhost
+    worker  available
+    db      errored    exit code 127"
 )]
 pub struct List {
     /// Hide the table header row

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -323,22 +323,23 @@ Shows logs from managed daemons. Logs are stored in the pitchfork logs directory
 and include timestamps for filtering.
 
 Examples:
-  pitchfork logs api              Show all logs for 'api' (paged if needed)
-  pitchfork logs api worker       Show logs for multiple daemons
-  pitchfork logs                  Show logs for all daemons
-  pitchfork logs api -n 50        Show last 50 lines
-  pitchfork logs api --follow     Follow logs in real-time
-  pitchfork logs api --since '2024-01-15 10:00:00'
-                                  Show logs since a specific time (forward)
-  pitchfork logs api --since '10:30:00'
-                                  Show logs since 10:30:00 today
-  pitchfork logs api --since '10:30' --until '12:00'
-                                  Show logs since 10:30:00 until 12:00:00 today
-  pitchfork logs api --since 5min Show logs from last 5 minutes
-  pitchfork logs api --raw        Output raw log lines without formatting
-  pitchfork logs api --raw -n 100 Output last 100 raw log lines
-  pitchfork logs api --clear      Delete logs for 'api'
-  pitchfork logs --clear          Delete logs for all daemons"
+
+    pitchfork logs api              Show all logs for 'api' (paged if needed)
+    pitchfork logs api worker       Show logs for multiple daemons
+    pitchfork logs                  Show logs for all daemons
+    pitchfork logs api -n 50        Show last 50 lines
+    pitchfork logs api --follow     Follow logs in real-time
+    pitchfork logs api --since '2024-01-15 10:00:00'
+                                    Show logs since a specific time (forward)
+    pitchfork logs api --since '10:30:00'
+                                    Show logs since 10:30:00 today
+    pitchfork logs api --since '10:30' --until '12:00'
+                                    Show logs since 10:30:00 until 12:00:00 today
+    pitchfork logs api --since 5min Show logs from last 5 minutes
+    pitchfork logs api --raw        Output raw log lines without formatting
+    pitchfork logs api --raw -n 100 Output last 100 raw log lines
+    pitchfork logs api --clear      Delete logs for 'api'
+    pitchfork logs --clear          Delete logs for all daemons"
 )]
 pub struct Logs {
     /// Show only logs for the specified daemon(s)

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -45,22 +45,24 @@ to AI assistants (Claude, Cursor, etc.) over stdin/stdout using JSON-RPC.
 Typically used as a subprocess by an MCP-aware AI agent.
 
 Examples:
-  # In claude_desktop_config.json or similar:
-  {
-    \"mcpServers\": {
-      \"pitchfork\": {
-        \"command\": \"pitchfork\",
-        \"args\": [\"mcp\"]
-      }
+
+    # In claude_desktop_config.json or similar:
+    {
+        \"mcpServers\": {
+            \"pitchfork\": {
+                \"command\": \"pitchfork\",
+                \"args\": [\"mcp\"]
+            }
+        }
     }
-  }
 
 Tools provided:
-  pitchfork_status    List all daemons and their state
-  pitchfork_start     Start a named daemon
-  pitchfork_stop      Stop a named daemon
-  pitchfork_restart   Restart a named daemon
-  pitchfork_logs      Return recent log output for a daemon"
+
+    pitchfork_status    List all daemons and their state
+    pitchfork_start     Start a named daemon
+    pitchfork_stop      Stop a named daemon
+    pitchfork_restart   Restart a named daemon
+    pitchfork_logs      Return recent log output for a daemon"
 )]
 pub struct Mcp {}
 
@@ -488,26 +490,26 @@ impl Mcp {
 
 static AFTER_LONG_HELP: &str = r#"Examples:
 
-  # Start the MCP server (used by AI assistant tools)
-  $ pitchfork mcp
+    # Start the MCP server (used by AI assistant tools)
+    $ pitchfork mcp
 
-  # Claude Desktop configuration (claude_desktop_config.json):
-  {
-    "mcpServers": {
-      "pitchfork": {
-        "command": "pitchfork",
-        "args": ["mcp"]
+    # Claude Desktop configuration (claude_desktop_config.json):
+    {
+      "mcpServers": {
+        "pitchfork": {
+          "command": "pitchfork",
+          "args": ["mcp"]
+        }
       }
     }
-  }
 
-  # Interactive testing with JSON-RPC:
-  $ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | pitchfork mcp
+    # Interactive testing with JSON-RPC:
+    $ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | pitchfork mcp
 
-  # Available tools:
-  - pitchfork_status  - List all daemons and their state
-  - pitchfork_start   - Start daemon(s) by name
-  - pitchfork_stop    - Stop daemon(s) by name
-  - pitchfork_restart - Restart daemon(s) by name
-  - pitchfork_logs    - Return recent log output for daemon(s)
+# Available tools:
+- pitchfork_status  - List all daemons and their state
+- pitchfork_start   - Start daemon(s) by name
+- pitchfork_stop    - Stop daemon(s) by name
+- pitchfork_restart - Restart daemon(s) by name
+- pitchfork_logs    - Return recent log output for daemon(s)
 "#;

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -68,8 +68,9 @@ Displays a table of active project sessions with their host PID, directory,
 liveness status, and recorded process title.
 
 Example:
-  pitchfork project list
-  pitchfork project list --json"
+
+    pitchfork project list
+    pitchfork project list --json"
 )]
 pub struct List {
     /// Output in JSON format

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -8,24 +8,25 @@ use crate::cli::json_output::{JsonLanInfo, JsonProxyStatus, JsonSlugEntry, print
     long_about = "\
 Manage the pitchfork reverse proxy
 
-The reverse proxy routes requests from stable slug-based URLs like:
-  https://myapp.localhost
-
-to the daemon's actual listening port (e.g. localhost:3000).
+The reverse proxy routes requests from stable slug-based URLs like
+`https://myapp.localhost` to the daemon's actual listening port (e.g.
+localhost:3000).
 
 Slugs are defined in the global config (~/.config/pitchfork/config.toml)
 under [slugs]. Each slug maps to a project directory and daemon name.
 
 Enable the proxy in your pitchfork.toml or settings:
-  [settings.proxy]
-  enable = true
+
+    [settings.proxy]
+    enable = true
 
 Subcommands:
-  trust     Install the proxy's TLS certificate into the system trust store
-  untrust   Remove the proxy's TLS certificate from the system trust store
-  add       Add a slug mapping to the global config
-  remove    Remove a slug mapping from the global config
-  status    Show all registered slugs and their current state"
+
+    trust     Install the proxy's TLS certificate into the system trust store
+    untrust   Remove the proxy's TLS certificate from the system trust store
+    add       Add a slug mapping to the global config
+    remove    Remove a slug mapping from the global config
+    status    Show all registered slugs and their current state"
 )]
 pub struct Proxy {
     #[clap(subcommand)]
@@ -74,8 +75,11 @@ impl Proxy {
 /// This DOES require sudo on Linux.
 ///
 /// Example:
-///   pitchfork proxy trust
-///   sudo pitchfork proxy trust    # Linux only
+///
+/// ```text
+/// pitchfork proxy trust
+/// sudo pitchfork proxy trust    # Linux only
+/// ```
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment)]
 struct Trust {
@@ -121,8 +125,11 @@ impl Trust {
 /// and runs the appropriate update command.
 ///
 /// Example:
-///   pitchfork proxy untrust
-///   sudo pitchfork proxy untrust    # Linux only
+///
+/// ```text
+/// pitchfork proxy untrust
+/// sudo pitchfork proxy untrust    # Linux only
+/// ```
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment)]
 struct Untrust {
@@ -392,9 +399,12 @@ impl ProxyStatus {
 /// If --daemon is not specified, defaults to the slug name.
 ///
 /// Example:
-///   pitchfork proxy add api
-///   pitchfork proxy add api --daemon server
-///   pitchfork proxy add api --dir /home/user/my-api --daemon server
+///
+/// ```text
+/// pitchfork proxy add api
+/// pitchfork proxy add api --daemon server
+/// pitchfork proxy add api --dir /home/user/my-api --daemon server
+/// ```
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment)]
 struct Add {
@@ -514,7 +524,10 @@ impl Add {
 /// Remove a slug mapping from the global config
 ///
 /// Example:
-///   pitchfork proxy remove api
+///
+/// ```text
+/// pitchfork proxy remove api
+/// ```
 #[derive(Debug, clap::Args)]
 #[clap(visible_alias = "rm", verbatim_doc_comment)]
 struct Remove {

--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -12,17 +12,18 @@ use std::sync::Arc;
     long_about = "\
 Restarts a daemon (stops then starts it)
 
-Equivalent to 'start --force' - stops the daemon (SIGTERM) then starts it again
+Equivalent to `start --force` - stops the daemon (SIGTERM) then starts it again
 from the pitchfork.toml configuration with dependency resolution.
 
 Examples:
-  pitchfork restart api           Restart a single daemon
-  pitchfork restart api worker    Restart multiple daemons
-  pitchfork restart --group backend Restart all daemons in the 'backend' group
-  pitchfork restart --all         Restart all running daemons
-  pitchfork restart -l            Restart all local daemons in pitchfork.toml
-  pitchfork restart -g            Restart all global daemons in config.toml
-  pitchfork restart api --delay 5 Wait 5 seconds for daemon to be ready"
+
+    pitchfork restart api           Restart a single daemon
+    pitchfork restart api worker    Restart multiple daemons
+    pitchfork restart --group backend Restart all daemons in the 'backend' group
+    pitchfork restart --all         Restart all running daemons
+    pitchfork restart -l            Restart all local daemons in pitchfork.toml
+    pitchfork restart -g            Restart all global daemons in config.toml
+    pitchfork restart api --delay 5 Wait 5 seconds for daemon to be ready"
 )]
 pub struct Restart {
     /// ID of the daemon(s) to restart

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -15,23 +15,24 @@ use miette::bail;
 Runs a one-off daemon
 
 Runs a command as a managed daemon without needing a pitchfork.toml.
-The daemon is tracked by pitchfork and can be monitored with 'pitchfork status'.
+The daemon is tracked by pitchfork and can be monitored with `pitchfork status`.
 
 Examples:
-  pitchfork run api -- npm run dev
-                                Run npm as daemon named 'api'
-  pitchfork run api -f -- npm run dev
-                                Force restart if 'api' is running
-  pitchfork run api --retry 3 -- ./server
-                                Restart up to 3 times on failure
-  pitchfork run api -d 5 -- ./server
-                                Wait 5 seconds for ready check
-  pitchfork run api -o 'Listening' -- ./server
-                                Wait for output pattern before ready
-  pitchfork run api --http http://localhost:8080/health -- ./server
-                                Wait for HTTP endpoint to return 2xx
-  pitchfork run api --port 8080 -- ./server
-                                Wait for TCP port to be listening"
+
+    pitchfork run api -- npm run dev
+                                  Run npm as daemon named 'api'
+    pitchfork run api -f -- npm run dev
+                                  Force restart if 'api' is running
+    pitchfork run api --retry 3 -- ./server
+                                  Restart up to 3 times on failure
+    pitchfork run api -d 5 -- ./server
+                                  Wait 5 seconds for ready check
+    pitchfork run api -o 'Listening' -- ./server
+                                  Wait for output pattern before ready
+    pitchfork run api --http http://localhost:8080/health -- ./server
+                                  Wait for HTTP endpoint to return 2xx
+    pitchfork run api --port 8080 -- ./server
+                                  Wait for TCP port to be listening"
 )]
 pub struct Run {
     /// Name of the daemon to run

--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -25,18 +25,20 @@ Settings can be configured in multiple ways (in order of precedence):
 5. Built-in defaults (lowest priority)
 
 Subcommands:
-  list    List all available settings with types and defaults
-  get     Get the current value of a setting
-  set     Set a setting value in a config file
+
+    list    List all available settings with types and defaults
+    get     Get the current value of a setting
+    set     Set a setting value in a config file
 
 Examples:
-  pitchfork settings                        Show all current settings
-  pitchfork settings list                   List all available settings
-  pitchfork settings get general.log_level  Get a specific setting
-  pitchfork settings set general.log_level debug
-  pitchfork settings set web.auto_start true --global
-  pitchfork settings set supervisor.stop_timeout 10s --local
-  pitchfork settings set supervisor.stop_timeout 10s --project"
+
+    pitchfork settings                        Show all current settings
+    pitchfork settings list                   List all available settings
+    pitchfork settings get general.log_level  Get a specific setting
+    pitchfork settings set general.log_level debug
+    pitchfork settings set web.auto_start true --global
+    pitchfork settings set supervisor.stop_timeout 10s --local
+    pitchfork settings set supervisor.stop_timeout 10s --project"
 )]
 pub struct Settings {
     #[clap(subcommand)]

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -16,20 +16,21 @@ Daemons are defined in pitchfork.toml with a `[daemons.<name>]` section.
 The command waits for the daemon to be ready before returning.
 
 Examples:
-  pitchfork start api           Start a single daemon
-  pitchfork start api worker    Start multiple daemons
-  pitchfork start --group backend Start all daemons in the 'backend' group
-  pitchfork start -l            Start all local daemons in pitchfork.toml
-  pitchfork start -g            Start all global daemons in config.toml
-  pitchfork start -a            Start all daemons (local and global)
-  pitchfork start api -f        Restart daemon if already running
-  pitchfork start api --delay 5 Wait 5 seconds for daemon to be ready
-  pitchfork start api --output 'Listening on'
-                                Wait for output pattern before ready
-  pitchfork start api --http http://localhost:8080/health
-                                Wait for HTTP endpoint to return 2xx
-  pitchfork start api --port 8080
-                                Wait for TCP port to be listening";
+
+    pitchfork start api           Start a single daemon
+    pitchfork start api worker    Start multiple daemons
+    pitchfork start --group backend Start all daemons in the 'backend' group
+    pitchfork start -l            Start all local daemons in pitchfork.toml
+    pitchfork start -g            Start all global daemons in config.toml
+    pitchfork start -a            Start all daemons (local and global)
+    pitchfork start api -f        Restart daemon if already running
+    pitchfork start api --delay 5 Wait 5 seconds for daemon to be ready
+    pitchfork start api --output 'Listening on'
+                                  Wait for output pattern before ready
+    pitchfork start api --http http://localhost:8080/health
+                                  Wait for HTTP endpoint to return 2xx
+    pitchfork start api --port 8080
+                                  Wait for TCP port to be listening";
 
 /// Starts a daemon from a pitchfork.toml file
 #[derive(Debug, clap::Args)]

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -19,12 +19,14 @@ Shows detailed information about a single daemon including its PID and
 current status (running, stopped, failed, etc.).
 
 Example:
-  pitchfork status api
+
+    pitchfork status api
 
 Output:
-  Name: api
-  PID: 12345
-  Status: running"
+
+    Name: api
+    PID: 12345
+    Status: running"
 )]
 pub struct Status {
     /// Name of the daemon to check

--- a/src/cli/stop.rs
+++ b/src/cli/stop.rs
@@ -24,13 +24,14 @@ When using --all/--local/--global, daemons are stopped in reverse dependency ord
 dependents are stopped before the daemons they depend on.
 
 Examples:
-  pitchfork stop api           Stop a single daemon
-  pitchfork stop api worker    Stop multiple daemons
-  pitchfork stop --group backend Stop all daemons in the 'backend' group
-  pitchfork stop --all         Stop all running daemons in dependency order
-  pitchfork stop -l            Stop all local daemons in pitchfork.toml
-  pitchfork stop -g            Stop all global daemons in config.toml
-  pitchfork kill api           Same as 'stop' (alias)"
+
+    pitchfork stop api           Stop a single daemon
+    pitchfork stop api worker    Stop multiple daemons
+    pitchfork stop --group backend Stop all daemons in the 'backend' group
+    pitchfork stop --all         Stop all running daemons in dependency order
+    pitchfork stop -l            Stop all local daemons in pitchfork.toml
+    pitchfork stop -g            Stop all global daemons in config.toml
+    pitchfork kill api           Same as 'stop' (alias)"
 )]
 pub struct Stop {
     /// The name of the daemon(s) to stop

--- a/src/cli/tui.rs
+++ b/src/cli/tui.rs
@@ -15,10 +15,11 @@ The dashboard can be scoped to one or more namespaces; the fuzzy search
 (`/`) then operates within the scoped set.
 
 Example:
-  pitchfork tui
-  pitchfork tui --namespace frontend
-                                  Show only daemons in the 'frontend' namespace
-  pitchfork tui --project         Show only the current project's daemons"
+
+    pitchfork tui
+    pitchfork tui --namespace frontend
+                                    Show only daemons in the 'frontend' namespace
+    pitchfork tui --project         Show only the current project's daemons"
 )]
 pub struct Tui {
     /// Only show daemons in this namespace (repeatable for OR logic)

--- a/src/cli/wait.rs
+++ b/src/cli/wait.rs
@@ -22,9 +22,10 @@ log output in real-time. Exits with the same status code as the daemon.
 Useful in scripts that need to wait for a daemon to complete.
 
 Examples:
-  pitchfork wait api              Wait for 'api' to stop
-  pitchfork w api                 Alias for 'wait'
-  pitchfork wait api && echo done Run command after daemon stops"
+
+    pitchfork wait api              Wait for 'api' to stop
+    pitchfork w api                 Alias for 'wait'
+    pitchfork wait api && echo done Run command after daemon stops"
 )]
 pub struct Wait {
     /// The name of the daemon to wait for


### PR DESCRIPTION
## Problem

Command examples in `docs/cli/*.md` (generated from clap `long_about` via the usage tool) render as a single collapsed paragraph in VitePress. For example, `pitchfork start`'s example block and `activate`'s shell setup lines all run together with no column alignment.

## Root cause

`clap_usage` passes `long_help` through the usage tool's markdown renderer verbatim (`escape_md` is a passthrough). The command examples in the help text use 2-space indentation, which CommonMark does not treat as a code block — the lines become a plain paragraph and interior whitespace collapses during HTML rendering. Terminal help looked fine only because terminals render the paragraph with its literal whitespace.

## Fix

In the 18 CLI help texts that contain command examples:

1. Command example blocks (`Examples:` / `Example:` / `Subcommands:` / `Output:` and similar aligned text) switched from 2-space to 4-space indentation with a blank line after the leading line, so markdown-it renders them as `<pre><code>` and column alignment is preserved.
2. Command references in prose switched from `'pitchfork xxx'` to backtick inline code.
3. `mcp`'s `AFTER_LONG_HELP` and `proxy` subcommand doc comments updated the same way (the latter as ` ```text ` fenced blocks so doctests still pass).

Numbered lists (e.g. the settings precedence 1-5) are untouched — markdown-it already renders those as ordered lists.

## Verification

- `mise run render` regenerates all docs successfully
- markdown-it render check: example blocks now produce `<pre><code>` with intact column alignment
- `cargo test`: 66 unit tests + doctests pass
- `cargo fmt --check` and `cargo clippy -D warnings` clean for the modified `src/cli/` files (pre-existing baseline warnings in `procs.rs` / `supervisor/lifecycle.rs` / `watch_files.rs` are unrelated to this change)

*This comment was generated by Claude Code.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved formatting and readability across CLI command documentation and built-in help.
  - Standardized indentation, spacing, Markdown formatting, URLs, examples, and sample output.
  - Expanded MCP guidance with configuration, startup, JSON-RPC testing, and tool usage examples.
  - Added clearer documentation for global daemon configuration, boot management, proxy operations, settings, and daemon lifecycle commands.
  - Clarified shell completion, activation, and platform-specific instructions.
  - Command behavior and arguments remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->