### PR TITLE
chore: release v2.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.22.0](https://github.com/jdx/pitchfork/compare/v2.21.0...v2.22.0) - 2026-08-18
+
+### Added
+
+- *(config)* auto-discover daemons in git worktrees and jj workspaces ([#737](https://github.com/jdx/pitchfork/pull/737))
+- *(tui)* add namespace scoping to tui and list ([#736](https://github.com/jdx/pitchfork/pull/736))
+
+### Fixed
+
+- *(proxy)* release config lock before hosts sync to avoid self-deadlock ([#739](https://github.com/jdx/pitchfork/pull/739))
+- *(cli)* render command examples as code blocks in generated docs ([#738](https://github.com/jdx/pitchfork/pull/738))
+- *(deps)* update rust crate comfy-table to v8 ([#734](https://github.com/jdx/pitchfork/pull/734))
+
+### Other
+
+- *(deps)* update rust crate rcgen to v0.14.9 ([#743](https://github.com/jdx/pitchfork/pull/743))
+- *(supervisor)* throttle full process-table refreshes with TTL cache ([#728](https://github.com/jdx/pitchfork/pull/728))
+
 ## [2.21.0](https://github.com/jdx/pitchfork/compare/v2.20.0...v2.21.0) - 2026-08-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,7 +2940,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.21.0"
+version = "2.22.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.21.0"
+version = "2.22.0"
 edition = "2024"
 resolver = "3"
 rust-version = "1.88"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3272,7 +3272,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.21.0",
+  "version": "2.22.0",
   "usage": "Usage: pitchfork <COMMAND>",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.21.0
+**Version**: 2.22.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name pitchfork
 bin pitchfork
-version "2.21.0"
+version "2.22.0"
 about "Daemons with DX"
 usage "Usage: pitchfork <COMMAND>"
 cmd activate help="Activate pitchfork in your shell session" effect=read {


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.21.0 -> 2.22.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.22.0](https://github.com/jdx/pitchfork/compare/v2.21.0...v2.22.0) - 2026-08-18

### Added

- *(config)* auto-discover daemons in git worktrees and jj workspaces ([#737](https://github.com/jdx/pitchfork/pull/737))
- *(tui)* add namespace scoping to tui and list ([#736](https://github.com/jdx/pitchfork/pull/736))

### Fixed

- *(proxy)* release config lock before hosts sync to avoid self-deadlock ([#739](https://github.com/jdx/pitchfork/pull/739))
- *(cli)* render command examples as code blocks in generated docs ([#738](https://github.com/jdx/pitchfork/pull/738))
- *(deps)* update rust crate comfy-table to v8 ([#734](https://github.com/jdx/pitchfork/pull/734))

### Other

- *(deps)* update rust crate rcgen to v0.14.9 ([#743](https://github.com/jdx/pitchfork/pull/743))
- *(supervisor)* throttle full process-table refreshes with TTL cache ([#728](https://github.com/jdx/pitchfork/pull/728))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation updates only; functional changes were merged in prior PRs listed in the changelog.
> 
> **Overview**
> **Release v2.22.0** bumps `pitchfork-cli` from **2.21.0 → 2.22.0** across `Cargo.toml`, `Cargo.lock`, generated CLI docs (`pitchfork.usage.kdl`, `docs/cli/*`), and adds a **2.22.0** section to `CHANGELOG.md`.
> 
> The changelog for this tag (not new code in this PR) highlights: **auto-discovery of daemons in git worktrees and jj workspaces**; **namespace scoping** on `list` and `tui`; a **proxy deadlock fix** (release config lock before hosts sync); **CLI doc examples as code blocks**; **supervisor process-table refresh throttling**; and dependency bumps (`comfy-table` v8, `rcgen` v0.14.9).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 796328ff40bf7064f4e3095f7b60e91797c938c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->