### PR TITLE
chore(release): regenerate cli docs for v2.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.23.0](https://github.com/jdx/pitchfork/compare/v2.22.0...v2.23.0) - 2026-08-23
+
+### Added
+
+- improve worktree lifecycle isolation ([#746](https://github.com/jdx/pitchfork/pull/746))
+
+### Fixed
+
+- *(logs)* preserve insertion order in log batches ([#761](https://github.com/jdx/pitchfork/pull/761))
+- *(config)* gate worktree auto-discovery behind global setting ([#755](https://github.com/jdx/pitchfork/pull/755))
+- *(deps)* update rust crate mdns-sd to 0.21 ([#751](https://github.com/jdx/pitchfork/pull/751))
+- *(config)* pass project mise setting to supervisor ([#750](https://github.com/jdx/pitchfork/pull/750))
+
+### Other
+
+- *(settings)* resolve settings with usage-config ([#756](https://github.com/jdx/pitchfork/pull/756))
+- *(cli)* replace clap with usage-rs ([#754](https://github.com/jdx/pitchfork/pull/754))
+- *(deps)* update rust crate tera to v2.1.1 ([#748](https://github.com/jdx/pitchfork/pull/748))
+
 ## [2.22.0](https://github.com/jdx/pitchfork/compare/v2.21.0...v2.22.0) - 2026-08-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,7 +2758,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.22.0"
+version = "2.23.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.22.0"
+version = "2.23.0"
 edition = "2024"
 resolver = "3"
 rust-version = "1.91"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5826,7 +5826,7 @@
       }
     ]
   },
-  "version": "2.22.0",
+  "version": "2.23.0",
   "usage": "",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `pitchfork <SUBCOMMAND>`
 
-**Version**: 2.22.0
+**Version**: 2.23.0
 
 - **Usage**: `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,7 +1,7 @@
 // @generated from usage-rs metadata
 name pitchfork
 bin pitchfork
-version "2.22.0"
+version "2.23.0"
 about "Daemons with DX"
 unknown_flags error
 external_subcommand #true


### PR DESCRIPTION
## Summary
- regenerate CLI usage artifacts after the v2.23.0 version bump
- update generated version metadata from 2.22.0 to 2.23.0

## Verification
- `mise run ci-dev`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and docs-only release metadata; no logic, auth, or data-handling changes.
> 
> **Overview**
> Bumps **pitchfork-cli** from `2.22.0` to `2.23.0` and records the release in `CHANGELOG.md`.
> 
> Generated CLI metadata (`pitchfork.usage.kdl`, `docs/cli/commands.json`, `docs/cli/index.md`) is updated to match the new version. No runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb455441f7227e1b3bda3afa14f379b70e260a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->