### PR TITLE
chore(ci): bump mr-boxington action

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -17,12 +17,12 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
+      uses: jdx/mr-boxington-action@0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec
       with:
         version: 0.5.4
         backend: github
         cache-links: ${{ inputs.cache-links }}
-    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
+    - uses: jdx/mr-boxington-action@0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec
       with:
         version: 0.5.4
         cache-links: ${{ inputs.cache-links }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,11 +14,11 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563 # v1.0.1
+      uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df # main
       with:
         version: 0.5.4
         backend: github
-    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563 # v1.0.1
+    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df # main
       with:
         version: 0.5.4
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -11,21 +11,26 @@ inputs:
   cache-links:
     description: Cache native links; "auto" enables this on Linux
     default: auto
+  toolchain:
+    description: Rust toolchain named explicitly by the build
+    required: false
 
 runs:
   using: composite
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec
+      uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
-        version: 0.5.4
+        version: 0.6.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
-    - uses: jdx/mr-boxington-action@0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec
+        toolchain: ${{ inputs.toolchain }}
+    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
-        version: 0.5.4
+        version: 0.6.0
         cache-links: ${{ inputs.cache-links }}
+        toolchain: ${{ inputs.toolchain }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/pitchfork

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -8,19 +8,24 @@ inputs:
   mirror-github-cache:
     description: Mirror a trusted main build into the restore-only cache used by fork PRs
     default: "false"
+  cache-links:
+    description: Cache native links; "auto" enables this on Linux
+    default: auto
 
 runs:
   using: composite
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df # main
+      uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
       with:
         version: 0.5.4
         backend: github
-    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df # main
+        cache-links: ${{ inputs.cache-links }}
+    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
       with:
         version: 0.5.4
+        cache-links: ${{ inputs.cache-links }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/pitchfork

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build:
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Assert OIDC is unavailable to untrusted CI
         if: ${{ !inputs.trusted }}

--- a/mise.lock
+++ b/mise.lock
@@ -139,44 +139,44 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633
 provenance = "github-attestations"
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.5.4"
+version = "0.6.0"
 backend = "github:jdx/mr-boxington"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:e34adc416bb508f2ce9893b1bfc37baf648cf37633f22ec2056313b134a8b8bf"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135048"
+checksum = "sha256:019c98cdf8ff28e8967919ea9a549b2a7d05f8636957fc443d2fe7d00d22a5ac"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792954"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:e34adc416bb508f2ce9893b1bfc37baf648cf37633f22ec2056313b134a8b8bf"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135048"
+checksum = "sha256:019c98cdf8ff28e8967919ea9a549b2a7d05f8636957fc443d2fe7d00d22a5ac"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792954"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:e63b7b1c1a628da767a7f6acd8c8a359c4a3266bc8dbad633983b6320861a8b8"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135059"
+checksum = "sha256:156bb820fd035f846b6efb5d7210a3b816ec8842005c904f4bf40fe0a1be245e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792966"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:e63b7b1c1a628da767a7f6acd8c8a359c4a3266bc8dbad633983b6320861a8b8"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135059"
+checksum = "sha256:156bb820fd035f846b6efb5d7210a3b816ec8842005c904f4bf40fe0a1be245e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792966"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:290e5400fb0626331e5216a51384a6dfe11c0e05817e3bc9f54aa471c38ddf14"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135050"
+checksum = "sha256:bbd19a27974cdbfe7fa4a6ffef3cb29150b12ccdf3a17d2dc1e0afdd09675f25"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792953"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:54f05f2b7da4b6b3570c1867d2ba5c4ce9c17732bd9199adab138a6914c8ff2e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135049"
+checksum = "sha256:4a0958560ecba3253cd1d4459abf6b05b70e739e40f207ac1c17df4cd6a9e8e7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792956"
 provenance = "github-attestations"
 
 [[tools."github:jdx/tak"]]


### PR DESCRIPTION
## Summary

Pin the merged mr-boxington action update from [jdx/mr-boxington-action#15](https://github.com/jdx/mr-boxington-action/pull/15). The action now enables eligible native-link caching automatically on Linux, with an explicit opt-out.

A controlled mise warm build improved from 124.7s to 84.9s (about 32%).

## Validation

- immutable action SHA
- YAML diff checked
- upstream action unit and platform matrix checks passed

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency and workflow tuning with no application or security logic changes; main effect is faster Linux builds via optional link caching.
> 
> **Overview**
> Upgrades **mr-boxington** (`jdx/mr-boxington-action` pin and `mise.lock`) from **0.5.4** to **0.6.0**, exposing new composite inputs **`cache-links`** (default `auto`, Linux native-link caching) and optional **`toolchain`**, both passed through to the mirror and main mbx setup steps.
> 
> The shared CI **build** job timeout increases from **10** to **20** minutes to accommodate longer or more cache-heavy runs; trusted/untrusted backend selection for mbx is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90767c01de1599d6791cf9250fb6b55006de2416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to select a specific Rust toolchain for automation.
* **Chores**
  * Updated the automation tooling to a newer version for improved reliability.
  * Increased the build time limit to better support longer-running builds.
  * Preserved existing link-caching and backend-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->