### PR TITLE
ci: seed mbx cache for fork PRs

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -5,10 +5,19 @@ inputs:
   backend:
     description: Explicit backend for structurally trusted or untrusted callers
     default: auto
+  mirror-github-cache:
+    description: Mirror a trusted main build into the restore-only cache used by fork PRs
+    default: "false"
 
 runs:
   using: composite
   steps:
+    - name: Restore the fork PR cache mirror
+      if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
+      with:
+        version: 0.4.0
+        backend: github
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}
+          mirror-github-cache: "true"
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - run: mise run build:ui
@@ -105,6 +106,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}
+          mirror-github-cache: "true"
       - name: Build UI assets
         working-directory: ui
         run: |


### PR DESCRIPTION
## Summary

- restore the fork-facing GitHub Actions mbx cache in one canonical CI job per supported OS
- keep the trusted server backend active for compilation, then save the updated local store under the exact key format fork PRs restore
- restrict mirror writes to jdx pushes on main; fork and other untrusted PR runs remain restore-only and OIDC-free

## Validation

- actionlint
- high-severity zizmor audit
- git diff check
- confirmed release workflows do not enable the mirror

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trusted-vs-untrusted CI cache behavior at the GitHub Actions boundary; writes are gated to jdx pushes on main, but misconfiguration could affect fork cache isolation.
> 
> **Overview**
> Adds an opt-in **`mirror-github-cache`** input to the composite **`mbx`** action. When enabled, trusted **`main`** pushes by **`jdx`** run an extra **`mr-boxington`** step with the **GitHub** backend first so fork PRs can restore the same cache keys; the existing step still picks **server** vs **GitHub** via **`backend: auto`** for compilation.
> 
> Turns the flag on in **`ci-impl`** for the canonical **Linux `build`** and **Windows `rust-tests`** jobs so each supported OS seeds the fork-facing cache from a trusted CI run without changing untrusted/fork workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa1d2dcc687b9c0f165ee69578f651e2d7798d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Improved build and Rust test workflows by enabling cache restoration in supported runs.
  - Added an option to control cache mirroring for trusted main-branch changes, helping eligible builds reuse cached results more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->