### PR TITLE
docs: disable light mode

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -37,6 +37,8 @@ const latestVersion = versionMatch?.[1] ?? "0.0.0";
 export default defineConfig({
   title: "pitchfork",
   description: "A devilishly good process manager for developers",
+  // Dark-only site: forces the dark theme and hides the appearance toggle
+  appearance: "force-dark",
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [


### PR DESCRIPTION
Forces the docs site to always render in dark mode and removes the light/dark toggle from the nav.

Sets `appearance: "force-dark"` in `docs/.vitepress/config.mts`. VitePress then injects a script that unconditionally adds the `dark` class to `<html>` (no `localStorage` lookup, no flash) and drops the `VPSwitchAppearance` component from the nav and mobile menu.

Verified with `mise run build:docs`: the built HTML contains no `VPSwitchAppearance` and the inline script is a bare `classList.add("dark")`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only VitePress theme setting with no application, security, or data-handling impact.
> 
> **Overview**
> Locks the docs site to dark mode by setting `appearance: "force-dark"` in the VitePress config. This always applies the dark theme and hides the light/dark appearance toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f467cd9fa2d901f0ff86668ede0c117bfafb7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the documentation site to always use dark mode.
  * Removed the appearance toggle from the site interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->