### PR TITLE
chore: release v2.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.0](https://github.com/jdx/pitchfork/compare/v2.23.0...v2.24.0) - 2026-08-31
+
+### Added
+
+- *(settings)* add global ready_delay default override ([#785](https://github.com/jdx/pitchfork/pull/785))
+
 ## [2.23.0](https://github.com/jdx/pitchfork/compare/v2.22.0...v2.23.0) - 2026-08-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,7 +2759,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.23.0"
+version = "2.24.0"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.23.0"
+version = "2.24.0"
 edition = "2024"
 resolver = "3"
 rust-version = "1.91"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6728,7 +6728,7 @@
       }
     ]
   },
-  "version": "2.23.0",
+  "version": "2.24.0",
   "usage": "",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `pitchfork <SUBCOMMAND>`
 
-**Version:** 2.23.0
+**Version:** 2.24.0
 
 - **Usage:** `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,7 +1,7 @@
 // @generated from usage-rs metadata
 name pitchfork
 bin pitchfork
-version "2.23.0"
+version "2.24.0"
 about "Daemons with DX"
 unknown_flags error
 external_subcommand #true


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.23.0 -> 2.24.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.24.0](https://github.com/jdx/pitchfork/compare/v2.23.0...v2.24.0) - 2026-08-31

### Added

- *(settings)* add global ready_delay default override ([#785](https://github.com/jdx/pitchfork/pull/785))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only release bump with no runtime code changes in this PR.
> 
> **Overview**
> **Release v2.24.0** for `pitchfork-cli`: bumps the crate version from **2.23.0** to **2.24.0** in `Cargo.toml`, `Cargo.lock`, generated CLI docs (`docs/cli/*`), and `pitchfork.usage.kdl`, and adds a **2.24.0** section to `CHANGELOG.md`.
> 
> The release notes call out one user-facing change already merged elsewhere: a **global `ready_delay` default** in settings so you can override the default wait (when a daemon has no other readiness check) without per-daemon config ([#785](https://github.com/jdx/pitchfork/pull/785)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f1f426573dc571529c037d2b70237ecd35f9d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->