### PR TITLE
feat(settings): add global ready_delay default override

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4822,6 +4822,38 @@
         "default_list": [],
         "extensions": []
       },
+      "general.ready_delay": {
+        "default": "3s",
+        "default_note": null,
+        "data_type": "null",
+        "value_type": {
+          "kind": "base",
+          "of": "duration"
+        },
+        "env": "PITCHFORK_READY_DELAY",
+        "envs": [
+          "PITCHFORK_READY_DELAY"
+        ],
+        "cli": [],
+        "bindings": {},
+        "help": "Default readiness delay in seconds when a daemon has no ready check configured",
+        "long_help": "Default readiness delay in seconds when a daemon has no ready check configured\n\nWhen a daemon has no other readiness check (output, HTTP, port, command), pitchfork waits this long before considering it ready. Daemons can override this with their own `ready_delay` setting.",
+        "help_heading": null,
+        "choices": [],
+        "merge": "replace",
+        "scope": "any",
+        "deprecated": null,
+        "deprecated_warn_at": null,
+        "deprecated_remove_at": null,
+        "renamed_to": null,
+        "hide": false,
+        "since": null,
+        "parse": null,
+        "writes_to": null,
+        "examples": [],
+        "default_list": [],
+        "extensions": []
+      },
       "general.shell": {
         "default": "sh -c",
         "default_note": null,

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -143,6 +143,16 @@ By default, pitchfork searches well-known locations for the mise binary: - `~/.l
 
 Set this to an absolute path if mise is installed elsewhere.
 
+## `general.ready_delay`
+
+- **Type:** `duration`
+- **Default:** `3s`
+- **Set with:** `PITCHFORK_READY_DELAY`
+
+Default readiness delay in seconds when a daemon has no ready check configured
+
+When a daemon has no other readiness check (output, HTTP, port, command), pitchfork waits this long before considering it ready. Daemons can override this with their own `ready_delay` setting.
+
 ## `general.shell`
 
 - **Type:** `string`

--- a/docs/guides/ready-checks.md
+++ b/docs/guides/ready-checks.md
@@ -23,6 +23,17 @@ run = "node server.js"
 ready_delay = 5  # Wait 5 seconds (CLI default: 3)
 ```
 
+The default delay when no ready check is configured can be changed globally in
+`[settings.general]` (or via the `PITCHFORK_READY_DELAY` environment variable):
+
+```toml
+[settings.general]
+ready_delay = "5s"
+```
+
+Individual daemons always override the global default with their own
+`ready_delay` setting.
+
 **Best for:** Simple services where a time delay is sufficient.
 
 ## Output Check

--- a/docs/guides/ready-checks.md
+++ b/docs/guides/ready-checks.md
@@ -34,6 +34,10 @@ ready_delay = "5s"
 Individual daemons always override the global default with their own
 `ready_delay` setting.
 
+The global `ready_delay` setting accepts duration strings but must be a whole
+number of seconds; subsecond values such as `"500ms"` are rejected with an
+error rather than silently truncated to a zero delay.
+
 **Best for:** Simple services where a time delay is sufficient.
 
 ## Output Check

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -813,6 +813,13 @@
             "null"
           ]
         },
