### PR TITLE
fix: allow repeatable usage file attributes

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -996,6 +996,8 @@ pub struct SettingsWeb {
 /// from these fields; the CLI's emitted spec carries the `config` block
 /// through `#[usage(config = ...)]` on the root.
 #[derive(usage_rs::Config, Debug, Clone, PartialEq)]
+// `file(...)` is intentionally repeatable in usage's configuration DSL.
+#[allow(clippy::duplicated_attributes)]
 #[usage(
     file(path = "/etc/pitchfork/config.toml", scope = "system", format = "toml"),
     file(


### PR DESCRIPTION
## Summary

- document that repeated `file(...)` entries are intentional usage macro configuration
- suppress Rust 1.98 clippy's `duplicated_attributes` false positive for that derive input

## Validation

- `git diff --check`
- `cargo clippy --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and lint suppression only; settings resolution and file precedence are unchanged.
> 
> **Overview**
> Adds a short comment on the root **`Settings`** `#[usage(...)]` block clarifying that multiple **`file(...)`** entries are deliberate usage-config DSL, not accidental duplicate attributes.
> 
> Adds **`#[allow(clippy::duplicated_attributes)]`** so Rust 1.98 Clippy with **`-D warnings`** no longer fails on those repeated **`file(...)`** lines. **No** change to which config paths are registered or how settings are loaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3653ffaef30c232edf8a8f713070be1ebf37cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Suppressed a static-analysis warning caused by intentionally repeated configuration entries.
  * No functional or user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->