### PR TITLE
chore: generate release notes before publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -115,7 +115,7 @@ jobs:
     name: Publish release
     needs: [release-plz-release, upload-assets, enhance-release]
     if: >-
-      ${{ always() && needs.upload-assets.result == 'success' && needs.enhance-release.result == 'success' && (inputs.tag != '' || needs.release-plz-release.outputs.tag != '') }}
+      ${{ !cancelled() && (needs.release-plz-release.result == 'success' || (needs.release-plz-release.result == 'skipped' && inputs.tag != '')) && needs.upload-assets.result == 'success' && needs.enhance-release.result == 'success' && (inputs.tag != '' || needs.release-plz-release.outputs.tag != '') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing tag to finish releasing (e.g. v2.7.0). Skips release-plz, runs upload-assets + enhance-release."
+        description: "Existing tag to finish releasing (e.g. v2.7.0). Skips release-plz, uploads assets, enhances notes, and publishes."
         required: true
         type: string
 
@@ -71,9 +71,9 @@ jobs:
 
   enhance-release:
     name: Enhance release notes
-    needs: [release-plz-release, upload-assets]
+    needs: release-plz-release
     if: >-
-      ${{ always() && needs.upload-assets.result == 'success' && (inputs.tag != '' || needs.release-plz-release.outputs.tag != '') }}
+      ${{ always() && (inputs.tag != '' || needs.release-plz-release.outputs.tag != '') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -110,6 +110,22 @@ jobs:
           EOF
           } > /tmp/release-notes.md
           gh release edit "$TAG" --notes-file /tmp/release-notes.md
+
+  publish-release:
+    name: Publish release
+    needs: [release-plz-release, upload-assets, enhance-release]
+    if: >-
+      ${{ always() && needs.upload-assets.result == 'success' && needs.enhance-release.result == 'success' && (inputs.tag != '' || needs.release-plz-release.outputs.tag != '') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ inputs.tag != '' && inputs.tag || needs.release-plz-release.outputs.tag }}
+    steps:
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+        run: gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false
 
   release-plz-pr:
     name: Release PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,15 +99,3 @@ jobs:
           ref: refs/tags/${{ inputs.tag }}
           token: ${{ secrets.GITHUB_TOKEN }}
           profile: serious
-
-  publish-release:
-    needs: [upload-assets]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Publish release
-        run: |
-          echo "Publishing release ${INPUTS_TAG}..."
-          gh release edit "${INPUTS_TAG}" --repo "${{ github.repository }}" --draft=false
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUTS_TAG: ${{ inputs.tag }}


### PR DESCRIPTION
## Summary

- keep the reusable binary workflow focused on uploading assets
- enhance the release-plz draft in parallel with binary uploads
- publish only after both jobs succeed, including manual tag recovery runs

## Validation

- actionlint with ShellCheck enabled
- git diff --check
- verified release-plz creates drafts and the reusable workflow no longer publishes them

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub release publish gate in CI. A bad job condition could leave drafts unpublished or publish before assets/notes are complete.
> 
> **Overview**
> Keeps GitHub releases as drafts until both binaries and enhanced notes are ready, then publishes them from `release-plz.yml`.
> 
> The reusable `release.yml` workflow now only uploads assets. Note generation runs in parallel with uploads instead of waiting on them. A new `publish-release` job undrafts the tag only after `upload-assets` and `enhance-release` succeed, including manual tag recovery runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09485264b147a6e91d0cba0d3bf7b3cc976fd444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release publishing now completes automatically after release assets are uploaded and release notes are enhanced.
  * Finishing an existing release also publishes it.
* **Bug Fixes**
  * Improved release workflow coordination to prevent releases from remaining in draft status.
  * Release asset uploads now integrate more reliably with the final publishing step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

