### PR TITLE
ci: back mbx with the GitHub Actions cache alone

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,13 +1,7 @@
 name: Set up mbx
-description: Select the trusted jdx server or fork-safe GitHub cache backend
+description: Set up mbx with the GitHub Actions cache backend
 
 inputs:
-  backend:
-    description: Explicit backend for structurally trusted or untrusted callers
-    default: auto
-  mirror-github-cache:
-    description: Mirror a trusted main build into the restore-only cache used by fork PRs
-    default: "false"
   cache-links:
     description: Cache native links; "auto" enables this on Linux
     default: auto
@@ -18,20 +12,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
         version: 0.6.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
-      with:
-        version: 0.6.0
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}
-        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
-        server-url: https://cache.mise.jdx.dev
-        namespace: jdx/pitchfork
-        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -6,9 +6,6 @@ on:
       trusted:
         required: true
         type: boolean
-      mbx-backend:
-        required: true
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,9 +34,6 @@ jobs:
           cache: false
       - run: rm -rf .cargo
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
-          mirror-github-cache: "true"
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - run: mise run build:ui
@@ -104,9 +98,6 @@ jobs:
         with:
           cache: false
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
-          mirror-github-cache: "true"
       - name: Build UI assets
         working-directory: ui
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: true
-      mbx-backend: server
 
   untrusted:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
@@ -27,7 +26,6 @@ jobs:
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: false
-      mbx-backend: github
 
   final:
     name: final


### PR DESCRIPTION
Retires the remote cache server from CI: every job now uses mbx's GitHub Actions cache backend. Removes the backend-selection expression, the `mbx-backend` workflow plumbing, the fork-PR cache mirror, and the server-warming workflow — all of which existed to route trusted builds at cache.mise.jdx.dev. mbx itself stays.

`id-token: write` grants are left in place where they may serve Pages deploys or attestations; they can be tightened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All CI jobs now depend on GitHub Actions cache behavior only, which can change build times and cache hits versus the former trusted remote server and fork mirror path.
> 
> **Overview**
> CI no longer routes **mbx** through `cache.mise.jdx.dev` or picks a backend per trust level. The composite **`.github/actions/mbx`** action always sets **`backend: github`**, and the **`backend`**, **`mirror-github-cache`**, **`server-url`**, **`namespace`**, and **`oidc-audience`** wiring is gone, including the main-push step that mirrored cache for fork PRs.
> 
> **`ci-impl.yml`** drops the **`mbx-backend`** workflow input; build and Windows test jobs call **mbx** with defaults only. **`ci.yml`** still splits trusted vs untrusted jobs (runners, OIDC checks) but no longer passes **`mbx-backend: server`** / **`github`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f52e0c8fbbb221481f0c9cfba77774413e315b93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized CI caching on the GitHub Actions cache backend.
  * Removed configuration options for alternate cache backends and cache mirroring.
  * Simplified workflow configuration by removing obsolete cache-related inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->