### PR TITLE
fix(logs): preserve insertion order in log batches

### DIFF
--- a/src/log_store/sqlite.rs
+++ b/src/log_store/sqlite.rs
@@ -964,11 +964,13 @@ impl SqliteLogStore {
 
 impl LogStore for SqliteLogStore {
     fn append(&self, daemon_id: &DaemonId, message: &str) -> Result<()> {
-        let ts = Local::now().timestamp_millis();
         let id = daemon_id.qualified();
         let msg = message.to_string();
 
         let conn = self.conn.lock().unwrap();
+        // Sample while holding the lock so timestamp order matches insertion
+        // order under concurrent writers.
+        let ts = Local::now().timestamp_millis();
         let _ = conn
             .execute(
                 "INSERT INTO log_entries (daemon_id, timestamp, message) VALUES (?1, ?2, ?3)",
@@ -982,22 +984,31 @@ impl LogStore for SqliteLogStore {
         if messages.is_empty() {
             return Ok(());
         }
-        let base_ts = Local::now().timestamp_millis();
         let id = daemon_id.qualified();
 
         let mut conn = self.conn.lock().unwrap();
-        let tx = conn.transaction().into_diagnostic()?;
+        // IMMEDIATE acquires the write lock at BEGIN, and we sample only after
+        // that, so timestamp order matches commit order even across processes
+        // (sink subprocesses and the supervisor each hold their own
+        // SqliteLogStore instance on the same database).
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .into_diagnostic()?;
+        let base_ts = Local::now().timestamp_millis();
         {
             let mut stmt = tx
                 .prepare(
                     "INSERT INTO log_entries (daemon_id, timestamp, message) VALUES (?1, ?2, ?3)",
                 )
                 .into_diagnostic()?;
-            for (idx, msg) in messages.iter().enumerate() {
-                // Slightly stagger timestamps within a batch so ordering by
-                // (timestamp, id) preserves insertion order without paying for
-                // a separate per-row clock read.
-                let ts = base_ts + idx as i64;
+            for msg in messages.iter() {
+                // Use the same timestamp for the whole batch: `id` is
+                // AUTOINCREMENT (insertion order), and queries order by
+                // (timestamp, id), so equal timestamps still sort by
+                // insertion order. Staggering by `idx` instead overlaps with
+                // the timestamps of a later batch flushed within this batch's
+                // fabricated span, interleaving the two batches.
+                let ts = base_ts;
                 stmt.execute(params![id, ts, msg]).into_diagnostic()?;
             }
         }
@@ -1006,10 +1017,12 @@ impl LogStore for SqliteLogStore {
     }
 
     fn append_structured(&self, daemon_id: &DaemonId, parsed: &ParsedLog) -> Result<()> {
-        let ts = Local::now().timestamp_millis();
         let id = daemon_id.qualified();
 
         let conn = self.conn.lock().unwrap();
+        // Sample while holding the lock so timestamp order matches insertion
+        // order under concurrent writers.
+        let ts = Local::now().timestamp_millis();
         let _ = conn
             .execute(
                 "INSERT INTO log_entries (daemon_id, timestamp, message, level, msg, logger, fields_json) \
@@ -1024,11 +1037,17 @@ impl LogStore for SqliteLogStore {
         if entries.is_empty() {
             return Ok(());
         }
-        let base_ts = Local::now().timestamp_millis();
         let id = daemon_id.qualified();
 
         let mut conn = self.conn.lock().unwrap();
-        let tx = conn.transaction().into_diagnostic()?;
+        // IMMEDIATE acquires the write lock at BEGIN, and we sample only after
+        // that, so timestamp order matches commit order even across processes
+        // (sink subprocesses and the supervisor each hold their own
+        // SqliteLogStore instance on the same database).
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .into_diagnostic()?;
+        let base_ts = Local::now().timestamp_millis();
         {
             let mut stmt = tx
                 .prepare(
@@ -1036,8 +1055,12 @@ impl LogStore for SqliteLogStore {
                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                 )
                 .into_diagnostic()?;
-            for (idx, entry) in entries.iter().enumerate() {
-                let ts = base_ts + idx as i64;
+            for entry in entries.iter() {
+                // Same timestamp for the whole batch; queries order by
+                // (timestamp, id) and `id` is AUTOINCREMENT, so insertion
+                // order is preserved without the cross-batch overlap that
+                // staggered timestamps (`base_ts + idx`) caused.
+                let ts = base_ts;
                 stmt.execute(params![
                     id,
                     ts,
@@ -1490,6 +1513,80 @@ mod tests {
                 found,
                 BATCHES * PER_BATCH,
                 "writer {writer} lost entries: got {found}"
+            );
+        }
+    }
+
+    /// Regression for the "burst of log lines comes back out of order" bug:
+    /// rows within one batch must share a single timestamp instead of being
+    /// staggered by index. Staggered timestamps (`base_ts + idx`) overlap with
+    /// the timestamps of the next batch flushed moments later, interleaving the
+    /// two batches under `ORDER BY timestamp, id`.
+    #[test]
+    fn batch_rows_share_single_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logs.db");
+        let store = SqliteLogStore::open(&path).unwrap();
+        let id = DaemonId::try_new("test", "burst").unwrap();
+
+        let entries: Vec<ParsedLog> = (0..50)
+            .map(|i| crate::log_parse::parse(&format!("line-{i}"), "text"))
+            .collect();
+        store.append_structured_batch(&id, &entries).unwrap();
+
+        let conn = store.conn.lock().unwrap();
+        let timestamps: Vec<i64> = {
+            let mut stmt = conn
+                .prepare("SELECT timestamp FROM log_entries ORDER BY id")
+                .unwrap();
+            let rows = stmt.query_map([], |row| row.get::<_, i64>(0)).unwrap();
+            rows.map(|r| r.unwrap()).collect()
+        };
+        assert_eq!(timestamps.len(), 50);
+        let distinct: std::collections::HashSet<i64> = timestamps.into_iter().collect();
+        assert_eq!(
+            distinct.len(),
+            1,
+            "all rows in a batch must share one timestamp so (timestamp, id) ordering matches insertion order"
+        );
+    }
+
+    /// End-to-end regression for the reported repro (`run = "exec seq 500"`):
+    /// several batches flushed back-to-back must still read back in insertion
+    /// order. With staggered per-row timestamps the later batch's fabricated
+    /// span overlaps the earlier one and interleaves the output.
+    #[test]
+    fn burst_batches_preserve_insertion_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logs.db");
+        let store = SqliteLogStore::open(&path).unwrap();
+        let id = DaemonId::try_new("test", "burst").unwrap();
+
+        // 3 batches of 300 rows, appended as fast as possible — the staggered
+        // spans (300ms each) are far wider than the inter-batch gap, so the
+        // old code always overlapped and interleaved these.
+        const BATCHES: usize = 3;
+        const PER_BATCH: usize = 300;
+        for batch in 0..BATCHES {
+            let entries: Vec<ParsedLog> = (0..PER_BATCH)
+                .map(|i| crate::log_parse::parse(&format!("{}", batch * PER_BATCH + i), "text"))
+                .collect();
+            store.append_structured_batch(&id, &entries).unwrap();
+        }
+
+        let entries = store
+            .query(&LogQuery {
+                daemon_ids: vec![id.qualified()],
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(entries.len(), BATCHES * PER_BATCH);
+        for (n, entry) in entries.iter().enumerate() {
+            assert_eq!(
+                entry.message,
+                n.to_string(),
+                "log line {n} read back out of order (got '{}')",
+                entry.message
             );
         }
     }

--- a/src/proxy/worktree.rs
+++ b/src/proxy/worktree.rs
@@ -31,7 +31,7 @@ pub fn discover_worktrees(project_dir: &Path) -> Vec<WorktreeEntry> {
 
 fn discover_jj_workspaces(project_dir: &Path) -> Vec<WorktreeEntry> {
     let output = match Command::new("jj")
-        .args(["workspace", "list"])
+        .args(["--ignore-working-copy", "workspace", "list"])
         .current_dir(project_dir)
         .output()
     {
@@ -159,7 +159,7 @@ fn parse_jj_workspace_list(
 
 fn get_jj_workspace_root(project_dir: &Path, name: &str) -> Option<PathBuf> {
     let output = Command::new("jj")
-        .args(["workspace", "root", "--name", name])
+        .args(["--ignore-working-copy", "workspace", "root", "--name", name])
         .current_dir(project_dir)
         .output()
         .ok()?;


### PR DESCRIPTION
## Problem

`pitchfork logs` returns log entries out of order when a daemon emits a burst of lines (reported in discussion #758). Repro: `run = "exec seq 500"`, then `pitchfork logs` shows e.g. `... 371, 470, 372, 471, 472`.

## Root cause

Batch log writes (`append_batch` / `append_structured_batch` in `src/log_store/sqlite.rs`) fabricated per-row timestamps as `base_ts + idx` — 100 rows spanned 100ms of fake time. When a burst flushes several batches back-to-back (LOG_BATCH_SIZE=100, flush every 100ms), each later batch's fabricated span overlaps the earlier batch's span. `ORDER BY timestamp, id` then interleaves the batches, so read-back order diverges from insertion order.

## Change

- Use one wall-clock timestamp for the whole batch instead of staggering by index. `id` is `INTEGER PRIMARY KEY AUTOINCREMENT` (insertion order) and all log queries order by `(timestamp, id)`, so equal timestamps within a batch still read back in insertion order. Timestamps stay real (no fabricated time, no drift), and cross-batch overlap is impossible.
- Sample the batch timestamp only after acquiring the write turn: both batch methods now use `transaction_with_behavior(TransactionBehavior::Immediate)` (takes the SQLite write lock at BEGIN) and sample `base_ts` inside the transaction, so timestamp order matches commit order when concurrent writers race — including the sink subprocess and the supervisor writing the same database from separate `SqliteLogStore` instances. Single-row appends (`append`, `append_structured`) sample under the connection lock for the same reason (review feedback).
- jj workspace discovery (`src/proxy/worktree.rs`) now passes `--ignore-working-copy` to both `jj workspace list` and `jj workspace root --name`, so it reads repository metadata without touching the working copy snapshot (avoids filesystem scanning and watchman wakeups when a supervisor runs inside a jj repo).

## Verification

- New regression tests: `batch_rows_share_single_timestamp` (all rows in a batch share one timestamp) and `burst_batches_preserve_insertion_order` (3 batches × 300 rows read back 0..899 in order). Confirmed `burst_batches_preserve_insertion_order` fails against the old code and passes with the fix.
- `mise run ci-dev` green: fmt + clippy, 678 unit tests, 308 bats integration tests, docs render.
- End-to-end: built the binary, ran the exact repro (`seq 500`), `pitchfork logs` returns 1..500 in strict monotonic order.
- Concurrency tests (`write_waits_for_a_contended_lock`, `concurrent_writers_do_not_lose_batches`) still pass with the IMMEDIATE transactions.

*AI-assisted — Tool: opencode; model: venus/deepseek-v4-flash-official; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event ordering for records created in rapid succession.
  * Ensured all records in a batch share a consistent timestamp.
  * Improved consistency when recording individual and batched events under heavy activity.
  * Improved workspace discovery and root resolution when local working-copy state changes.
* **Tests**
  * Added regression coverage for batch timestamp consistency and insertion order.
  * Added validation for rapid consecutive event batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->