### PR TITLE
fix(config): gate worktree auto-discovery behind global setting

### DIFF
--- a/docs/concepts/namespaces.md
+++ b/docs/concepts/namespaces.md
@@ -94,6 +94,8 @@ pitchfork status api          # myapp/api, unaffected by the worktree
 
 Daemons started in a worktree run with the worktree directory as their working directory, and supervisor background tasks (cron scheduling, boot_start, file watching) automatically discover daemons defined in every worktree of a repository.
 
+This automatic discovery (and worktree-aware proxy slug routing) is controlled by the `general.worktree` setting, which is enabled by default. Set it to `false` to disable all worktree/workspace discovery; only the main project directory is then used.
+
 Automatic worktree isolation applies when namespaces are derived from project directories — so worktree directories need distinct names (the default when you create worktrees per branch). If a config sets an explicit top-level `namespace`, it overrides the directory-derived namespace, so give each worktree a distinct explicit namespace to keep same-named daemons from colliding.
 
 ## Display Behavior

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -824,6 +824,13 @@
             "boolean",
             "null"
           ]
+        },
+        "worktree": {
+          "description": "Enable git worktree / jj workspace auto-discovery",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },
@@ -1066,13 +1073,6 @@
         },
         "wildcard": {
           "description": "Enable wildcard subdomain matching for proxy routes",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "worktree": {
-          "description": "Enable git worktree / jj workspace auto-discovery for slug routing",
           "type": [
             "boolean",
             "null"

--- a/settings.toml
+++ b/settings.toml
@@ -78,6 +78,31 @@ For example, set console to `"info"` but file to `"debug"` to keep
 detailed logs for troubleshooting without cluttering the console.
 """
 
+[general.worktree]
+type = "Bool"
+env = "PITCHFORK_WORKTREE"
+deprecated_env = "PITCHFORK_PROXY_WORKTREE"
+default = "true"
+description = "Enable git worktree / jj workspace auto-discovery"
+docs = """
+When enabled (default), pitchfork automatically discovers git worktrees and jj
+workspaces. This drives two behaviors:
+
+1. Proxy slug routing: subdomain prefixes are routed to the daemon running in
+   the matching worktree / workspace directory.
+2. Config discovery: daemons defined in a worktree / workspace are visible to
+   supervisor background tasks (cron registration, boot_start, file watch)
+   even when that namespace was never registered in `[namespaces]`.
+
+Each worktree / workspace gets its own namespace (the directory name), so
+multiple copies can run the same daemon name without conflict. Branch /
+workspace names are sanitized for URL compatibility: `feature/my-endpoint`
+becomes `feature-my-endpoint`.
+
+Set to `false` to disable all worktree/workspace discovery. Only the main
+project directory is used.
+"""
+
 [general.mise]
 type = "Bool"
 env = "PITCHFORK_MISE"
@@ -1071,33 +1096,6 @@ subdomain (e.g. `acme.myapp.localhost`, `globex.myapp.localhost`) but
 all share the same backend server.
 
 Set to `false` to require exact hostname matches only.
-"""
-
-[proxy.worktree]
-type = "Bool"
-env = "PITCHFORK_PROXY_WORKTREE"
-default = "true"
-description = "Enable git worktree / jj workspace auto-discovery for slug routing"
-docs = """
-When enabled (default), pitchfork automatically detects git worktrees or jj
-workspaces for registered slugs and routes subdomain prefixes to the
-corresponding worktree / workspace.
-
-For example, with slug "myapp" pointing to /home/user/myapp (main branch),
-a git worktree at /home/user/myapp-feature-a (branch feature-a) or a jj
-workspace at /home/user/myapp-feature-a is automatically discovered.
-Requests to feature-a.myapp.localhost are routed to the daemon running in
-that directory.
-
-Each worktree / workspace gets its own namespace (the directory name), so
-multiple copies can run the same daemon name without conflict.
-
-Branch / workspace names are sanitized for URL compatibility:
-`feature/my-endpoint` becomes `feature-my-endpoint`, accessed as
-`feature-my-endpoint.myapp.localhost`.
-
-Set to `false` to disable worktree/workspace discovery. Only the main
-project directory will be used for slug routing.
 """
 
 [proxy.lan]

--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -368,6 +368,7 @@ fn get_general_value(g: &crate::settings::SettingsGeneral, field: &str) -> Strin
         "mise_bin" => g.mise_bin.clone(),
         "shell" => g.shell.clone(),
         "startup_log_timestamps" => g.startup_log_timestamps.to_string(),
+        "worktree" => g.worktree.to_string(),
         _ => String::new(),
     }
 }
@@ -462,7 +463,6 @@ fn get_proxy_value(g: &crate::settings::SettingsProxy, field: &str) -> String {
         "auto_start_timeout" => g.auto_start_timeout.clone(),
         "sync_hosts" => g.sync_hosts.to_string(),
         "wildcard" => g.wildcard.to_string(),
-        "worktree" => g.worktree.to_string(),
         "lan" => g.lan.to_string(),
         "lan_ip" => g.lan_ip.clone(),
         _ => String::new(),
@@ -522,6 +522,7 @@ fn apply_general_value(
         "mise_bin" => partial.mise_bin = Some(value.to_string()),
         "shell" => partial.shell = Some(value.to_string()),
         "startup_log_timestamps" => partial.startup_log_timestamps = Some(parse_bool_value(value)?),
+        "worktree" => partial.worktree = Some(parse_bool_value(value)?),
         _ => bail!("unknown general setting '{field}'"),
     }
     let _ = typ;
@@ -667,7 +668,6 @@ fn apply_proxy_value(
         "auto_start_timeout" => partial.auto_start_timeout = Some(value.to_string()),
         "sync_hosts" => partial.sync_hosts = Some(parse_bool_value(value)?),
         "wildcard" => partial.wildcard = Some(parse_bool_value(value)?),
-        "worktree" => partial.worktree = Some(parse_bool_value(value)?),
         "lan" => partial.lan = Some(parse_bool_value(value)?),
         "lan_ip" => partial.lan_ip = Some(value.to_string()),
         _ => bail!("unknown proxy setting '{field}'"),

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -1030,7 +1030,12 @@ impl PitchforkToml {
         // `[namespaces]`. Discovery spawns a `git`/`jj` subprocess (<1ms) and
         // the per-worktree config reads are cached by `CONFIG_CACHE`, so no
         // extra caching layer is needed here.
-        if let Some(project_root) = find_project_root(start_dir) {
+        //
+        // Controlled by the `general.worktree` setting (default on); when
+        // disabled, no discovery runs and no `git`/`jj` subprocess is spawned.
+        if crate::settings::settings().general.worktree
+            && let Some(project_root) = find_project_root(start_dir)
+        {
             let worktrees = crate::proxy::worktree::discover_worktrees(&project_root);
             for wt in &worktrees {
                 match Self::all_merged_from(&wt.path) {

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -94,7 +94,7 @@ static SLUG_CACHE: once_cell::sync::Lazy<tokio::sync::Mutex<SlugCache>> =
 fn build_slug_entries() -> std::collections::HashMap<String, CachedSlugEntry> {
     let global_slugs = crate::pitchfork_toml::PitchforkToml::read_global_slugs();
     let mut entries = std::collections::HashMap::with_capacity(global_slugs.len());
-    let worktree_enabled = crate::settings::settings().proxy.worktree;
+    let worktree_enabled = crate::settings::settings().general.worktree;
     for (slug, entry) in &global_slugs {
         let ns = entry.resolve_namespace();
         let daemon_name = entry.daemon.as_deref().unwrap_or(slug).to_string();


### PR DESCRIPTION
## Problem

The git/jj worktree auto-discovery added in #737 runs inside `PitchforkToml::all_merged_all_namespaces()` **without checking the existing `proxy.worktree` toggle**. The proxy slug-routing path checks the toggle; the config-discovery path does not.

Consequences for a supervisor whose sticky cwd is inside a git/jj repo:

- `jj workspace list` (plus `jj workspace root` per non-default workspace) is spawned on every cron tick (default every 10s), plus on boot start and file-watch init.
- When the supervisor runs as root (e.g. `sudo pitchfork` to manage docker), those `jj` subprocesses run as root. With jj's watchman integration, the root `jj` invocation wakes watchman into a system-wide root launchd task, which then updates the repo's `.jj` directory as root — breaking `jj` for the normal user.

## Change

- Promote `[proxy.worktree]` to a global setting `[general.worktree]` (default `true`, env `PITCHFORK_WORKTREE`).
- Make the config-discovery path (`all_merged_all_namespaces`) honor the toggle: when disabled, no worktree discovery runs and no `git`/`jj` subprocess is spawned.
- Update the proxy slug-routing path to read `general.worktree` so both paths share one switch.
- Update `pitchfork settings get/set` mappings (`general.worktree`).
- Keep `PITCHFORK_PROXY_WORKTREE` working via `deprecated_env` for env-var users.

Note: `[settings.proxy] worktree = false` in config files is silently ignored after this change (the settings generator does not support key aliases); only the env var keeps backward compatibility.

## Verification

- `mise run ci-dev` green: fmt + clippy, 678 unit tests, 308 bats integration tests, docs render.
- `pitchfork settings get general.worktree` → `true`; `proxy.worktree` → unknown setting.

*AI-assisted — Tool: opencode; model: venus/deepseek-v4-flash-official; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized `general.worktree` setting to control Git worktree and jj workspace auto-discovery, including proxy slug routing.
  * Worktree discovery is enabled by default; disabling it limits operation to the main project directory.

* **Documentation**
  * Updated configuration documentation and schema to reflect the new setting.
  * Removed the separate proxy-specific worktree configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->