### PR TITLE
fix(config): pass project mise setting to supervisor

### DIFF
--- a/build/generate_settings.rs
+++ b/build/generate_settings.rs
@@ -100,13 +100,21 @@ fn generate_settings_struct(settings: &Table) -> Result<String, Box<dyn std::err
             /// 3. Project-level: pitchfork.toml files from root to current directory
             /// Environment variables override all file-based settings.
             pub fn load() -> Self {
+                Self::load_from_dir(&crate::env::CWD)
+            }
+
+            /// Load settings for a specific project directory, then overlay environment variables.
+            ///
+            /// This is used when operating on daemons from registered namespaces whose project
+            /// settings may differ from those of the invoking process's current directory.
+            pub fn load_from_dir(start_dir: &std::path::Path) -> Self {
                 // Start with defaults
                 let mut settings = Self::default();
 
                 // Load and merge from all pitchfork.toml files
                 // Note: We can't use PitchforkToml::all_merged() here to avoid circular dependency
                 // Instead, we load each config file directly
-                for path in Self::config_paths() {
+                for path in Self::config_paths_from(start_dir) {
                     if path.exists() {
                         match std::fs::read_to_string(&path) {
                             Err(e) => eprintln!("pitchfork: warning: failed to read {}: {}", path.display(), e),
@@ -131,14 +139,14 @@ fn generate_settings_struct(settings: &Table) -> Result<String, Box<dyn std::err
             }
 
             /// Get all config file paths in precedence order (lowest to highest)
-            fn config_paths() -> Vec<std::path::PathBuf> {
+            fn config_paths_from(start_dir: &std::path::Path) -> Vec<std::path::PathBuf> {
                 let mut paths = Vec::new();
                 paths.push(crate::env::PITCHFORK_GLOBAL_CONFIG_SYSTEM.clone());
                 paths.push(crate::env::PITCHFORK_GLOBAL_CONFIG_USER.clone());
 
                 // Find project-level pitchfork.toml files
                 let mut project_paths = xx::file::find_up_all(
-                    &*crate::env::CWD,
+                    start_dir,
                     &["pitchfork.local.toml", "pitchfork.toml"]
                 );
                 project_paths.reverse();

--- a/build/generate_settings.rs
+++ b/build/generate_settings.rs
@@ -147,7 +147,12 @@ fn generate_settings_struct(settings: &Table) -> Result<String, Box<dyn std::err
                 // Find project-level pitchfork.toml files
                 let mut project_paths = xx::file::find_up_all(
                     start_dir,
-                    &["pitchfork.local.toml", "pitchfork.toml"]
+                    &[
+                        "pitchfork.local.toml",
+                        "pitchfork.toml",
+                        ".config/pitchfork.local.toml",
+                        ".config/pitchfork.toml",
+                    ]
                 );
                 project_paths.reverse();
                 paths.extend(project_paths);

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -1212,7 +1212,7 @@ mod tests {
                 "--nocapture",
             ])
             .env("PITCHFORK_TEST_PROJECT_MISE_MODE", mode)
-            .env_remove("PITCHFORK_GENERAL_MISE")
+            .env_remove("PITCHFORK_MISE")
             .output()
             .await
             .unwrap();

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -112,14 +112,15 @@ pub fn build_run_options(
 
     let mut run_opts = daemon_config.to_run_options(id, cmd);
     // Resolve the project-scoped setting in the client process. The supervisor is
-    // long-lived and may have been started from a different directory, so asking
-    // it to resolve `None` against its own Settings instance loses values from the
-    // calling project's `[settings.general]` table.
-    run_opts.mise = Some(
-        run_opts
+    // long-lived and may have been started from a different directory. Use this
+    // daemon's defining config path rather than the invoking client's CWD because
+    // batch operations can include daemons from other registered namespaces.
+    run_opts.mise = Some(run_opts.mise.unwrap_or_else(|| {
+        let project_dir = resolve_config_base_dir(daemon_config.path.as_deref());
+        crate::settings::Settings::load_from_dir(&project_dir)
+            .general
             .mise
-            .unwrap_or(crate::settings::settings().general.mise),
-    );
+    }));
     run_opts.wait_ready = true;
     run_opts.ready_delay = run_opts.ready_delay.or(Some(3));
 
@@ -1182,6 +1183,29 @@ mod tests {
             run_opts.mise,
             Some(crate::settings::settings().general.mise)
         );
+    }
+
+    #[test]
+    fn build_run_options_resolves_mise_from_daemon_project() {
+        let project = tempfile::tempdir().unwrap();
+        let config_path = project.path().join("pitchfork.toml");
+        let project_mise = !crate::settings::settings().general.mise;
+        std::fs::write(
+            &config_path,
+            format!("[settings.general]\nmise = {project_mise}\n"),
+        )
+        .unwrap();
+
+        let id = DaemonId::try_new("other-project", "api").unwrap();
+        let daemon_config = PitchforkTomlDaemon {
+            run: "echo ready".to_string(),
+            path: Some(config_path),
+            ..PitchforkTomlDaemon::default()
+        };
+
+        let run_opts = build_run_options(&id, &daemon_config, None).unwrap();
+
+        assert_eq!(run_opts.mise, Some(project_mise));
     }
 
     #[test]

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -102,7 +102,7 @@ pub struct StartOptions {
 /// - Command parsing from the config's run string
 /// - Extracting all config values (cron, retry, ready checks, depends, etc.)
 /// - Merging CLI/API overrides with config defaults
-pub fn build_run_options(
+pub async fn build_run_options(
     id: &DaemonId,
     daemon_config: &PitchforkTomlDaemon,
     overrides: Option<&StartOptions>,
@@ -115,12 +115,17 @@ pub fn build_run_options(
     // long-lived and may have been started from a different directory. Use this
     // daemon's defining config path rather than the invoking client's CWD because
     // batch operations can include daemons from other registered namespaces.
-    run_opts.mise = Some(run_opts.mise.unwrap_or_else(|| {
+    if run_opts.mise.is_none() {
         let project_dir = resolve_config_base_dir(daemon_config.path.as_deref());
-        crate::settings::Settings::load_from_dir(&project_dir)
-            .general
-            .mise
-    }));
+        let project_mise = tokio::task::spawn_blocking(move || {
+            crate::settings::Settings::load_from_dir(&project_dir)
+                .general
+                .mise
+        })
+        .await
+        .map_err(|e| format!("Failed to load project settings: {e}"))?;
+        run_opts.mise = Some(project_mise);
+    }
     run_opts.wait_ready = true;
     run_opts.ready_delay = run_opts.ready_delay.or(Some(3));
 
@@ -755,11 +760,11 @@ impl IpcClient {
         let mut start_opts = opts.clone();
         start_opts.force = opts.force && is_explicitly_requested;
 
-        let run_opts = build_run_options(&id, daemon_config, Some(&start_opts));
+        let daemon_config = daemon_config.clone();
         let quiet = opts.quiet;
 
         tokio::spawn(async move {
-            let run_opts = match run_opts {
+            let run_opts = match build_run_options(&id, &daemon_config, Some(&start_opts)).await {
                 Ok(opts) => opts,
                 Err(e) => {
                     return SpawnTaskResult {
@@ -946,8 +951,9 @@ impl IpcClient {
         // Render Tera templates and merge top-level env (per-daemon wins).
         render_daemon_config(id, &mut daemon_config, &pt)?;
 
-        let run_opts =
-            build_run_options(id, &daemon_config, overrides).map_err(|e| miette::miette!("{e}"))?;
+        let run_opts = build_run_options(id, &daemon_config, overrides)
+            .await
+            .map_err(|e| miette::miette!("{e}"))?;
 
         self.run(run_opts).await
     }
@@ -1145,8 +1151,8 @@ mod tests {
         assert!(!ready_http.accepts_status(200));
     }
 
-    #[test]
-    fn build_run_options_preserves_ready_http_status_for_cli_http_override() {
+    #[tokio::test]
+    async fn build_run_options_preserves_ready_http_status_for_cli_http_override() {
         let id = DaemonId::try_new("project", "api").unwrap();
         let daemon_config = PitchforkTomlDaemon {
             run: "echo ready".to_string(),
@@ -1162,22 +1168,24 @@ mod tests {
             ..StartOptions::default()
         };
 
-        let run_opts = build_run_options(&id, &daemon_config, Some(&opts)).unwrap();
+        let run_opts = build_run_options(&id, &daemon_config, Some(&opts))
+            .await
+            .unwrap();
         let ready_http = run_opts.ready_http.unwrap();
 
         assert_eq!(ready_http.url, "http://localhost:3000/health");
         assert_eq!(ready_http.status, vec![401]);
     }
 
-    #[test]
-    fn build_run_options_resolves_global_mise_for_supervisor() {
+    #[tokio::test]
+    async fn build_run_options_resolves_global_mise_for_supervisor() {
         let id = DaemonId::try_new("project", "api").unwrap();
         let daemon_config = PitchforkTomlDaemon {
             run: "echo ready".to_string(),
             ..PitchforkTomlDaemon::default()
         };
 
-        let run_opts = build_run_options(&id, &daemon_config, None).unwrap();
+        let run_opts = build_run_options(&id, &daemon_config, None).await.unwrap();
 
         assert_eq!(
             run_opts.mise,
@@ -1185,15 +1193,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn build_run_options_resolves_mise_from_daemon_project() {
+    #[tokio::test]
+    async fn build_run_options_resolves_mise_from_daemon_project() {
         let project = tempfile::tempdir().unwrap();
         let config_path = project.path().join("pitchfork.toml");
         let project_mise = !crate::settings::settings().general.mise;
-        std::fs::write(
+        tokio::fs::write(
             &config_path,
             format!("[settings.general]\nmise = {project_mise}\n"),
         )
+        .await
         .unwrap();
 
         let id = DaemonId::try_new("other-project", "api").unwrap();
@@ -1203,22 +1212,23 @@ mod tests {
             ..PitchforkTomlDaemon::default()
         };
 
-        let run_opts = build_run_options(&id, &daemon_config, None).unwrap();
+        let run_opts = build_run_options(&id, &daemon_config, None).await.unwrap();
 
         assert_eq!(run_opts.mise, Some(project_mise));
     }
 
-    #[test]
-    fn build_run_options_resolves_mise_from_daemon_dot_config() {
+    #[tokio::test]
+    async fn build_run_options_resolves_mise_from_daemon_dot_config() {
         let project = tempfile::tempdir().unwrap();
         let config_dir = project.path().join(".config");
-        std::fs::create_dir(&config_dir).unwrap();
+        tokio::fs::create_dir(&config_dir).await.unwrap();
         let config_path = config_dir.join("pitchfork.toml");
         let project_mise = !crate::settings::settings().general.mise;
-        std::fs::write(
+        tokio::fs::write(
             &config_path,
             format!("[settings.general]\nmise = {project_mise}\n"),
         )
+        .await
         .unwrap();
 
         let id = DaemonId::try_new("other-project", "api").unwrap();
@@ -1228,13 +1238,13 @@ mod tests {
             ..PitchforkTomlDaemon::default()
         };
 
-        let run_opts = build_run_options(&id, &daemon_config, None).unwrap();
+        let run_opts = build_run_options(&id, &daemon_config, None).await.unwrap();
 
         assert_eq!(run_opts.mise, Some(project_mise));
     }
 
-    #[test]
-    fn build_run_options_preserves_daemon_mise_override() {
+    #[tokio::test]
+    async fn build_run_options_preserves_daemon_mise_override() {
         let id = DaemonId::try_new("project", "api").unwrap();
         let daemon_config = PitchforkTomlDaemon {
             run: "echo ready".to_string(),
@@ -1242,13 +1252,13 @@ mod tests {
             ..PitchforkTomlDaemon::default()
         };
 
-        let run_opts = build_run_options(&id, &daemon_config, None).unwrap();
+        let run_opts = build_run_options(&id, &daemon_config, None).await.unwrap();
 
         assert_eq!(run_opts.mise, daemon_config.mise);
     }
 
-    #[test]
-    fn build_run_options_preserves_ready_port_timeout_for_cli_port_override() {
+    #[tokio::test]
+    async fn build_run_options_preserves_ready_port_timeout_for_cli_port_override() {
         let id = DaemonId::try_new("project", "api").unwrap();
         let daemon_config = PitchforkTomlDaemon {
             run: "echo ready".to_string(),
@@ -1264,15 +1274,17 @@ mod tests {
             ..StartOptions::default()
         };
 
-        let run_opts = build_run_options(&id, &daemon_config, Some(&opts)).unwrap();
+        let run_opts = build_run_options(&id, &daemon_config, Some(&opts))
+            .await
+            .unwrap();
         let ready_port = run_opts.ready_port.unwrap();
 
         assert_eq!(ready_port.port, Some(4000));
         assert_eq!(ready_port.timeout, Some(Duration::from_secs(45)));
     }
 
-    #[test]
-    fn build_run_options_preserves_ready_output_timeout_for_cli_output_override() {
+    #[tokio::test]
+    async fn build_run_options_preserves_ready_output_timeout_for_cli_output_override() {
         let id = DaemonId::try_new("project", "api").unwrap();
         let daemon_config = PitchforkTomlDaemon {
             run: "echo ready".to_string(),
@@ -1287,7 +1299,9 @@ mod tests {
             ..StartOptions::default()
         };
 
-        let run_opts = build_run_options(&id, &daemon_config, Some(&opts)).unwrap();
+        let run_opts = build_run_options(&id, &daemon_config, Some(&opts))
+            .await
+            .unwrap();
         let ready_output = run_opts.ready_output.unwrap();
 
         assert_eq!(ready_output.pattern, "DONE");

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -1195,33 +1195,59 @@ mod tests {
 
     #[tokio::test]
     async fn build_run_options_resolves_mise_from_daemon_project() {
-        let project = tempfile::tempdir().unwrap();
-        let config_path = project.path().join("pitchfork.toml");
-        let project_mise = !crate::settings::settings().general.mise;
-        tokio::fs::write(
-            &config_path,
-            format!("[settings.general]\nmise = {project_mise}\n"),
-        )
-        .await
-        .unwrap();
-
-        let id = DaemonId::try_new("other-project", "api").unwrap();
-        let daemon_config = PitchforkTomlDaemon {
-            run: "echo ready".to_string(),
-            path: Some(config_path),
-            ..PitchforkTomlDaemon::default()
-        };
-
-        let run_opts = build_run_options(&id, &daemon_config, None).await.unwrap();
-
-        assert_eq!(run_opts.mise, Some(project_mise));
+        run_project_mise_test_in_sanitized_child("project").await;
     }
 
     #[tokio::test]
     async fn build_run_options_resolves_mise_from_daemon_dot_config() {
+        run_project_mise_test_in_sanitized_child("dot-config").await;
+    }
+
+    async fn run_project_mise_test_in_sanitized_child(mode: &str) {
+        const CHILD_SENTINEL: &str = "project-mise-sanitized-child-ran";
+        let output = tokio::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "ipc::batch::tests::build_run_options_resolves_mise_in_sanitized_child",
+                "--nocapture",
+            ])
+            .env("PITCHFORK_TEST_PROJECT_MISE_MODE", mode)
+            .env_remove("PITCHFORK_GENERAL_MISE")
+            .output()
+            .await
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "sanitized child failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(CHILD_SENTINEL),
+            "sanitized child test did not run:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[tokio::test]
+    async fn build_run_options_resolves_mise_in_sanitized_child() {
+        let Ok(mode) = std::env::var("PITCHFORK_TEST_PROJECT_MISE_MODE") else {
+            return;
+        };
+        eprintln!("project-mise-sanitized-child-ran");
+
         let project = tempfile::tempdir().unwrap();
-        let config_dir = project.path().join(".config");
-        tokio::fs::create_dir(&config_dir).await.unwrap();
+        let config_dir = match mode.as_str() {
+            "project" => project.path().to_path_buf(),
+            "dot-config" => {
+                let config_dir = project.path().join(".config");
+                tokio::fs::create_dir(&config_dir).await.unwrap();
+                config_dir
+            }
+            _ => panic!("unknown project mise test mode: {mode}"),
+        };
         let config_path = config_dir.join("pitchfork.toml");
         let project_mise = !crate::settings::settings().general.mise;
         tokio::fs::write(

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -1209,6 +1209,31 @@ mod tests {
     }
 
     #[test]
+    fn build_run_options_resolves_mise_from_daemon_dot_config() {
+        let project = tempfile::tempdir().unwrap();
+        let config_dir = project.path().join(".config");
+        std::fs::create_dir(&config_dir).unwrap();
+        let config_path = config_dir.join("pitchfork.toml");
+        let project_mise = !crate::settings::settings().general.mise;
+        std::fs::write(
+            &config_path,
+            format!("[settings.general]\nmise = {project_mise}\n"),
+        )
+        .unwrap();
+
+        let id = DaemonId::try_new("other-project", "api").unwrap();
+        let daemon_config = PitchforkTomlDaemon {
+            run: "echo ready".to_string(),
+            path: Some(config_path),
+            ..PitchforkTomlDaemon::default()
+        };
+
+        let run_opts = build_run_options(&id, &daemon_config, None).unwrap();
+
+        assert_eq!(run_opts.mise, Some(project_mise));
+    }
+
+    #[test]
     fn build_run_options_preserves_daemon_mise_override() {
         let id = DaemonId::try_new("project", "api").unwrap();
         let daemon_config = PitchforkTomlDaemon {

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -111,6 +111,15 @@ pub fn build_run_options(
         .map_err(|e| format!("Failed to parse command: {e}"))?;
 
     let mut run_opts = daemon_config.to_run_options(id, cmd);
+    // Resolve the project-scoped setting in the client process. The supervisor is
+    // long-lived and may have been started from a different directory, so asking
+    // it to resolve `None` against its own Settings instance loses values from the
+    // calling project's `[settings.general]` table.
+    run_opts.mise = Some(
+        run_opts
+            .mise
+            .unwrap_or(crate::settings::settings().general.mise),
+    );
     run_opts.wait_ready = true;
     run_opts.ready_delay = run_opts.ready_delay.or(Some(3));
 
@@ -1157,6 +1166,36 @@ mod tests {
 
         assert_eq!(ready_http.url, "http://localhost:3000/health");
         assert_eq!(ready_http.status, vec![401]);
+    }
+
+    #[test]
+    fn build_run_options_resolves_global_mise_for_supervisor() {
+        let id = DaemonId::try_new("project", "api").unwrap();
+        let daemon_config = PitchforkTomlDaemon {
+            run: "echo ready".to_string(),
+            ..PitchforkTomlDaemon::default()
+        };
+
+        let run_opts = build_run_options(&id, &daemon_config, None).unwrap();
+
+        assert_eq!(
+            run_opts.mise,
+            Some(crate::settings::settings().general.mise)
+        );
+    }
+
+    #[test]
+    fn build_run_options_preserves_daemon_mise_override() {
+        let id = DaemonId::try_new("project", "api").unwrap();
+        let daemon_config = PitchforkTomlDaemon {
+            run: "echo ready".to_string(),
+            mise: Some(!crate::settings::settings().general.mise),
+            ..PitchforkTomlDaemon::default()
+        };
+
+        let run_opts = build_run_options(&id, &daemon_config, None).unwrap();
+
+        assert_eq!(run_opts.mise, daemon_config.mise);
     }
 
     #[test]

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -1559,7 +1559,7 @@ async fn try_auto_start_inner(
         ..crate::ipc::batch::StartOptions::default()
     };
     let mut run_opts =
-        match crate::ipc::batch::build_run_options(daemon_id, &daemon_config, Some(&opts)) {
+        match crate::ipc::batch::build_run_options(daemon_id, &daemon_config, Some(&opts)).await {
             Ok(o) => o,
             Err(e) => {
                 log::warn!("Auto-start: failed to build run options for {daemon_id}: {e}");

--- a/test/config_fields.bats
+++ b/test/config_fields.bats
@@ -39,19 +39,30 @@ EOF
   assert_output --partial "got_sigint"
 }
 
-@test "mise=true wraps run command with mise x" {
+@test "settings.general.mise loads the project mise environment" {
   command -v mise >/dev/null 2>&1 || skip "mise not installed"
+  export PITCHFORK_MISE_BIN
+  PITCHFORK_MISE_BIN="$(command -v mise)"
+  pitchfork supervisor start --force >/dev/null
 
-  create_pitchfork_toml <<EOF
+  cat >mise.toml <<'EOF'
+[env]
+PITCHFORK_MISE_TEST = "loaded_from_mise"
+EOF
+  mise trust mise.toml
+
+  create_pitchfork_toml <<'EOF'
 [daemons.mise_test]
-run = "echo hello_from_mise"
-mise = true
+run = "echo $PITCHFORK_MISE_TEST"
 ready_delay = 1
+
+[settings.general]
+mise = true
 EOF
 
   run pitchfork start mise_test
   assert_success
-  wait_for_logs mise_test "hello_from_mise" 10
+  wait_for_logs mise_test "loaded_from_mise" 10
 }
 
 @test "cpu_limit triggers on high CPU usage" {


### PR DESCRIPTION
## Summary

- resolve the effective project-scoped `settings.general.mise` value in the client before sending daemon run options over IPC
- preserve explicit per-daemon `mise` overrides
- strengthen unit and end-to-end coverage to verify environment variables from `mise.toml` reach daemon processes

## Root cause

Daemons without a per-daemon `mise` override were sent to the long-running supervisor with `mise = None`. The supervisor resolved that value against its own process-global settings, which may have been loaded from a different directory, so project-level `settings.general.mise = true` was lost.

## Impact

Project-level mise integration now consistently wraps daemon commands with `mise x --`, allowing mise-provided environment variables and tool paths to reach commands such as `docker compose up`.

## Validation

- `mise run ci-dev`
- 671 Rust tests passed
- 308 Bats tests passed
- focused project mise environment regression passed

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon command wrapping at start time across batch, single-daemon, and proxy auto-start paths; behavior is scoped to mise resolution with tests, but incorrect settings paths could still mis-wrap commands.
> 
> **Overview**
> Fixes project-level mise integration being ignored when the long-lived supervisor was started from a different directory than the daemon’s project.
> 
> **Settings loading** now supports `Settings::load_from_dir(start_dir)` so config discovery walks from a chosen directory (not only the process CWD). Project config search also includes `.config/pitchfork.toml` and `.config/pitchfork.local.toml`.
> 
> **Daemon starts** resolve `settings.general.mise` in the client inside `build_run_options` (now async): when a daemon has no per-daemon `mise` override, the effective value is loaded from the daemon’s defining config path via `resolve_config_base_dir`, then sent on `RunOptions` to the supervisor. Explicit per-daemon `mise` overrides are unchanged.
> 
> Coverage adds unit tests for project and `.config` paths and daemon overrides; the Bats test asserts env from `mise.toml` under `[settings.general] mise = true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 147e0f2947fdee1eb478355d5f037ebba20b8258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project-level Mise settings are now correctly applied when no daemon-level override is configured.
  * Explicit daemon-level Mise settings continue to take precedence.
  * Mise environments are resolved from the daemon’s defining project, including supported `.config` configuration paths.
  * Trusted project configuration is now loaded consistently during daemon and automatic proxy starts.

* **Tests**
  * Added coverage for project-level settings, `.config` configurations, and daemon-level overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->