### PR TITLE
fix(proxy): release config lock before hosts sync to avoid self-deadlock

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -66,6 +66,25 @@ pub static PITCHFORK_STATE_DIR: Lazy<PathBuf> = Lazy::new(|| {
 });
 pub static PITCHFORK_STATE_FILE: Lazy<PathBuf> =
     Lazy::new(|| PITCHFORK_STATE_DIR.join("state.toml"));
+/// Path to the hosts file managed by the proxy's hosts sync.
+///
+/// `PITCHFORK_HOSTS_FILE` overrides the platform default; tests use it to
+/// keep the sync away from the real system hosts file.
+pub static PITCHFORK_HOSTS_FILE: Lazy<PathBuf> = Lazy::new(|| {
+    if let Some(p) = var_path("PITCHFORK_HOSTS_FILE") {
+        return p;
+    }
+    if cfg!(windows) {
+        let system_root = var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
+        PathBuf::from(system_root)
+            .join("System32")
+            .join("drivers")
+            .join("etc")
+            .join("hosts")
+    } else {
+        PathBuf::from("/etc/hosts")
+    }
+});
 pub static PITCHFORK_LOG: Lazy<log::LevelFilter> =
     Lazy::new(|| var_log_level("PITCHFORK_LOG").unwrap_or(log::LevelFilter::Info));
 pub static PITCHFORK_LOG_FILE_LEVEL: Lazy<log::LevelFilter> =

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -1629,7 +1629,7 @@ impl PitchforkToml {
             })?;
         }
 
-        let lock = xx::fslock::get(global_path, false)
+        let _lock = xx::fslock::get(global_path, false)
             .wrap_err_with(|| format!("failed to acquire lock on {}", global_path.display()))?;
 
         let mut pt = if global_path.exists() {
@@ -1678,11 +1678,13 @@ impl PitchforkToml {
             },
         );
         pt.write_unlocked()?;
-        // Release the config lock before syncing hosts: sync_hosts_from_settings()
-        // re-reads the global config via read(), which acquires this same lock and
-        // would deadlock against our own held lock.
-        drop(lock);
-        crate::proxy::hosts::sync_hosts_from_settings();
+        // Sync hosts from the in-memory slug set, not sync_hosts_from_settings():
+        // that re-reads the global config via read(), which acquires the lock held
+        // above — flock is per open file description, so re-acquiring in the same
+        // process deadlocks against our own lock. Staying under the lock also keeps
+        // hosts writes ordered with config mutations across concurrent commands.
+        let slug_names: Vec<String> = pt.slugs.keys().cloned().collect();
+        crate::proxy::hosts::sync_hosts_from_settings_with_slugs(&slug_names);
         Ok(())
     }
 
@@ -1693,7 +1695,7 @@ impl PitchforkToml {
             return Ok(false);
         }
 
-        let lock = xx::fslock::get(global_path, false)
+        let _lock = xx::fslock::get(global_path, false)
             .wrap_err_with(|| format!("failed to acquire lock on {}", global_path.display()))?;
 
         let raw = std::fs::read_to_string(global_path).map_err(|e| FileError::ReadError {
@@ -1705,11 +1707,13 @@ impl PitchforkToml {
         let removed = pt.slugs.shift_remove(slug).is_some();
         if removed {
             pt.write_unlocked()?;
-            // Release the config lock before syncing hosts: sync_hosts_from_settings()
-            // re-reads the global config via read(), which acquires this same lock and
-            // would deadlock against our own held lock.
-            drop(lock);
-            crate::proxy::hosts::sync_hosts_from_settings();
+            // Sync hosts from the in-memory slug set, not sync_hosts_from_settings():
+            // that re-reads the global config via read(), which acquires the lock held
+            // above — flock is per open file description, so re-acquiring in the same
+            // process deadlocks against our own lock. Staying under the lock also keeps
+            // hosts writes ordered with config mutations across concurrent commands.
+            let slug_names: Vec<String> = pt.slugs.keys().cloned().collect();
+            crate::proxy::hosts::sync_hosts_from_settings_with_slugs(&slug_names);
         }
         Ok(removed)
     }

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -1629,7 +1629,7 @@ impl PitchforkToml {
             })?;
         }
 
