### PR TITLE
docs: stop sponsor logos from stretching

### DIFF
--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -136,8 +136,10 @@ onMounted(async () => {
 
 .EndevSponsorsLogo img {
   display: block;
-  max-height: 22px;
+  height: 22px;
   max-width: 120px;
+  object-fit: contain;
+  width: auto;
 }
 
 .EndevSponsorsCta {


### PR DESCRIPTION
The sponsor logos in the docs footer render distorted on https://pitchfork.jdx.dev/ — most visibly the Entire title-sponsor lockup, which comes out horizontally stretched.

## Cause

`.EndevSponsorsLogo img` sized the logos with `max-height: 22px; max-width: 120px` only. `https://jdx.dev/sponsors/entire-lockup.svg` ships a `viewBox` with no `width`/`height`, so it has no intrinsic dimensions: the browser falls back to the 300×150 default object size, both max constraints clamp the box to 120×22, and the default `object-fit: fill` then stretches the artwork to fill it instead of keeping the ~4:1 lockup ratio.

## Fix

Pin the height, let the width follow from the aspect ratio, and add `object-fit: contain`:

```css
.EndevSponsorsLogo img {
  display: block;
  height: 22px;
  max-width: 120px;
  object-fit: contain;
  width: auto;
}
```

This is the same fix `mise`, `hk`, `usage`, and `fnox` already carry in their copies of `EndevSponsors.vue` — pitchfork, communique, and aube still have the old rule. (`communique` and `aube` are left for separate PRs.)

## Verification

- `mise run build:docs` — build succeeds, emitted CSS contains `.EndevSponsorsLogo img{display:block;height:22px;max-width:120px;object-fit:contain;width:auto}`
- `mise run lint` — clean

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic CSS-only change to docs sponsor logo sizing; no functional or security impact.
> 
> **Overview**
> Fixes distorted docs-footer sponsor logos by pinning image height and preserving aspect ratio.
> 
> `.EndevSponsorsLogo img` now uses `height: 22px`, `width: auto`, and `object-fit: contain` instead of `max-height` only, so SVGs without intrinsic size (notably the Entire lockup) no longer stretch to fill the 120×22 box.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb645f03bd40aa673ae3d3da9106c0c7a9ab0dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sponsor logo display by standardizing height, preserving image proportions, and allowing width to adjust automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->