### PR TITLE
security(ci): isolate mbx OIDC permissions

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
+        backend: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/pitchfork
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,13 +1,18 @@
 name: Set up mbx
 description: Select the trusted jdx server or fork-safe GitHub cache backend
 
+inputs:
+  backend:
+    description: Explicit backend for structurally trusted or untrusted callers
+    default: auto
+
 runs:
   using: composite
   steps:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server' }}
+        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/pitchfork
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -2,6 +2,13 @@ name: ci implementation
 
 on:
   workflow_call:
+    inputs:
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,9 +20,14 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 10
     steps:
+      - name: Assert OIDC is unavailable to untrusted CI
+        if: ${{ !inputs.trusted }}
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
@@ -25,6 +37,8 @@ jobs:
           cache: false
       - run: rm -rf .cargo
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - run: mise run build:ui
@@ -53,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         tranche: [0, 1]
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -89,6 +103,8 @@ jobs:
         with:
           cache: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - name: Build UI assets
         working-directory: ui
         run: |

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -1,0 +1,192 @@
+name: ci implementation
+
+on:
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  MISE_EXPERIMENTAL: true
+
+jobs:
+  build:
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+          persist-credentials: false
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+      - run: rm -rf .cargo
+      - uses: ./.github/actions/mbx
+      - name: Install Rust components
+        run: rustup component add rustfmt clippy
+      - run: mise run build:ui
+      - run: mbx build
+      - run: mise run lint
+      - run: mise run render
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff HEAD
+            exit 1
+          fi
+      - run: mbx nextest run
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pitchfork-debug
+          path: target/debug/pitchfork
+
+  ci-bats:
+    needs: build
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        tranche: [0, 1]
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+          persist-credentials: false
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: pitchfork-debug
+          path: target/debug
+      - run: chmod +x target/debug/pitchfork
+      - run: sudo apt-get update && sudo apt-get install -y parallel
+      - run: mise run test:bats
+        env:
+          TRANCHE: ${{ matrix.tranche }}
+          TRANCHE_COUNT: 2
+
+  # Windows coverage lives in this workflow (rather than a separate one) so the
+  # `final` aggregator below can gate on it — a job's `needs:` cannot reference
+  # jobs in another workflow file.
+  rust-tests:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+          persist-credentials: false
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+      - uses: ./.github/actions/mbx
+      - name: Build UI assets
+        working-directory: ui
+        run: |
+          aube install
+          aube run build
+      - name: Run Rust tests
+        shell: bash
+        run: |
+          mbx build --all-features
+          mbx nextest run --all-features
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pitchfork-windows
+          path: target/debug/pitchfork.exe
+          if-no-files-found: error
+
+  bats-tests:
+    needs: rust-tests
+    runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: pitchfork-windows
+          path: target/debug
+      - name: Install sqlite3
+        shell: pwsh
+        run: choco install sqlite -y --no-progress
+      - name: Create UI placeholder
+        shell: bash
+        run: mkdir -p ui/dist && echo '<html><body>placeholder</body></html>' > ui/dist/index.html
+      - name: Run bats e2e tests (shard ${{ matrix.shard }})
+        shell: bash
+        env:
+          SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: 4
+          # Windows runners have slow, highly variable process/bash startup, which
+          # makes the timing-sensitive e2e assertions (ready-delay windows, elapsed
+          # bounds) flaky. Retry each failed test a couple of times so transient
+          # timing slips don't red the build; genuine failures still fail 3x.
+          # Consumed by _common_setup, which sets bats' BATS_TEST_RETRIES from it
+          # (bats resets BATS_TEST_RETRIES to 0 per file, so the env var alone
+          # would be ignored).
+          PITCHFORK_TEST_RETRIES: 2
+        run: |
+          export PATH="$PWD/target/debug:$PATH"
+          tests=$(ls -1 test/*.bats | sort | awk -v t="$SHARD" -v n="$SHARD_COUNT" 'NR % n == t')
+          echo "Running shard $SHARD: $tests"
+          test/bats/bin/bats $tests
+
+  # Aggregator that required-status-checks can target. If any upstream job
+  # failed, was cancelled, or was skipped, this step exits non-zero so the PR is
+  # blocked. Lets the branch-protection rule depend on one name instead of N.
+  final:
+    needs:
+      - build
+      - ci-bats
+      - rust-tests
+      - bats-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Gate on upstream job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          failed = False
+          for name, data in sorted(needs.items()):
+              result = data.get("result", "unknown")
+              if result == "success":
+                  print(f"::notice::{name}: {result}")
+              else:
+                  print(f"::error::{name}: {result}")
+                  failed = True
+
+          if failed:
+              print("One or more upstream jobs did not complete successfully.")
+              sys.exit(1)
+
+          print("All CI jobs completed successfully.")
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,22 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/ci-impl.yml
+    with:
+      trusted: true
+      mbx-backend: server
 
   untrusted:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
     uses: ./.github/workflows/ci-impl.yml
+    with:
+      trusted: false
+      mbx-backend: github
 
   final:
     name: final
-    if: ${{ always() && !cancelled() }}
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
     permissions: {}
     needs: [trusted, untrusted]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,198 +7,38 @@ on:
     tags: ["*"]
     branches: ["main"]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions: {}
 
-env:
-  CARGO_TERM_COLOR: always
-  MISE_EXPERIMENTAL: true
-
 jobs:
-  build:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 10
+  trusted:
+    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
       id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: true
-          persist-credentials: false
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: false
-      - run: rm -rf .cargo
-      - uses: ./.github/actions/mbx
-      - name: Install Rust components
-        run: rustup component add rustfmt clippy
-      - run: mise run build:ui
-      - run: mbx build
-      - run: mise run lint
-      - run: mise run render
-      - name: assert render produces no diff
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::error::'mise run render' produced changes. Run it locally and commit."
-            git status
-            git diff HEAD
-            exit 1
-          fi
-      - run: mbx nextest run
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: pitchfork-debug
-          path: target/debug/pitchfork
+    uses: ./.github/workflows/ci-impl.yml
 
-  ci-bats:
-    needs: build
+  untrusted:
+    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        tranche: [0, 1]
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: true
-          persist-credentials: false
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: pitchfork-debug
-          path: target/debug
-      - run: chmod +x target/debug/pitchfork
-      - run: sudo apt-get update && sudo apt-get install -y parallel
-      - run: mise run test:bats
-        env:
-          TRANCHE: ${{ matrix.tranche }}
-          TRANCHE_COUNT: 2
+    uses: ./.github/workflows/ci-impl.yml
 
-  # Windows coverage lives in this workflow (rather than a separate one) so the
-  # `final` aggregator below can gate on it — a job's `needs:` cannot reference
-  # jobs in another workflow file.
-  rust-tests:
-    runs-on: windows-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: true
-          persist-credentials: false
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: false
-      - uses: ./.github/actions/mbx
-      - name: Build UI assets
-        working-directory: ui
-        run: |
-          aube install
-          aube run build
-      - name: Run Rust tests
-        shell: bash
-        run: |
-          mbx build --all-features
-          mbx nextest run --all-features
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: pitchfork-windows
-          path: target/debug/pitchfork.exe
-          if-no-files-found: error
-
-  bats-tests:
-    needs: rust-tests
-    runs-on: windows-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1, 2, 3]
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: true
-          persist-credentials: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: pitchfork-windows
-          path: target/debug
-      - name: Install sqlite3
-        shell: pwsh
-        run: choco install sqlite -y --no-progress
-      - name: Create UI placeholder
-        shell: bash
-        run: mkdir -p ui/dist && echo '<html><body>placeholder</body></html>' > ui/dist/index.html
-      - name: Run bats e2e tests (shard ${{ matrix.shard }})
-        shell: bash
-        env:
-          SHARD: ${{ matrix.shard }}
-          SHARD_COUNT: 4
-          # Windows runners have slow, highly variable process/bash startup, which
-          # makes the timing-sensitive e2e assertions (ready-delay windows, elapsed
-          # bounds) flaky. Retry each failed test a couple of times so transient
-          # timing slips don't red the build; genuine failures still fail 3x.
-          # Consumed by _common_setup, which sets bats' BATS_TEST_RETRIES from it
-          # (bats resets BATS_TEST_RETRIES to 0 per file, so the env var alone
-          # would be ignored).
-          PITCHFORK_TEST_RETRIES: 2
-        run: |
-          export PATH="$PWD/target/debug:$PATH"
-          tests=$(ls -1 test/*.bats | sort | awk -v t="$SHARD" -v n="$SHARD_COUNT" 'NR % n == t')
-          echo "Running shard $SHARD: $tests"
-          test/bats/bin/bats $tests
-
-  # Aggregator that required-status-checks can target. If any upstream job
-  # failed, was cancelled, or was skipped, this step exits non-zero so the PR is
-  # blocked. Lets the branch-protection rule depend on one name instead of N.
   final:
-    needs:
-      - build
-      - ci-bats
-      - rust-tests
-      - bats-tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
+    name: final
+    if: ${{ always() && !cancelled() }}
     permissions: {}
-    # Run on success or upstream failure but skip when the workflow is cancelled
-    # — `always()` would override `cancel-in-progress` and waste a runner.
-    if: ${{ !cancelled() }}
+    needs: [trusted, untrusted]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
-      - name: Gate on upstream job results
+      - name: Check selected workflow result
         env:
-          NEEDS_JSON: ${{ toJSON(needs) }}
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import sys
-
-          needs = json.loads(os.environ["NEEDS_JSON"])
-          failed = False
-          for name, data in sorted(needs.items()):
-              result = data.get("result", "unknown")
-              if result == "success":
-                  print(f"::notice::{name}: {result}")
-              else:
-                  print(f"::error::{name}: {result}")
-                  failed = True
-
-          if failed:
-              print("One or more upstream jobs did not complete successfully.")
-              sys.exit(1)
-
-          print("All CI jobs completed successfully.")
-          PY
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
+            exit 0
+          fi
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1


### PR DESCRIPTION
## Summary

- cap untrusted CI at `contents: read`, so it cannot mint GitHub OIDC tokens
- pass an explicit trust/backend decision into the reusable workflow
- keep trusted runs on Namespace with the server backend and all other actors on GitHub-hosted runners with GitHub cache
- preserve the existing artifacts and `final` fan-in check

Validated first with both trusted and forced-untrusted runs in jdx/tak#61. This follows up #775.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes which workflows may mint OIDC tokens and which mbx cache backend runs; misconfiguration could expose the trusted cache to fork or third-party PR code.
> 
> **Overview**
> **Splits CI into mutually exclusive trusted and untrusted paths** so only structurally trusted runs can request GitHub OIDC tokens for the jdx mbx cache server.
> 
> `ci.yml` now dispatches to a new reusable **`ci-impl.yml`** with `trusted` and `mbx-backend` inputs: trusted jobs keep **`id-token: write`**, Namespace Linux runners, and **`mbx-backend: server`**; untrusted jobs are capped at **`contents: read`**, use GitHub-hosted Linux runners, and force **`mbx-backend: github`**. Untrusted Linux **`build`** adds a guard that OIDC request env vars are empty.
> 
> The **`mbx` composite action** gains a **`backend`** input (default `auto`) and callers pass an explicit backend from the reusable workflow instead of embedding trust logic only in the action.
> 
> The top-level **`final`** check now passes when exactly one of **`trusted`** / **`untrusted`** succeeds and the other is skipped, replacing the in-workflow Python aggregator over individual build/test jobs (that fan-in still lives inside **`ci-impl.yml`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f7f576ed621f80531fe9d202dc26c7a2355f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable backend selection for automated workflows.
  * Added reusable CI workflows covering builds, linting, generated output checks, and cross-platform tests.
  * Added test artifact handling, sharding, Windows test retries, and final status aggregation.
* **Security**
  * Trusted and untrusted workflow runs now use separate permissions and execution backends.
* **Reliability**
  * Added concurrency cancellation and validation to ensure delegated workflow results are reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->