### PR TITLE
chore(ci): avoid stale release pr render failures

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -136,6 +136,11 @@ jobs:
         run: |
           aube install
           aube run build
+      # release-plz updates the PR before the next step can regenerate docs.
+      # Warm the render dependencies so the follow-up push supersedes that
+      # intermediate PR revision before its CI run reaches the render check.
+      - name: Warm render dependencies
+        run: mise run build
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
@@ -156,7 +161,7 @@ jobs:
           echo "Updating release PR on branch: $PR_BRANCH"
           git fetch origin "$PR_BRANCH"
           git checkout "$PR_BRANCH"
-          mise run render ::: lint-fix
+          mise run render
           git add -A
           if git diff --cached --quiet; then
             echo "No changes to commit"

--- a/mise.lock
+++ b/mise.lock
@@ -289,40 +289,40 @@ version = "stable"
 backend = "core:rust"
 
 [[tools.usage]]
-version = "5.0.0"
+version = "6.1.0"
 backend = "aqua:jdx/usage"
 
 [tools.usage."platforms.linux-arm64"]
-checksum = "sha256:fb2dfc21532129ce230314818e05a8a75ee1c8929936f8b3a5bbd078736706d7"
-url = "https://github.com/jdx/usage/releases/download/v5.0.0/usage-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/501424806"
+checksum = "sha256:bb52c86367cabd59d455debdc8402434a7863cc5d24b506e9230409a187ceb57"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532817"
 
 [tools.usage."platforms.linux-arm64-musl"]
-checksum = "sha256:fb2dfc21532129ce230314818e05a8a75ee1c8929936f8b3a5bbd078736706d7"
-url = "https://github.com/jdx/usage/releases/download/v5.0.0/usage-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/501424806"
+checksum = "sha256:bb52c86367cabd59d455debdc8402434a7863cc5d24b506e9230409a187ceb57"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532817"
 
 [tools.usage."platforms.linux-x64"]
-checksum = "sha256:16e87ac9110face925d39a9aae5c90767738df2cc390af1be1f00e625b599280"
-url = "https://github.com/jdx/usage/releases/download/v5.0.0/usage-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/501424566"
+checksum = "sha256:2ceec78d071d66a5dcdcc6ad68a5ee79c64fc6c2fbe0050d4f013dfbc3308ba2"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532821"
 
 [tools.usage."platforms.linux-x64-musl"]
-checksum = "sha256:16e87ac9110face925d39a9aae5c90767738df2cc390af1be1f00e625b599280"
-url = "https://github.com/jdx/usage/releases/download/v5.0.0/usage-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/501424566"
+checksum = "sha256:2ceec78d071d66a5dcdcc6ad68a5ee79c64fc6c2fbe0050d4f013dfbc3308ba2"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532821"
 
 [tools.usage."platforms.macos-arm64"]
-checksum = "sha256:35f1703ed922486387d499265c9d6c0dbc84b8347e565fb31d54ad23fdff712d"
-url = "https://github.com/jdx/usage/releases/download/v5.0.0/usage-universal-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/501428939"
+checksum = "sha256:317156bbd740ce95195e1016eb6800145944b4dbd2bd7e4f874684761b989524"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525531450"
 
 [tools.usage."platforms.macos-x64"]
-checksum = "sha256:35f1703ed922486387d499265c9d6c0dbc84b8347e565fb31d54ad23fdff712d"
-url = "https://github.com/jdx/usage/releases/download/v5.0.0/usage-universal-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/501428939"
+checksum = "sha256:317156bbd740ce95195e1016eb6800145944b4dbd2bd7e4f874684761b989524"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525531450"
 
 [tools.usage."platforms.windows-x64"]
-checksum = "sha256:0ca7cbc821d6fe274ef42162058935261bf0f7ad8029a197275ff83cc36d996e"
-url = "https://github.com/jdx/usage/releases/download/v5.0.0/usage-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/501427490"
+checksum = "sha256:816843e71bf5ecc2d458b328b89edc771ca0a1f8b1777ff7be254007920a64bf"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525535418"

--- a/mise.toml
+++ b/mise.toml
@@ -71,20 +71,14 @@ outputs = ["dist/**/*"]
 dir = "docs"
 run = "aube install && exec aube run docs:build"
 
-[tasks."build:usage"]
-description = "Build the usage CLI matching the generated spec dialect"
-run = "cargo install --force --locked --root .mise/usage-cli-6 --version 6.1.0 usage-cli"
-sources = ["Cargo.lock", "mise.toml"]
-outputs = [".mise/usage-cli-6/bin/usage"]
-
 [tasks.render]
-depends = ["build", "build:usage"]
+depends = ["build"]
 # Render with the released CLI matching the usage-rs major version.
 run = [
   "pitchfork usage > pitchfork.usage.kdl",
   "rm -rf docs/cli && mkdir -p docs/cli",
-  ".mise/usage-cli-6/bin/usage g markdown -mf pitchfork.usage.kdl --out-dir docs/cli --url-prefix /cli",
-  ".mise/usage-cli-6/bin/usage g json -f pitchfork.usage.kdl > docs/cli/commands.json",
+  "usage g markdown -mf pitchfork.usage.kdl --out-dir docs/cli --url-prefix /cli",
+  "usage g json -f pitchfork.usage.kdl > docs/cli/commands.json",
   "pitchfork schema > docs/public/schema.json",
   "pitchfork api-schema > docs/public/api-schema.json",
   "git add pitchfork.usage.kdl docs",
@@ -99,6 +93,7 @@ run = [
 ]
 
 [tools]
+usage = "6.1.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in pitchfork's numbers, indistinguishable from a real regression. Bump deliberately.


### PR DESCRIPTION
## Summary

- manage usage-cli as the pinned precompiled mise `usage` tool
- prebuild Pitchfork before release-plz updates the release PR
- render the updated release PR immediately after checkout

This lets the follow-up generated-docs push supersede the intermediate release-plz revision before CI reaches the render check, without compiling usage-cli in the workflow.

## Verification

- mise run ci-dev
- mise x actionlint@1.7.7 shellcheck@0.11.0 -- actionlint .github/workflows/release-plz.yml
- MISE_LOCKED=1 mise install usage@6.1.0
- usage --version

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow by preparing required build resources before publishing.
  * Streamlined documentation regeneration for more consistent results.
  * Updated the project tool configuration to use a pinned version of the usage utility.
  * Simplified the build and documentation generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->