-        let _lock = xx::fslock::get(global_path, false)
+        let lock = xx::fslock::get(global_path, false)
             .wrap_err_with(|| format!("failed to acquire lock on {}", global_path.display()))?;
 
         let mut pt = if global_path.exists() {
@@ -1648,11 +1648,21 @@ impl PitchforkToml {
         if let Some(ns) = namespace
             && !pt.namespaces.contains_key(ns)
         {
+            // Resolve against the already-parsed `pt` instead of
+            // SlugEntry::resolve_dir(): that re-reads the global config via
+            // read(), which would re-acquire the lock held above (flock is per
+            // open file description, so the same process deadlocks on itself).
             let dir = pt
                 .slugs
                 .get(slug)
-                .and_then(|e| e.resolve_dir())
-                .or_else(|| namespace.and_then(|_| env::CWD.as_path().canonicalize().ok()));
+                .and_then(|e| {
+                    e.dir.clone().or_else(|| {
+                        e.namespace
+                            .as_ref()
+                            .and_then(|ns| pt.namespaces.get(ns).map(|entry| entry.dir.clone()))
+                    })
+                })
+                .or_else(|| env::CWD.as_path().canonicalize().ok());
             if let Some(ref d) = dir {
                 pt.namespaces
                     .insert(ns.to_string(), NamespaceEntry { dir: d.clone() });
@@ -1668,6 +1678,10 @@ impl PitchforkToml {
             },
         );
         pt.write_unlocked()?;
+        // Release the config lock before syncing hosts: sync_hosts_from_settings()
+        // re-reads the global config via read(), which acquires this same lock and
+        // would deadlock against our own held lock.
+        drop(lock);
         crate::proxy::hosts::sync_hosts_from_settings();
         Ok(())
     }
@@ -1679,7 +1693,7 @@ impl PitchforkToml {
             return Ok(false);
         }
 
-        let _lock = xx::fslock::get(global_path, false)
+        let lock = xx::fslock::get(global_path, false)
             .wrap_err_with(|| format!("failed to acquire lock on {}", global_path.display()))?;
 
         let raw = std::fs::read_to_string(global_path).map_err(|e| FileError::ReadError {
@@ -1691,6 +1705,10 @@ impl PitchforkToml {
         let removed = pt.slugs.shift_remove(slug).is_some();
         if removed {
             pt.write_unlocked()?;
+            // Release the config lock before syncing hosts: sync_hosts_from_settings()
+            // re-reads the global config via read(), which acquires this same lock and
+            // would deadlock against our own held lock.
+            drop(lock);
             crate::proxy::hosts::sync_hosts_from_settings();
         }
         Ok(removed)

--- a/src/proxy/hosts.rs
+++ b/src/proxy/hosts.rs
@@ -16,26 +16,6 @@ const MARKER_START: &str = "# pitchfork-start";
 const MARKER_END: &str = "# pitchfork-end";
 static BLANK_LINES_RE: OnceLock<regex::Regex> = OnceLock::new();
 
-/// Path to the hosts file on the current platform.
-///
-/// `PITCHFORK_HOSTS_FILE` overrides the path; tests use it to keep the sync
-/// away from the real system hosts file.
-fn hosts_path() -> std::path::PathBuf {
-    if let Some(p) = std::env::var_os("PITCHFORK_HOSTS_FILE") {
-        return std::path::PathBuf::from(p);
-    }
-    if cfg!(windows) {
-        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
-        std::path::PathBuf::from(system_root)
-            .join("System32")
-            .join("drivers")
-            .join("etc")
-            .join("hosts")
-    } else {
-        std::path::PathBuf::from("/etc/hosts")
-    }
-}
-
 /// Sync the given slug hostnames into /etc/hosts.
 ///
 /// Builds the expected hosts block and replaces (or appends) the
@@ -101,7 +81,7 @@ pub fn clean_hosts_file() {
 
 /// Read /etc/hosts, replace the marked block, write back atomically.
 fn write_hosts_block(entries: &[String]) {
-    let path = hosts_path();
+    let path = crate::env::PITCHFORK_HOSTS_FILE.clone();
 
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,

--- a/src/proxy/hosts.rs
+++ b/src/proxy/hosts.rs
@@ -17,7 +17,13 @@ const MARKER_END: &str = "# pitchfork-end";
 static BLANK_LINES_RE: OnceLock<regex::Regex> = OnceLock::new();
 
 /// Path to the hosts file on the current platform.
+///
+/// `PITCHFORK_HOSTS_FILE` overrides the path; tests use it to keep the sync
+/// away from the real system hosts file.
 fn hosts_path() -> std::path::PathBuf {
+    if let Some(p) = std::env::var_os("PITCHFORK_HOSTS_FILE") {
+        return std::path::PathBuf::from(p);
+    }
     if cfg!(windows) {
         let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
         std::path::PathBuf::from(system_root)
@@ -30,19 +36,18 @@ fn hosts_path() -> std::path::PathBuf {
     }
 }
 
-/// Sync all registered slug hostnames into /etc/hosts.
+/// Sync the given slug hostnames into /etc/hosts.
 ///
-/// Reads the current slug table from global config, builds the expected
-/// hosts block, and replaces (or appends) the pitchfork-managed block.
+/// Builds the expected hosts block and replaces (or appends) the
+/// pitchfork-managed block.
 ///
 /// Best-effort: logs a warning on failure (e.g. permission denied) and
 /// does not prevent proxy startup.
-pub fn sync_hosts_file(bind_ip: &str, tld: &str) {
-    let slugs = crate::pitchfork_toml::PitchforkToml::read_global_slugs();
-    let mut entries: Vec<String> = Vec::new();
-    for slug in slugs.keys() {
-        entries.push(format!("{bind_ip} {slug}.{tld}"));
-    }
+fn sync_hosts_file_with_slugs(bind_ip: &str, tld: &str, slug_names: &[String]) {
+    let entries: Vec<String> = slug_names
+        .iter()
+        .map(|slug| format!("{bind_ip} {slug}.{tld}"))
+        .collect();
     write_hosts_block(&entries);
 }
 
@@ -51,6 +56,18 @@ pub fn sync_hosts_file(bind_ip: &str, tld: &str) {
 /// Used when slug registrations change while the proxy is already running.
 /// In LAN mode, entries are mapped to the detected LAN IP instead of 127.0.0.1.
 pub fn sync_hosts_from_settings() {
+    let slugs = crate::pitchfork_toml::PitchforkToml::read_global_slugs();
+    let slug_names: Vec<String> = slugs.keys().cloned().collect();
+    sync_hosts_from_settings_with_slugs(&slug_names);
+}
+
+/// Like `sync_hosts_from_settings`, but with a caller-provided slug list.
+///
+/// Use this from code that holds the global config fslock: reading the slug
+/// registry here would re-acquire that lock via `PitchforkToml::read()`, and
+/// flock(2) is per open file description, so the same process would deadlock
+/// against its own held lock.
+pub fn sync_hosts_from_settings_with_slugs(slug_names: &[String]) {
     let s = settings();
     if s.proxy.enable && s.proxy.sync_hosts {
         let lan_enabled = s.proxy.lan || !s.proxy.lan_ip.is_empty();
@@ -71,7 +88,7 @@ pub fn sync_hosts_from_settings() {
         } else {
             s.proxy.host.clone()
         };
-        sync_hosts_file(&ip, tld);
+        sync_hosts_file_with_slugs(&ip, tld, slug_names);
     }
 }
 

--- a/tests/test_proxy_slug_lock.rs
+++ b/tests/test_proxy_slug_lock.rs
@@ -1,0 +1,61 @@
+//! Regression test for the `proxy add`/`proxy remove` fslock self-deadlock.
+//!
+//! `add_slug_with_namespace()` and `remove_slug()` hold the global config
+//! fslock across a read-modify-write. They used to call
+//! `sync_hosts_from_settings()` while still holding it; that function re-reads
+//! the global config via `PitchforkToml::read()`, which acquires the same
+//! lock. flock(2) locks are per open file description, so the second
+//! acquisition in the same process blocked forever against the first.
+//!
+//! This test lives in its own integration-test binary on purpose: the config
+//! path and settings are process-wide lazies initialized from env vars, so it
+//! needs a process where no other test has touched them first.
+
+use std::time::{Duration, Instant};
+
+#[test]
+fn test_proxy_slug_add_remove_does_not_self_deadlock() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+
+    // SAFETY: this is the only test in this binary, so no other thread is
+    // reading or writing the environment concurrently.
+    unsafe {
+        std::env::set_var("PITCHFORK_CONFIG_DIR", temp_dir.path());
+        // The deadlock only triggers when the hosts sync actually runs
+        // (proxy.enable && proxy.sync_hosts); sync_hosts defaults to true.
+        std::env::set_var("PITCHFORK_PROXY_ENABLE", "true");
+    }
+
+    // If another test in this process initialized the config path lazy before
+    // us, bail out rather than write to the user's real config.
+    let config_path = pitchfork_cli::env::PITCHFORK_GLOBAL_CONFIG_USER.clone();
+    if config_path.parent() != Some(temp_dir.path()) {
+        eprintln!("skipping: PITCHFORK_GLOBAL_CONFIG_USER already initialized elsewhere");
+        return;
+    }
+
+    // Run the add + remove on a separate thread so a regression shows up as a
+    // clean test failure after the deadline instead of a hung test binary.
+    let worker = std::thread::spawn(|| -> pitchfork_cli::Result<bool> {
+        use pitchfork_cli::pitchfork_toml::PitchforkToml;
+        PitchforkToml::add_slug_with_namespace("pf-lock-test", Some("pf-lock-ns"), Some("server"))?;
+        PitchforkToml::remove_slug("pf-lock-test")
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while !worker.is_finished() {
+        assert!(
+            Instant::now() < deadline,
+            "proxy slug add/remove deadlocked: the global config fslock was \
+             re-acquired while already held (fslock re-entrancy regression)"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let removed = worker.join().unwrap().unwrap();
+    assert!(removed, "slug should have been added and then removed");
+
+    // The slug must be gone from the written config again.
+    let raw = std::fs::read_to_string(&config_path).unwrap();
+    assert!(!raw.contains("pf-lock-test"));
+}

--- a/tests/test_proxy_slug_lock.rs
+++ b/tests/test_proxy_slug_lock.rs
@@ -13,49 +13,89 @@
 
 use std::time::{Duration, Instant};
 
+const DEADLINE: Duration = Duration::from_secs(30);
+
+/// Wait for a worker thread to finish, failing after `DEADLINE`.
+///
+/// The workers run on plain detached threads, deliberately NOT on a tokio
+/// runtime via `spawn_blocking`: tokio joins already-started blocking tasks
+/// during runtime teardown, so a worker deadlocked in `flock` would hang the
+/// entire test run there instead of letting the deadline assertion report a
+/// clean failure (verified against the pre-fix code).
+fn join_within<T>(handle: std::thread::JoinHandle<T>, what: &str) -> pitchfork_cli::Result<T> {
+    let start = Instant::now();
+    while !handle.is_finished() {
+        miette::ensure!(
+            start.elapsed() < DEADLINE,
+            "proxy slug {what} deadlocked: the global config fslock was \
+             re-acquired while already held (fslock re-entrancy regression)"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    handle
+        .join()
+        .map_err(|_| miette::miette!("proxy slug {what} worker panicked"))
+}
+
 #[test]
-fn test_proxy_slug_add_remove_does_not_self_deadlock() {
-    let temp_dir = tempfile::TempDir::new().unwrap();
+fn test_proxy_slug_add_remove_does_not_self_deadlock() -> pitchfork_cli::Result<()> {
+    use miette::IntoDiagnostic;
+    use pitchfork_cli::pitchfork_toml::PitchforkToml;
+
+    let temp_dir = tempfile::TempDir::new().into_diagnostic()?;
+
+    // Keep the hosts sync away from the real system hosts file.
+    let hosts_file = temp_dir.path().join("hosts");
+    std::fs::write(&hosts_file, "127.0.0.1 localhost\n").into_diagnostic()?;
 
     // SAFETY: this is the only test in this binary, so no other thread is
     // reading or writing the environment concurrently.
     unsafe {
         std::env::set_var("PITCHFORK_CONFIG_DIR", temp_dir.path());
-        // The deadlock only triggers when the hosts sync actually runs
+        std::env::set_var("PITCHFORK_HOSTS_FILE", &hosts_file);
+        // The deadlock only triggered when the hosts sync actually ran
         // (proxy.enable && proxy.sync_hosts); sync_hosts defaults to true.
         std::env::set_var("PITCHFORK_PROXY_ENABLE", "true");
     }
 
-    // If another test in this process initialized the config path lazy before
-    // us, bail out rather than write to the user's real config.
+    // The config path lazy must have picked up our override; anything else
+    // means the test's process isolation is broken and running on would write
+    // to the user's real config.
     let config_path = pitchfork_cli::env::PITCHFORK_GLOBAL_CONFIG_USER.clone();
-    if config_path.parent() != Some(temp_dir.path()) {
-        eprintln!("skipping: PITCHFORK_GLOBAL_CONFIG_USER already initialized elsewhere");
-        return;
-    }
+    miette::ensure!(
+        config_path.parent() == Some(temp_dir.path()),
+        "PITCHFORK_GLOBAL_CONFIG_USER was initialized before this test set \
+         PITCHFORK_CONFIG_DIR; this test must be the only one in its binary"
+    );
 
-    // Run the add + remove on a separate thread so a regression shows up as a
-    // clean test failure after the deadline instead of a hung test binary.
-    let worker = std::thread::spawn(|| -> pitchfork_cli::Result<bool> {
-        use pitchfork_cli::pitchfork_toml::PitchforkToml;
-        PitchforkToml::add_slug_with_namespace("pf-lock-test", Some("pf-lock-ns"), Some("server"))?;
-        PitchforkToml::remove_slug("pf-lock-test")
+    let add = std::thread::spawn(|| {
+        PitchforkToml::add_slug_with_namespace("pf-lock-test", Some("pf-lock-ns"), Some("server"))
     });
+    join_within(add, "add")??;
 
-    let deadline = Instant::now() + Duration::from_secs(30);
-    while !worker.is_finished() {
-        assert!(
-            Instant::now() < deadline,
-            "proxy slug add/remove deadlocked: the global config fslock was \
-             re-acquired while already held (fslock re-entrancy regression)"
-        );
-        std::thread::sleep(Duration::from_millis(50));
-    }
+    // The hosts sync must actually have run — it is the code path that used to
+    // re-acquire the lock. If it were skipped, this test would prove nothing.
+    let hosts = std::fs::read_to_string(&hosts_file).into_diagnostic()?;
+    miette::ensure!(
+        hosts.contains("pf-lock-test"),
+        "hosts sync did not run; the deadlock code path was not exercised"
+    );
 
-    let removed = worker.join().unwrap().unwrap();
-    assert!(removed, "slug should have been added and then removed");
+    let remove = std::thread::spawn(|| PitchforkToml::remove_slug("pf-lock-test"));
+    let removed = join_within(remove, "remove")??;
+    miette::ensure!(removed, "slug should have been added and then removed");
 
-    // The slug must be gone from the written config again.
-    let raw = std::fs::read_to_string(&config_path).unwrap();
-    assert!(!raw.contains("pf-lock-test"));
+    // Both the config and the synced hosts file must be clean again.
+    let raw = std::fs::read_to_string(&config_path).into_diagnostic()?;
+    miette::ensure!(
+        !raw.contains("pf-lock-test"),
+        "slug must be gone from the written config"
+    );
+    let hosts = std::fs::read_to_string(&hosts_file).into_diagnostic()?;
+    miette::ensure!(
+        !hosts.contains("pf-lock-test"),
+        "slug must be gone from the synced hosts file"
+    );
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

`pitchfork proxy add <slug> --dir <dir> --daemon <name>` deadlocks against itself, deterministically, whenever the hosts sync is active (`proxy.enable = true` with the default `proxy.sync_hosts = true`). While it hangs, **every pitchfork command on the machine queues behind the same lock** until the hung process is killed. `proxy remove` has the identical bug.

Reproduced on released 2.21.0 (also seen on 2.20.0); the code path is unchanged on current `main`. Affected since v2.10.0, which introduced the hosts sync (c85ef81, #418). (Issues are disabled on this repo, so the full report lives here.)

## Diagnostic signature

- `lsof -p <pid> | grep fslock` → the hung process holds the **same lock file on two fds** and is the only process with it open:

  ```
  pitchfork 76075 quinn 10u REG 1,14 0 150806207 .../T/fslock/542f1124b0ca1907
  pitchfork 76075 quinn 11u REG 1,14 0 150806207 .../T/fslock/542f1124b0ca1907
  ```

- `sample <pid>` → main thread parked in `flock` (inside `xx::fslock::get`).
- The slug entry **is** written to `~/.config/pitchfork/config.toml` before the hang (the write itself is fine).

## Root cause

`PitchforkToml::add_slug_with_namespace()` acquires the fslock on the global config path and does its read-modify-write via `write_unlocked()` (the earlier `register_slug` fix) — but then calls `proxy::hosts::sync_hosts_from_settings()` **while still holding the lock guard**. That function re-reads the global config via `PitchforkToml::read()`, which calls `xx::fslock::get()` on the same path. flock(2) locks are per open file description, so the second acquisition opens the lock file a second time (the two fds above) and blocks forever against the process's own first lock:

```
Add::run
└─ add_slug_with_namespace            acquires fslock on config.toml   (fd 1)
   ├─ write_unlocked()                config written — OK
   └─ sync_hosts_from_settings()     ← still holding the lock
      └─ read_global_slugs()
         └─ PitchforkToml::read()     acquires the same fslock         (fd 2) → deadlock
```

Any other pitchfork invocation that reads the global config then parks in `flock` behind the stuck process, which is why the whole machine wedges.

## The fix

- New `sync_hosts_from_settings_with_slugs(&[String])` takes the slug list from the caller instead of re-reading the global config. `add_slug_with_namespace()` and `remove_slug()` call it with their in-memory slug snapshot **while still holding the config lock** — the re-entrant read is gone, and hosts writes stay ordered with config mutations across concurrent commands (an earlier revision dropped the lock before syncing; review correctly flagged that as a stale-overwrite race, so the sync now stays under the lock).
- `add_slug_with_namespace()`'s namespace auto-register branch: resolve the slug's directory against the already-parsed `pt` instead of `SlugEntry::resolve_dir()`, which re-reads the global config via `read_global_namespaces()` → `read()` under the same held lock. Latent today (`proxy add` pre-registers the namespace first) but the same re-entrancy class in the same locked region.
- `hosts_path()` honors a `PITCHFORK_HOSTS_FILE` override so tests (or root users who want it) can redirect the sync away from the system hosts file.

No behavior change otherwise: the hosts sync still runs on every add/remove with the same settings gating.

## Testing

- New regression test `tests/test_proxy_slug_lock.rs`: runs `add_slug_with_namespace` + `remove_slug` end-to-end with `PITCHFORK_CONFIG_DIR` and `PITCHFORK_HOSTS_FILE` pointed at a tempdir and `PITCHFORK_PROXY_ENABLE=true`, asserts the hosts sync actually executed (so the test can't go vacuous), and runs each operation on a detached worker thread with a 30s deadline. It fails hard if process isolation is broken rather than skipping. It lives in its own integration-test binary because the config path and settings are process-wide lazies.
  - Against pre-fix code: fails cleanly at ~30s with the deadlock message.
  - With the fix: passes in ~0.1s.
  - Detached threads (not tokio `spawn_blocking`) are load-bearing: tokio joins already-started blocking tasks at runtime teardown, so a deadlocked worker would hang the whole test run instead of failing at the deadline — verified empirically against the pre-fix code.
- Full suite passes (638 tests), `cargo fmt --check` and clippy `-D warnings` clean. (Two pre-existing env-dependent failures on my machine — `test_settings_reference`, `test_find_project_root_resolves_symlinked_start_dir` — fail identically on a clean `main` checkout.)
- Live verification against a long-running root supervisor (2.21.x): `proxy add` of a fresh slug completes in ~2s, the slug appears in `proxy status`, and the running proxy routes it immediately (`curl --resolve <slug>.<tld>:443:127.0.0.1` returns the daemon's response, vs the proxy's 502 "No daemon found" for unknown hosts). `proxy remove` of the same slug also completes instantly and cleans the config.

One adjacent observation kept out of this PR to stay scoped: on setups where the CLI can't write `/etc/hosts` (non-root), a slug added while the supervisor is already running routes at the proxy layer but its hostname doesn't resolve for browsers until the supervisor restarts — the supervisor only syncs `/etc/hosts` at proxy startup and `SyncMdns` only refreshes LAN mDNS records. Happy to write that up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause slug add/remove operations to hang.
  * Improved synchronization between configured slugs and the hosts file.
  * Preserved slug ordering during configuration updates.

* **New Features**
  * Added support for configuring a custom hosts-file location through `PITCHFORK_HOSTS_FILE`.
  * Added platform-specific default hosts-file paths when no override is provided.

* **Tests**
  * Added regression coverage for slug operations and hosts-file synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->