### PR TITLE
chore(ci): adopt mbx for Rust builds

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
+        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/pitchfork
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,0 +1,13 @@
+name: Set up mbx
+description: Select the trusted jdx server or fork-safe GitHub cache backend
+
+runs:
+  using: composite
+  steps:
+    - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
+      with:
+        version: 0.3.0
+        backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
+        server-url: https://cache.mise.jdx.dev
+        namespace: jdx/pitchfork
+        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
-        version: 0.3.0
+        version: 0.4.0
         backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/pitchfork

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - run: rm -rf .cargo
       - uses: ./.github/actions/mbx
       - run: mise run build:ui
-      - run: mbx build build
+      - run: mbx build
       - run: mise run lint
       - run: mise run render
       - name: assert render produces no diff
@@ -46,7 +46,7 @@ jobs:
             git diff HEAD
             exit 1
           fi
-      - run: mbx build nextest run
+      - run: mbx nextest run
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pitchfork-debug
@@ -105,7 +105,7 @@ jobs:
           aube install
           aube run build
       - name: Run Rust tests
-        run: mbx build nextest run --all-features
+        run: mbx nextest run --all-features
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pitchfork-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
           aube install
           aube run build
       - name: Run Rust tests
+        shell: bash
         run: |
           mbx build --all-features
           mbx nextest run --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         tranche: [0, 1]
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -105,11 +105,14 @@ jobs:
           aube install
           aube run build
       - name: Run Rust tests
-        run: mbx nextest run --all-features
+        run: |
+          mbx build --all-features
+          mbx nextest run --all-features
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pitchfork-windows
           path: target/debug/pitchfork.exe
+          if-no-files-found: error
 
   bats-tests:
     needs: rust-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,11 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 10
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -32,12 +33,9 @@ jobs:
         with:
           cache: false
       - run: rm -rf .cargo
-      # save-if gates cache writes to main so PRs can only restore, not poison.
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # zizmor: ignore[cache-poisoning] v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: ./.github/actions/mbx
       - run: mise run build:ui
-      - run: cargo build
+      - run: mbx build build
       - run: mise run lint
       - run: mise run render
       - name: assert render produces no diff
@@ -48,7 +46,7 @@ jobs:
             git diff HEAD
             exit 1
           fi
-      - run: cargo nextest run
+      - run: mbx build nextest run
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pitchfork-debug
@@ -62,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         tranche: [0, 1]
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -72,9 +70,6 @@ jobs:
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # zizmor: ignore[cache-poisoning] v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: pitchfork-debug
@@ -94,6 +89,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -102,18 +98,21 @@ jobs:
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # zizmor: ignore[cache-poisoning] v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: ./.github/actions/mbx
       - name: Build UI assets
         working-directory: ui
         run: |
           aube install
           aube run build
       - name: Run Rust tests
-        run: cargo nextest run --all-features
+        run: mbx build nextest run --all-features
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pitchfork-windows
+          path: target/debug/pitchfork.exe
 
   bats-tests:
+    needs: rust-tests
     runs-on: windows-latest
     timeout-minutes: 30
     permissions:
@@ -127,24 +126,16 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # zizmor: ignore[cache-poisoning] v2
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          shared-key: windows-ci-bats
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          name: pitchfork-windows
+          path: target/debug
       - name: Install sqlite3
         shell: pwsh
         run: choco install sqlite -y --no-progress
       - name: Create UI placeholder
         shell: bash
         run: mkdir -p ui/dist && echo '<html><body>placeholder</body></html>' > ui/dist/index.html
-      - name: Build (skip if cached)
-        shell: bash
-        run: |
-          if [ -f target/debug/pitchfork.exe ]; then
-            echo "pitchfork.exe found in cache, skipping cargo build"
-          else
-            cargo build --all-features
-          fi
       - name: Run bats e2e tests (shard ${{ matrix.shard }})
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           cache: false
       - run: rm -rf .cargo
       - uses: ./.github/actions/mbx
+      - name: Install Rust components
+        run: rustup component add rustfmt clippy
       - run: mise run build:ui
       - run: mbx build
       - run: mise run lint

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -34,6 +34,8 @@ jobs:
           persist-credentials: false
       - name: Install mise
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          cache: false
       - name: Build UI assets
         working-directory: ui
         run: |
@@ -85,6 +87,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          cache: false
       - run: communique generate "$TAG" --github-release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
@@ -147,6 +151,8 @@ jobs:
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install mise
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          cache: false
       - name: Build UI assets
         working-directory: ui
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
           persist-credentials: false
       - name: Install mise
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          cache: false
       - name: Build UI assets
         working-directory: ui
         run: |
@@ -66,9 +68,6 @@ jobs:
         uses: taiki-e/setup-cross-toolchain-action@12b7ad4acfa95a1476779d6c06699b96ec1691f8 # v1.42.0
         with:
           target: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-        with:
