### PR TITLE
chore(sponsors): replace 37signals with omacom foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,22 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://omarchy.org/patrons/">Omacom Foundation</a>.<br>
-  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
+  Sponsored by<br><br>
+  <a href="https://entire.io">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/entire-lockup.svg">
+      <img src="https://jdx.dev/sponsors/entire-lockup-on-light.svg" alt="Entire" height="36">
+    </picture>
+  </a>
+  &nbsp;&nbsp;&nbsp;
+  <a href="https://omarchy.org/patrons/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/omacom-foundation.svg">
+      <img src="https://jdx.dev/sponsors/omacom-foundation-on-light.svg" alt="Omacom Foundation" height="36">
+    </picture>
+  </a>
+  <br><br>
+  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>
 </p>
 
 <hr />

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://37signals.com">37signals</a>.<br>
+  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://omarchy.org/patrons/">Omacom Foundation</a>.<br>
   <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -10,7 +10,7 @@ impl Sponsors {
             r#"pitchfork and the jdx.dev open source tools are sponsored by:
 
   entire.io - https://entire.io
-  37signals - https://37signals.com
+  Omacom Foundation - https://omarchy.org/patrons/
 
 View all sponsors: https://jdx.dev/sponsors.html"#
         );


### PR DESCRIPTION
## Summary
- replace 37signals with the Omacom Foundation in the README and `pitchfork sponsors` output
- add linked, theme-aware Entire and Omarchy wordmarks to the README

## Verification
- `mise run ci-dev` (701 Rust tests and 308 Bats tests passed before the README-only follow-up)

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*