### PR TITLE
security(ci): restrict trusted mbx runs to jdx

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'github' || 'server' }}
+        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/pitchfork
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         tranche: [0, 1]
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

- reserve Namespace runners and the server cache for same-repository PRs authored by `jdx`
- route every other PR author, including dependency bots, through GitHub-hosted runners and GitHub cache
- keep trusted-only repository secrets unavailable to non-`jdx` PRs

## Validation

- `git diff --check`
- actionlint workflow and expression validation
- confirmed no dependency-bot-specific trust predicates remain

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request workflows to select execution environments based on whether changes come from trusted same-repository sources or external contributors.
  * Improved cache backend selection for pull request builds.
  * Maintained specialized handling for trusted repository-authored changes while using GitHub infrastructure for other pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->