-          shared-key: rust-${{ matrix.target }}
       - name: Upload binary (macOS signed)
         if: startsWith(matrix.os, 'macos')
         uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # CLAUDE.md
 
+## mbx build cache
+
+Compilation-heavy mise tasks and hk checks use `mbx`. If an mbx command fails
+or creates a development papercut, rerun the exact equivalent `cargo` command
+from `CONTRIBUTING.md`; this unblocks work without weakening the check. If Cargo
+succeeds, surface the mismatch and recommend a
+[mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
+the repository and commit, OS, `mbx --version`, both commands and outputs, the
+cache summary, and `MBX_BYPASS_LOG` details when relevant. Do not silently make
+Cargo the permanent path, and do not post externally without user authorization.
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Build Commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ cargo build
 cargo nextest run
 git submodule update --init --recursive
 mise run test:bats
-cargo clippy --manifest-path Cargo.toml --quiet
+cargo clippy --manifest-path Cargo.toml --quiet -- -D warnings
 ```
 
 If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,23 @@
 # Contributing
 
 See the [contributing guide](https://pitchfork.jdx.dev/contributing).
+
+## mbx build cache
+
+The normal `mise run build`, `mise run test`, and `mise run lint` workflows use
+[mbx](https://mr-boxington.jdx.dev) for compilation-heavy Cargo work. If mbx
+appears to be the problem, first run `mise run build:ui`, then use the
+equivalent Cargo commands to unblock yourself without skipping or weakening the
+check:
+
+```sh
+cargo build
+cargo nextest run
+cargo clippy --manifest-path Cargo.toml --quiet
+```
+
+If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a
+[mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
+Include the repository and commit, operating system, `mbx --version`, both
+commands and their output, the mbx cache summary, and an `MBX_BYPASS_LOG` when
+relevant (for example, `MBX_BYPASS_LOG=mbx-bypasses.log mise run build`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ check:
 ```sh
 cargo build
 cargo nextest run
+git submodule update --init --recursive
+mise run test:bats
 cargo clippy --manifest-path Cargo.toml --quiet
 ```
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -4,7 +4,7 @@ import "package://github.com/jdx/hk/releases/download/v1.44.3/hk@1.44.3#/Builtin
 local linters = new Mapping<String, Step> {
     ["cargo_fmt"] = Builtins.cargo_fmt
     ["cargo_clippy"] = (Builtins.cargo_clippy) {
-        check = "mbx clippy --manifest-path {{workspace_indicator}} --quiet"
+        check = "mbx clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
     }
     ["pkl"] {
         glob = "*.pkl"

--- a/hk.pkl
+++ b/hk.pkl
@@ -4,7 +4,7 @@ import "package://github.com/jdx/hk/releases/download/v1.44.3/hk@1.44.3#/Builtin
 local linters = new Mapping<String, Step> {
     ["cargo_fmt"] = Builtins.cargo_fmt
     ["cargo_clippy"] = (Builtins.cargo_clippy) {
-        check = "mbx build clippy --manifest-path {{workspace_indicator}} --quiet"
+        check = "mbx clippy --manifest-path {{workspace_indicator}} --quiet"
     }
     ["pkl"] {
         glob = "*.pkl"

--- a/hk.pkl
+++ b/hk.pkl
@@ -3,7 +3,9 @@ import "package://github.com/jdx/hk/releases/download/v1.44.3/hk@1.44.3#/Builtin
 
 local linters = new Mapping<String, Step> {
     ["cargo_fmt"] = Builtins.cargo_fmt
-    ["cargo_clippy"] = Builtins.cargo_clippy
+    ["cargo_clippy"] = (Builtins.cargo_clippy) {
+        check = "mbx build clippy --manifest-path {{workspace_indicator}} --quiet"
+    }
     ["pkl"] {
         glob = "*.pkl"
         check = "pkl eval {{files}} >/dev/null"

--- a/mise.lock
+++ b/mise.lock
@@ -139,43 +139,43 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633
 provenance = "github-attestations"
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.3.0"
+version = "0.4.0"
 backend = "github:jdx/mr-boxington"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:1803cec79be0b753fc3af23044edc46fd81ffdf9d66fcb7b6637cfb22cc6db4a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704881"
+checksum = "sha256:416cab92e23c4652183e4a794af3fdcbc50b56296d8c09f8b6548e7577416307"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719398"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-x64"]
-checksum = "sha256:72a98d019b83859e465d30a91422e7b2eb72cf53fb42e116a277865310392c0c"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704883"
+checksum = "sha256:9f1016b0592ffd3b4b4000640223e10a2100cc6136d722fac5c4829cb89fc7ed"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719400"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+checksum = "sha256:f841b1907cf86c54db4d3d2d1e88f87303ccc8f720efff90b6331d7d5592bf4e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719397"
 
 [[tools."github:jdx/tak"]]
 version = "0.0.5"

--- a/mise.lock
+++ b/mise.lock
@@ -138,6 +138,45 @@ url = "https://github.com/jdx/communique/releases/download/v1.3.2/communique-x86
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633"
 provenance = "github-attestations"
 
+[[tools."github:jdx/mr-boxington"]]
+version = "0.3.0"
+backend = "github:jdx/mr-boxington"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
+checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
+checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64"]
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+
+[tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
+checksum = "sha256:1803cec79be0b753fc3af23044edc46fd81ffdf9d66fcb7b6637cfb22cc6db4a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704881"
+
+[tools."github:jdx/mr-boxington"."platforms.macos-x64"]
+checksum = "sha256:72a98d019b83859e465d30a91422e7b2eb72cf53fb42e116a277865310392c0c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704883"
+
+[tools."github:jdx/mr-boxington"."platforms.windows-x64"]
+checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+
 [[tools."github:jdx/tak"]]
 version = "0.0.5"
 backend = "github:jdx/tak"

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ _.path = ["target/debug", "test/bats/bin"]
 [tasks.test]
 depends = ["build:ui"]
 run = [
-  "mbx build nextest run",
+  "mbx nextest run",
   "git submodule update --init --recursive",
   "mise run test:bats",
 ]
@@ -50,7 +50,7 @@ run = "hk fix --all"
 
 [tasks.build]
 depends = ["build:ui"]
-run = ["mbx build build"]
+run = ["mbx build"]
 
 [tasks."test:web-ui"]
 depends = ["build"]

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ _.path = ["target/debug", "test/bats/bin"]
 [tasks.test]
 depends = ["build:ui"]
 run = [
-  "cargo nextest run",
+  "mbx build nextest run",
   "git submodule update --init --recursive",
   "mise run test:bats",
 ]
@@ -50,7 +50,7 @@ run = "hk fix --all"
 
 [tasks.build]
 depends = ["build:ui"]
-run = ["cargo build"]
+run = ["mbx build build"]
 
 [tasks."test:web-ui"]
 depends = ["build"]
@@ -93,6 +93,7 @@ run = [
 ]
 
 [tools]
+"github:jdx/mr-boxington" = "latest"
 usage = "6.4.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change


### PR DESCRIPTION
## Summary

- route compilation-heavy local mise tasks and hk checks through mbx
- configure trusted Namespace jobs for the jdx server cache and fork-safe GitHub-hosted cache restores
- document exact Cargo fallbacks and the mr-boxington Discussions escalation path
- use the direct Cargo-subcommand syntax released in mbx 0.4.0
- pin local and CI setup to mbx 0.4.0
- ensure release, publishing, and packaging builds never restore or save persistent caches

## Validation

- resolved the committed mise lock to mbx 0.4.0
- installed the locked tool and confirmed `mbx 0.4.0`
- evaluated the mise configuration and task list
- confirmed `mbx build` direct syntax
- ran actionlint over changed workflows
- audited release and publish entrypoints for Rust, Actions, Namespace, mise, Node, and mbx caches

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI handling for pull requests, including Dependabot and fork contributions.
  * Added explicit Windows build validation and clearer artifact failure reporting.
  * Updated development and release workflows for more consistent builds, tests, caching, and tool setup.
  * Standardized local tasks around the project’s build and test commands.

* **Documentation**
  * Expanded troubleshooting guidance with fallback build commands, submodule setup, test instructions, and diagnostics.
  * Documented requirements for reporting cache issues through external discussions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI and local dev now depend on mbx for builds and tests; a cache or wrapper bug could block merges until Cargo fallbacks are used, and runner/OIDC cache routing changes affect fork vs trusted PR behavior.
> 
> **Overview**
> **Replaces `Swatinem/rust-cache` and direct `cargo` invocations with [mbx](https://mr-boxington.jdx.dev) (pinned 0.4.0)** for compilation-heavy build, test, and clippy paths in `mise.toml`, `hk.pkl`, and CI.
> 
> Adds a composite **`.github/actions/mbx`** step that wires `mr-boxington-action` to the jdx OIDC cache server on trusted runs, and to a **GitHub-hosted cache backend** for fork PRs and Dependabot so untrusted jobs cannot use the shared server cache.
> 
> **Linux CI** now runs on Namespace (`namespace-profile-endev-linux-amd64`) for in-repo PRs/pushes while fork/Dependabot PRs stay on `ubuntu-latest`; jobs that use mbx get `id-token: write`. **Windows** builds/tests go through mbx, upload `pitchfork-windows` artifacts, and **bats** shards download that binary instead of rebuilding from `rust-cache`.
> 
> **Release and publish workflows** disable `mise-action` caching and drop `rust-cache` from binary uploads so release builds are not tied to persistent Rust caches. **AGENTS.md** and **CONTRIBUTING.md** document Cargo fallbacks and mr-boxington escalation when mbx misbehaves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41a0f727011763bdac2bf88bd7ddca5e90e72a5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->