+        "ready_delay": {
+          "description": "Default readiness delay in seconds when a daemon has no ready check configured",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "shell": {
           "description": "Shell command used to execute daemon run scripts",
           "type": [

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -216,7 +216,7 @@ auto = ["start", "stop"]  # Both auto-start and auto-stop
 
 ### `ready_delay`
 
-Seconds to wait before considering the daemon ready. When started via `pitchfork start` or `pitchfork run`, defaults to `3` seconds if no other ready check is configured. The default can be changed globally via `[settings.general] ready_delay` (or the `PITCHFORK_READY_DELAY` environment variable); a daemon-level `ready_delay` always takes precedence.
+Seconds to wait before considering the daemon ready. When started via `pitchfork start` or `pitchfork run`, defaults to `3` seconds if no other ready check is configured. The default can be changed globally via `[settings.general] ready_delay` (or the `PITCHFORK_READY_DELAY` environment variable); a daemon-level `ready_delay` always takes precedence. The global setting is a duration string and must be a whole number of seconds; subsecond values (e.g. `"500ms"`) are rejected with an error rather than silently truncated.
 
 ```toml
 [daemons.api]

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -216,7 +216,7 @@ auto = ["start", "stop"]  # Both auto-start and auto-stop
 
 ### `ready_delay`
 
-Seconds to wait before considering the daemon ready. When started via `pitchfork start` or `pitchfork run`, defaults to `3` seconds if no other ready check is configured.
+Seconds to wait before considering the daemon ready. When started via `pitchfork start` or `pitchfork run`, defaults to `3` seconds if no other ready check is configured. The default can be changed globally via `[settings.general] ready_delay` (or the `PITCHFORK_READY_DELAY` environment variable); a daemon-level `ready_delay` always takes precedence.
 
 ```toml
 [daemons.api]

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1223,6 +1223,9 @@ config {
     prop "general.startup_log_timestamps" type="bool" default=#false help="Show timestamps in startup log output" long_help="Show timestamps in startup log output\n\nWhen enabled, pitchfork prefixes each startup log line and result line with a timestamp (e.g. `19:03:15`), making it easier to see how long each daemon took to start.\n\nWhen disabled (default), a dim bullet (`•`) is used instead to keep the output compact and aligned with the spinner / status icons." {
         env "PITCHFORK_STARTUP_LOG_TIMESTAMPS"
     }
+    prop "general.ready_delay" type="duration" default="3s" help="Default readiness delay in seconds when a daemon has no ready check configured" long_help="Default readiness delay in seconds when a daemon has no ready check configured\n\nWhen a daemon has no other readiness check (output, HTTP, port, command), pitchfork waits this long before considering it ready. Daemons can override this with their own `ready_delay` setting." {
+        env "PITCHFORK_READY_DELAY"
+    }
     prop "general.worktree" type="bool" default=#true help="Enable git worktree / jj workspace auto-discovery" long_help="Enable git worktree / jj workspace auto-discovery\n\nWhen enabled (default), pitchfork discovers git worktrees and jj workspaces for proxy slug routing and supervisor config discovery. Each worktree gets its own namespace.\n\nSet to `false` to disable all worktree/workspace discovery. The deprecated `PITCHFORK_PROXY_WORKTREE` environment variable remains an alias during migration." {
         env "PITCHFORK_WORKTREE"
         deprecated_env "PITCHFORK_PROXY_WORKTREE"

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -126,7 +126,7 @@ pub async fn build_run_options(
             run_opts.mise = Some(project_settings.general.mise);
         }
         if run_opts.ready_delay.is_none() {
-            run_opts.ready_delay = Some(project_settings.general_ready_delay().as_secs());
+            run_opts.ready_delay = Some(project_settings.general_ready_delay_secs()?);
         }
     }
     run_opts.wait_ready = true;
@@ -832,7 +832,6 @@ impl IpcClient {
         is_explicitly_requested: bool,
         opts: &StartOptions,
     ) -> tokio::task::JoinHandle<SpawnTaskResult> {
-        let default_delay = crate::settings::settings().general_ready_delay().as_secs();
         let force = opts.force && is_explicitly_requested;
         let delay = opts.delay;
         let output = opts.output.clone();
@@ -846,6 +845,25 @@ impl IpcClient {
         let quiet = opts.quiet;
 
         tokio::spawn(async move {
+            // Only consult the global setting when no explicit --delay was given,
+            // mirroring build_run_options above.
+            let default_delay = if delay.is_some() {
+                None
+            } else {
+                Some(
+                    match crate::settings::settings().general_ready_delay_secs() {
+                        Ok(delay) => delay,
+                        Err(e) => {
+                            return SpawnTaskResult {
+                                id,
+                                job: None,
+                                run_result: Err(miette::miette!("{e}")),
+                            };
+                        }
+                    },
+                )
+            };
+
             let run_opts = RunOptions {
                 id: id.clone(),
                 cmd,
@@ -853,7 +871,7 @@ impl IpcClient {
                 shell_pid,
                 dir: crate::config_types::Dir(dir),
                 retry,
-                ready_delay: delay.or(Some(default_delay)),
+                ready_delay: delay.or(default_delay),
                 ready_output: output.map(ReadyOutput::new),
                 ready_http: http,
                 ready_port: port.map(ReadyPort::new),
@@ -1061,6 +1079,17 @@ impl IpcClient {
         dir: PathBuf,
         opts: StartOptions,
     ) -> Result<RunResult> {
+        // Only consult the global setting when no explicit --delay was given.
+        let default_delay = if opts.delay.is_some() {
+            None
+        } else {
+            Some(
+                crate::settings::settings()
+                    .general_ready_delay_secs()
+                    .map_err(|e| miette::miette!("{e}"))?,
+            )
+        };
+
         self.run(RunOptions {
             id,
             cmd,
@@ -1068,9 +1097,7 @@ impl IpcClient {
             force: opts.force,
             dir: crate::config_types::Dir(dir),
             retry: opts.retry.unwrap_or_default(),
-            ready_delay: opts.delay.or(Some(
-                crate::settings::settings().general_ready_delay().as_secs(),
-            )),
+            ready_delay: opts.delay.or(default_delay),
             ready_output: opts.output.map(ReadyOutput::new),
             ready_http: merge_ready_http_override(None, opts.http),
             ready_port: opts.port.map(ReadyPort::new),
@@ -1373,6 +1400,73 @@ mod tests {
         let run_opts = build_run_options(&id, &daemon_config, None).await.unwrap();
 
         assert_eq!(run_opts.ready_delay, Some(7));
+    }
+
+    #[tokio::test]
+    async fn build_run_options_rejects_subsecond_ready_delay() {
+        const CHILD_SENTINEL: &str = "subsecond-ready-delay-child-ran";
+        let output = tokio::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "ipc::batch::tests::build_run_options_rejects_subsecond_ready_delay_in_child",
+                "--nocapture",
+            ])
+            .env(
+                "PITCHFORK_TEST_PROJECT_READY_DELAY_MODE",
+                "subsecond-ready-delay-project",
+            )
+            .env_remove("PITCHFORK_READY_DELAY")
+            .output()
+            .await
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "sanitized child failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(CHILD_SENTINEL),
+            "sanitized child test did not run:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[tokio::test]
+    async fn build_run_options_rejects_subsecond_ready_delay_in_child() {
+        let Ok(mode) = std::env::var("PITCHFORK_TEST_PROJECT_READY_DELAY_MODE") else {
+            return;
+        };
+        if mode != "subsecond-ready-delay-project" {
+            return;
+        }
+        eprintln!("subsecond-ready-delay-child-ran");
+
+        let project = tempfile::tempdir().unwrap();
+        let config_path = project.path().join("pitchfork.toml");
+        tokio::fs::write(
+            &config_path,
+            "[settings.general]\nready_delay = \"500ms\"\n",
+        )
+        .await
+        .unwrap();
+
+        let id = DaemonId::try_new("other-project", "api").unwrap();
+        let daemon_config = PitchforkTomlDaemon {
+            run: "echo ready".to_string(),
+            path: Some(config_path),
+            ..PitchforkTomlDaemon::default()
+        };
+
+        let err = build_run_options(&id, &daemon_config, None)
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("whole number of seconds"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -115,19 +115,21 @@ pub async fn build_run_options(
     // long-lived and may have been started from a different directory. Use this
     // daemon's defining config path rather than the invoking client's CWD because
     // batch operations can include daemons from other registered namespaces.
-    if run_opts.mise.is_none() {
+    if run_opts.mise.is_none() || run_opts.ready_delay.is_none() {
         let project_dir = resolve_config_base_dir(daemon_config.path.as_deref());
-        let project_mise = tokio::task::spawn_blocking(move || {
+        let project_settings = tokio::task::spawn_blocking(move || {
             crate::settings::Settings::load_from_dir(&project_dir)
-                .general
-                .mise
         })
         .await
         .map_err(|e| format!("Failed to load project settings: {e}"))?;
-        run_opts.mise = Some(project_mise);
+        if run_opts.mise.is_none() {
+            run_opts.mise = Some(project_settings.general.mise);
+        }
+        if run_opts.ready_delay.is_none() {
+            run_opts.ready_delay = Some(project_settings.general_ready_delay().as_secs());
+        }
     }
     run_opts.wait_ready = true;
-    run_opts.ready_delay = run_opts.ready_delay.or(Some(3));
 
     if let Some(opts) = overrides {
         run_opts.shell_pid = opts.shell_pid;
@@ -830,6 +832,7 @@ impl IpcClient {
         is_explicitly_requested: bool,
         opts: &StartOptions,
     ) -> tokio::task::JoinHandle<SpawnTaskResult> {
+        let default_delay = crate::settings::settings().general_ready_delay().as_secs();
         let force = opts.force && is_explicitly_requested;
         let delay = opts.delay;
         let output = opts.output.clone();
@@ -850,7 +853,7 @@ impl IpcClient {
                 shell_pid,
                 dir: crate::config_types::Dir(dir),
                 retry,
-                ready_delay: delay.or(Some(3)),
+                ready_delay: delay.or(Some(default_delay)),
                 ready_output: output.map(ReadyOutput::new),
                 ready_http: http,
                 ready_port: port.map(ReadyPort::new),
@@ -1065,7 +1068,9 @@ impl IpcClient {
             force: opts.force,
             dir: crate::config_types::Dir(dir),
             retry: opts.retry.unwrap_or_default(),
-            ready_delay: opts.delay.or(Some(3)),
+            ready_delay: opts.delay.or(Some(
+                crate::settings::settings().general_ready_delay().as_secs(),
+            )),
             ready_output: opts.output.map(ReadyOutput::new),
             ready_http: merge_ready_http_override(None, opts.http),
             ready_port: opts.port.map(ReadyPort::new),
@@ -1281,6 +1286,93 @@ mod tests {
         let run_opts = build_run_options(&id, &daemon_config, None).await.unwrap();
 
         assert_eq!(run_opts.mise, daemon_config.mise);
+    }
+
+    #[tokio::test]
+    async fn build_run_options_falls_back_to_global_ready_delay() {
+        let id = DaemonId::try_new("project", "api").unwrap();
+        let daemon_config = PitchforkTomlDaemon {
+            run: "echo ready".to_string(),
+            ..PitchforkTomlDaemon::default()
+        };
+
+        let run_opts = build_run_options(&id, &daemon_config, None).await.unwrap();
+
+        assert_eq!(
+            run_opts.ready_delay,
+            Some(crate::settings::settings().general_ready_delay().as_secs())
+        );
+    }
+
+    #[tokio::test]
+    async fn build_run_options_preserves_daemon_ready_delay_override() {
+        let id = DaemonId::try_new("project", "api").unwrap();
+        let daemon_config = PitchforkTomlDaemon {
+            run: "echo ready".to_string(),
+            ready_delay: Some(5),
+            ..PitchforkTomlDaemon::default()
+        };
+
+        let run_opts = build_run_options(&id, &daemon_config, None).await.unwrap();
+
+        assert_eq!(run_opts.ready_delay, Some(5));
+    }
+
+    #[tokio::test]
+    async fn build_run_options_resolves_ready_delay_from_daemon_project() {
+        const CHILD_SENTINEL: &str = "project-ready-delay-sanitized-child-ran";
+        let output = tokio::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "ipc::batch::tests::build_run_options_resolves_ready_delay_in_sanitized_child",
+                "--nocapture",
+            ])
+            .env(
+                "PITCHFORK_TEST_PROJECT_READY_DELAY_MODE",
+                "ready-delay-project",
+            )
+            .env_remove("PITCHFORK_READY_DELAY")
+            .output()
+            .await
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "sanitized child failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(CHILD_SENTINEL),
+            "sanitized child test did not run:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[tokio::test]
+    async fn build_run_options_resolves_ready_delay_in_sanitized_child() {
+        let Ok(_mode) = std::env::var("PITCHFORK_TEST_PROJECT_READY_DELAY_MODE") else {
+            return;
+        };
+        eprintln!("project-ready-delay-sanitized-child-ran");
+
+        let project = tempfile::tempdir().unwrap();
+        let config_path = project.path().join("pitchfork.toml");
+        tokio::fs::write(&config_path, "[settings.general]\nready_delay = \"7s\"\n")
+            .await
+            .unwrap();
+
+        let id = DaemonId::try_new("other-project", "api").unwrap();
+        let daemon_config = PitchforkTomlDaemon {
+            run: "echo ready".to_string(),
+            path: Some(config_path),
+            ..PitchforkTomlDaemon::default()
+        };
+
+        let run_opts = build_run_options(&id, &daemon_config, None).await.unwrap();
+
+        assert_eq!(run_opts.ready_delay, Some(7));
     }
 
     #[tokio::test]

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -328,6 +328,16 @@ impl IpcClient {
     /// Run a single daemon with the given options (low-level operation)
     pub async fn run(&self, opts: RunOptions) -> Result<RunResult> {
         let start_time = chrono::Local::now();
+        // Resolve the effective ready delay before computing the timeout. The
+        // global setting is only consulted when no per-run delay is given, and
+        // subsecond values are rejected there rather than silently truncated
+        // by `as_secs()` into a zero delay.
+        let ready_delay = match opts.ready_delay {
+            Some(secs) => secs,
+            None => crate::settings::settings()
+                .general_ready_delay_secs()
+                .map_err(|e| miette::miette!("{e}"))?,
+        };
         // If any configured readiness check is unbounded (no timeout), the
         // supervisor may wait indefinitely. Use a generous cap so the client
         // does not disconnect prematurely — e.g. when a bounded ready_cmd
@@ -376,10 +386,7 @@ impl IpcClient {
                         .map(|d| d.as_secs())
                         .unwrap_or(0),
                 )
-                .max(
-                    opts.ready_delay
-                        .unwrap_or(crate::settings::settings().general_ready_delay().as_secs()),
-                );
+                .max(ready_delay);
             Duration::from_secs(max_deadline + 60)
         };
         let rsp = self

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -376,7 +376,10 @@ impl IpcClient {
                         .map(|d| d.as_secs())
                         .unwrap_or(0),
                 )
-                .max(opts.ready_delay.unwrap_or(3));
+                .max(
+                    opts.ready_delay
+                        .unwrap_or(crate::settings::settings().general_ready_delay().as_secs()),
+                );
             Duration::from_secs(max_deadline + 60)
         };
         let rsp = self

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -215,6 +215,14 @@ pub struct SettingsGeneral {
     #[usage(env = "PITCHFORK_STARTUP_LOG_TIMESTAMPS", default = false)]
     pub startup_log_timestamps: bool,
 
+    /// Default readiness delay in seconds when a daemon has no ready check configured
+    ///
+    /// When a daemon has no other readiness check (output, HTTP, port, command),
+    /// pitchfork waits this long before considering it ready. Daemons can
+    /// override this with their own `ready_delay` setting.
+    #[usage(env = "PITCHFORK_READY_DELAY", default = "3s", ty = "duration")]
+    pub ready_delay: String,
+
     /// Enable git worktree / jj workspace auto-discovery
     ///
     /// When enabled (default), pitchfork discovers git worktrees and jj workspaces for proxy
@@ -1077,6 +1085,7 @@ macro_rules! duration_getters {
 duration_getters! {
     general_autostop_delay => general.autostop_delay, "1m";
     general_interval => general.interval, "10s";
+    general_ready_delay => general.ready_delay, "3s";
     ipc_connect_max_delay => ipc.connect_max_delay, "1s";
     ipc_connect_min_delay => ipc.connect_min_delay, "100ms";
     ipc_rate_limit_window => ipc.rate_limit_window, "1s";
@@ -1526,6 +1535,8 @@ settings_partial! {
         shell: String,
         /// Show timestamps in startup log output
         startup_log_timestamps: bool,
+        /// Default readiness delay in seconds when a daemon has no ready check configured
+        ready_delay: String,
         /// Enable git worktree / jj workspace auto-discovery
         worktree: bool,
     }
@@ -1736,6 +1747,7 @@ mod tests {
         assert_eq!(settings.general.autostop_delay, "1m");
         assert_eq!(settings.general.interval, "10s");
         assert_eq!(settings.general.log_level, "info");
+        assert_eq!(settings.general.ready_delay, "3s");
 
         // Test IPC settings
         assert_eq!(settings.ipc.connect_attempts, 5);
@@ -1817,7 +1829,7 @@ mod tests {
             .iter()
             .map(|meta| meta.key)
             .collect();
-        assert_eq!(keys.len(), 68, "{keys:?}");
+        assert_eq!(keys.len(), 69, "{keys:?}");
         assert!(keys.contains(&"general.autostop_delay"));
         assert!(keys.contains(&"logs.archive_hook.command"));
         assert!(keys.contains(&"supervisor.watch_interval"));
@@ -2010,6 +2022,7 @@ mod tests {
 
         assert_eq!(settings.general_autostop_delay(), Duration::from_secs(60));
         assert_eq!(settings.general_interval(), Duration::from_secs(10));
+        assert_eq!(settings.general_ready_delay(), Duration::from_secs(3));
         assert_eq!(settings.ipc_connect_min_delay(), Duration::from_millis(100));
         assert_eq!(settings.ipc_connect_max_delay(), Duration::from_secs(1));
         assert_eq!(settings.ipc_request_timeout(), Duration::from_secs(5));

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1108,6 +1108,24 @@ duration_getters! {
 }
 
 impl Settings {
+    /// Resolve `general.ready_delay` as whole seconds.
+    ///
+    /// The ready-check pipeline (RunOptions/IPC/supervisor) models the delay
+    /// in whole seconds. Reject subsecond values that would otherwise be
+    /// silently truncated to a zero delay by `as_secs()`.
+    pub fn general_ready_delay_secs(&self) -> Result<u64, String> {
+        let delay = self.general_ready_delay();
+        if delay.subsec_nanos() != 0 {
+            return Err(format!(
+                "settings.general.ready_delay must be a whole number of seconds, got \"{}\"",
+                self.general.ready_delay
+            ));
+        }
+        Ok(delay.as_secs())
+    }
+}
+
+impl Settings {
     /// Load settings from pitchfork.toml files, then overlay environment variables.
     /// Settings are loaded from all pitchfork.toml files in precedence order:
     /// 1. System-level: /etc/pitchfork/config.toml
@@ -2056,6 +2074,35 @@ mod tests {
             settings.supervisor_http_client_timeout(),
             Duration::from_secs(5)
         );
+    }
+
+    #[test]
+    fn test_general_ready_delay_secs() {
+        let mut settings = Settings::default();
+
+        // Default "3s" resolves to whole seconds.
+        assert_eq!(settings.general_ready_delay_secs(), Ok(3));
+
+        // Subsecond values are rejected, not silently truncated by as_secs().
+        settings.general.ready_delay = "500ms".to_string();
+        let err = settings.general_ready_delay_secs().unwrap_err();
+        assert!(err.contains("500ms"), "unexpected error: {err}");
+        assert!(
+            err.contains("whole number of seconds"),
+            "unexpected error: {err}"
+        );
+
+        settings.general.ready_delay = "1.5s".to_string();
+        let err = settings.general_ready_delay_secs().unwrap_err();
+        assert!(err.contains("1.5s"), "unexpected error: {err}");
+
+        // Empty string falls back to the schema default "3s".
+        settings.general.ready_delay = String::new();
+        assert_eq!(settings.general_ready_delay_secs(), Ok(3));
+
+        // Whole-second values resolve as seconds.
+        settings.general.ready_delay = "90s".to_string();
+        assert_eq!(settings.general_ready_delay_secs(), Ok(90));
     }
 
     /// A directory tree, cleaned up when the test ends.


### PR DESCRIPTION
## Summary

Add `settings.general.ready_delay` (default `"3s"`, env `PITCHFORK_READY_DELAY`) as the global default for per-daemon readiness delay when a daemon has no ready check configured.

Priority: daemon-level `ready_delay` > `--delay` flag > `settings.general.ready_delay` > built-in 3s.

## Changes

- `src/settings.rs`: declare `ready_delay` on `SettingsGeneral` with `#[usage(env, default, ty = "duration")]`, add `general_ready_delay()` duration getter, mirror in partial, update registry/default/duration tests
- `src/ipc/batch.rs`: replace 3 hardcoded `Some(3)` fallbacks with the resolved setting; add 4 tests (fallback, daemon override, project-level settings via sanitized child)
- `src/ipc/client.rs`: replace `unwrap_or(3)` deadline fallback
- Regenerate `pitchfork.usage.kdl`, `docs/cli/*`, `docs/public/schema.json` (render)
- Document in `docs/guides/ready-checks.md` and `docs/reference/configuration.md`

## Verification

- fmt / clippy (`-D warnings`): clean
- `cargo nextest run`: 709/709 pass (8 ready_delay + 50 settings tests)
- BATS e2e: 308/308 pass, 0 skip
- Runtime: `settings get general.ready_delay` → `3s`; `PITCHFORK_READY_DELAY=9s` → `9s`

*AI-assisted — Tool: opencode; model: astra/deepseek_v4_flash_code/max; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable global readiness delay, defaulting to 3 seconds.
  * Configure it through general settings or `PITCHFORK_READY_DELAY`.
  * The setting applies when no other readiness check is configured.
  * Individual daemon readiness delays continue to take precedence.
  * Global delay values must use whole seconds; subsecond values are rejected.

* **Documentation**
  * Updated configuration references, schemas, usage information, and readiness-check guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->