### PR TITLE
feat: add health checks (command, HTTP, and TCP port probes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ node_modules
 /ui/playwright-report
 /ui/test-results
 .slim/deepwork/
+.slim/clonedeps/
 .mise/usage-cli-6/

--- a/.ignore
+++ b/.ignore
@@ -1,2 +1,4 @@
 !.slim/deepwork/
 !.slim/deepwork/**
+!.slim/clonedeps/
+!.slim/clonedeps/**

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -630,6 +630,63 @@
                 }
               },
               {
+                "name": "health-cmd",
+                "usage": "--health-cmd <HEALTH_CMD>",
+                "help": "Shell command to poll for health (exit code 0 = healthy)",
+                "help_first_line": "Shell command to poll for health (exit code 0 = healthy)",
+                "short": [],
+                "long": [
+                  "health-cmd"
+                ],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "HEALTH_CMD",
+                  "usage": "<HEALTH_CMD>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
+                "name": "health-http",
+                "usage": "--health-http <HEALTH_HTTP>",
+                "help": "HTTP endpoint URL to poll for health",
+                "help_first_line": "HTTP endpoint URL to poll for health",
+                "short": [],
+                "long": [
+                  "health-http"
+                ],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "HEALTH_HTTP",
+                  "usage": "<HEALTH_HTTP>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
+                "name": "health-port",
+                "usage": "--health-port <HEALTH_PORT>",
+                "help": "TCP port to probe for health (connection success = healthy)",
+                "help_first_line": "TCP port to probe for health (connection success = healthy)",
+                "short": [],
+                "long": [
+                  "health-port"
+                ],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "HEALTH_PORT",
+                  "usage": "<HEALTH_PORT>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "expected-port",
                 "usage": "--expected-port <EXPECTED_PORT>",
                 "help": "Ports the daemon is expected to bind to (can be specified multiple times or comma-separated)",
@@ -2750,6 +2807,63 @@
             }
           },
           {
+            "name": "health-cmd",
+            "usage": "--health-cmd <HEALTH_CMD>",
+            "help": "Shell command to poll for health (exit code 0 = healthy)",
+            "help_first_line": "Shell command to poll for health (exit code 0 = healthy)",
+            "short": [],
+            "long": [
+              "health-cmd"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "HEALTH_CMD",
+              "usage": "<HEALTH_CMD>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "health-http",
+            "usage": "--health-http <HEALTH_HTTP>",
+            "help": "HTTP endpoint URL to poll for health",
+            "help_first_line": "HTTP endpoint URL to poll for health",
+            "short": [],
+            "long": [
+              "health-http"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "HEALTH_HTTP",
+              "usage": "<HEALTH_HTTP>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "health-port",
+            "usage": "--health-port <HEALTH_PORT>",
+            "help": "TCP port to probe for health (connection success = healthy)",
+            "help_first_line": "TCP port to probe for health (connection success = healthy)",
+            "short": [],
+            "long": [
+              "health-port"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "HEALTH_PORT",
+              "usage": "<HEALTH_PORT>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
             "name": "quiet",
             "usage": "-q --quiet",
             "help": "Suppress startup log output",
@@ -2993,6 +3107,63 @@
             "arg": {
               "name": "CMD",
               "usage": "<CMD>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "health-cmd",
+            "usage": "--health-cmd <HEALTH_CMD>",
+            "help": "Shell command to poll for health (exit code 0 = healthy)",
+            "help_first_line": "Shell command to poll for health (exit code 0 = healthy)",
+            "short": [],
+            "long": [
+              "health-cmd"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "HEALTH_CMD",
+              "usage": "<HEALTH_CMD>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "health-http",
+            "usage": "--health-http <HEALTH_HTTP>",
+            "help": "HTTP endpoint URL to poll for health",
+            "help_first_line": "HTTP endpoint URL to poll for health",
+            "short": [],
+            "long": [
+              "health-http"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "HEALTH_HTTP",
+              "usage": "<HEALTH_HTTP>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "health-port",
+            "usage": "--health-port <HEALTH_PORT>",
+            "help": "TCP port to probe for health (connection success = healthy)",
+            "help_first_line": "TCP port to probe for health (connection success = healthy)",
+            "short": [],
+            "long": [
+              "health-port"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "HEALTH_PORT",
+              "usage": "<HEALTH_PORT>",
               "required": true,
               "double_dash": "Optional",
               "hide": false
@@ -3671,6 +3842,63 @@
             "arg": {
               "name": "CMD",
               "usage": "<CMD>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "health-cmd",
+            "usage": "--health-cmd <HEALTH_CMD>",
+            "help": "Shell command to poll for health (exit code 0 = healthy)",
+            "help_first_line": "Shell command to poll for health (exit code 0 = healthy)",
+            "short": [],
+            "long": [
+              "health-cmd"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "HEALTH_CMD",
+              "usage": "<HEALTH_CMD>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "health-http",
+            "usage": "--health-http <HEALTH_HTTP>",
+            "help": "HTTP endpoint URL to poll for health",
+            "help_first_line": "HTTP endpoint URL to poll for health",
+            "short": [],
+            "long": [
+              "health-http"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "HEALTH_HTTP",
+              "usage": "<HEALTH_HTTP>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "health-port",
+            "usage": "--health-port <HEALTH_PORT>",
+            "help": "TCP port to probe for health (connection success = healthy)",
+            "help_first_line": "TCP port to probe for health (connection success = healthy)",
+            "short": [],
+            "long": [
+              "health-port"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "HEALTH_PORT",
+              "usage": "<HEALTH_PORT>",
               "required": true,
               "double_dash": "Optional",
               "hide": false
@@ -5964,6 +6192,134 @@
         "bindings": {},
         "help": "File watch debounce duration",
         "long_help": "File watch debounce duration\n\nWhen using `watch` patterns to auto-restart daemons on file changes, this controls how long to wait after the last change before triggering a restart.\n\nThis prevents rapid restart cycles when many files change at once (e.g., during a build or git checkout).",
+        "help_heading": null,
+        "choices": [],
+        "merge": "replace",
+        "scope": "any",
+        "deprecated": null,
+        "deprecated_warn_at": null,
+        "deprecated_remove_at": null,
+        "renamed_to": null,
+        "hide": false,
+        "since": null,
+        "parse": null,
+        "writes_to": null,
+        "examples": [],
+        "default_list": [],
+        "extensions": []
+      },
+      "supervisor.health_check_interval": {
+        "default": "10s",
+        "default_note": null,
+        "data_type": "null",
+        "value_type": {
+          "kind": "base",
+          "of": "duration"
+        },
+        "env": "PITCHFORK_HEALTH_CHECK_INTERVAL",
+        "envs": [
+          "PITCHFORK_HEALTH_CHECK_INTERVAL"
+        ],
+        "cli": [],
+        "bindings": {},
+        "help": "Default time between health probes",
+        "long_help": "Default time between health probes\n\nWhen a daemon has `health_cmd`, `health_http` or `health_port` configured but does not set its own `interval`, the supervisor probes it this often.",
+        "help_heading": null,
+        "choices": [],
+        "merge": "replace",
+        "scope": "any",
+        "deprecated": null,
+        "deprecated_warn_at": null,
+        "deprecated_remove_at": null,
+        "renamed_to": null,
+        "hide": false,
+        "since": null,
+        "parse": null,
+        "writes_to": null,
+        "examples": [],
+        "default_list": [],
+        "extensions": []
+      },
+      "supervisor.health_check_retries": {
+        "default": 3,
+        "default_note": null,
+        "data_type": "integer",
+        "value_type": {
+          "kind": "base",
+          "of": "int"
+        },
+        "env": "PITCHFORK_HEALTH_CHECK_RETRIES",
+        "envs": [
+          "PITCHFORK_HEALTH_CHECK_RETRIES"
+        ],
+        "cli": [],
+        "bindings": {},
+        "help": "Default consecutive health-check failures before killing a daemon",
+        "long_help": "Default consecutive health-check failures before killing a daemon\n\nWhen a daemon's `health_cmd`, `health_http` or `health_port` fails this many times in a row, the daemon is killed as a crash so the retry logic restarts it. Individual daemons can override this with `retries` in their health check configuration.",
+        "help_heading": null,
+        "choices": [],
+        "merge": "replace",
+        "scope": "any",
+        "deprecated": null,
+        "deprecated_warn_at": null,
+        "deprecated_remove_at": null,
+        "renamed_to": null,
+        "hide": false,
+        "since": null,
+        "parse": null,
+        "writes_to": null,
+        "examples": [],
+        "default_list": [],
+        "extensions": []
+      },
+      "supervisor.health_cmd_timeout": {
+        "default": "10s",
+        "default_note": null,
+        "data_type": "null",
+        "value_type": {
+          "kind": "base",
+          "of": "duration"
+        },
+        "env": "PITCHFORK_HEALTH_CMD_TIMEOUT",
+        "envs": [
+          "PITCHFORK_HEALTH_CMD_TIMEOUT"
+        ],
+        "cli": [],
+        "bindings": {},
+        "help": "Default per-probe timeout for `health_cmd`",
+        "long_help": "Default per-probe timeout for `health_cmd`\n\nMaximum time to wait for a `health_cmd` shell command to finish before counting the probe as failed and cancelling it.",
+        "help_heading": null,
+        "choices": [],
+        "merge": "replace",
+        "scope": "any",
+        "deprecated": null,
+        "deprecated_warn_at": null,
+        "deprecated_remove_at": null,
+        "renamed_to": null,
+        "hide": false,
+        "since": null,
+        "parse": null,
+        "writes_to": null,
+        "examples": [],
+        "default_list": [],
+        "extensions": []
+      },
+      "supervisor.health_http_timeout": {
+        "default": "5s",
+        "default_note": null,
+        "data_type": "null",
+        "value_type": {
+          "kind": "base",
+          "of": "duration"
+        },
+        "env": "PITCHFORK_HEALTH_HTTP_TIMEOUT",
+        "envs": [
+          "PITCHFORK_HEALTH_HTTP_TIMEOUT"
+        ],
+        "cli": [],
+        "bindings": {},
+        "help": "Default per-request timeout for `health_http`",
+        "long_help": "Default per-request timeout for `health_http`\n\nMaximum time to wait for a response from a `health_http` endpoint before counting the probe as failed.",
         "help_heading": null,
         "choices": [],
         "merge": "replace",

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6336,6 +6336,38 @@
         "default_list": [],
         "extensions": []
       },
+      "supervisor.health_port_timeout": {
+        "default": "5s",
+        "default_note": null,
+        "data_type": "null",
+        "value_type": {
+          "kind": "base",
+          "of": "duration"
+        },
+        "env": "PITCHFORK_HEALTH_PORT_TIMEOUT",
+        "envs": [
+          "PITCHFORK_HEALTH_PORT_TIMEOUT"
+        ],
+        "cli": [],
+        "bindings": {},
+        "help": "Default per-connect timeout for `health_port`",
+        "long_help": "Default per-connect timeout for `health_port`\n\nMaximum time to wait for a TCP connection to a `health_port` to establish before counting the probe as failed.",
+        "help_heading": null,
+        "choices": [],
+        "merge": "replace",
+        "scope": "any",
+        "deprecated": null,
+        "deprecated_warn_at": null,
+        "deprecated_remove_at": null,
+        "renamed_to": null,
+        "hide": false,
+        "since": null,
+        "parse": null,
+        "writes_to": null,
+        "examples": [],
+        "default_list": [],
+        "extensions": []
+      },
       "supervisor.http_client_timeout": {
         "default": "5s",
         "default_note": null,

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -634,6 +634,46 @@ When using `watch` patterns to auto-restart daemons on file changes, this contro
 
 This prevents rapid restart cycles when many files change at once (e.g., during a build or git checkout).
 
+## `supervisor.health_check_interval`
+
+- **Type:** `duration`
+- **Default:** `10s`
+- **Set with:** `PITCHFORK_HEALTH_CHECK_INTERVAL`
+
+Default time between health probes
+
+When a daemon has `health_cmd`, `health_http` or `health_port` configured but does not set its own `interval`, the supervisor probes it this often.
+
+## `supervisor.health_check_retries`
+
+- **Type:** `int`
+- **Default:** `3`
+- **Set with:** `PITCHFORK_HEALTH_CHECK_RETRIES`
+
+Default consecutive health-check failures before killing a daemon
+
+When a daemon's `health_cmd`, `health_http` or `health_port` fails this many times in a row, the daemon is killed as a crash so the retry logic restarts it. Individual daemons can override this with `retries` in their health check configuration.
+
+## `supervisor.health_cmd_timeout`
+
+- **Type:** `duration`
+- **Default:** `10s`
+- **Set with:** `PITCHFORK_HEALTH_CMD_TIMEOUT`
+
+Default per-probe timeout for `health_cmd`
+
+Maximum time to wait for a `health_cmd` shell command to finish before counting the probe as failed and cancelling it.
+
+## `supervisor.health_http_timeout`
+
+- **Type:** `duration`
+- **Default:** `5s`
+- **Set with:** `PITCHFORK_HEALTH_HTTP_TIMEOUT`
+
+Default per-request timeout for `health_http`
+
+Maximum time to wait for a response from a `health_http` endpoint before counting the probe as failed.
+
 ## `supervisor.http_client_timeout`
 
 - **Type:** `duration`

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -674,6 +674,16 @@ Default per-request timeout for `health_http`
 
 Maximum time to wait for a response from a `health_http` endpoint before counting the probe as failed.
 
+## `supervisor.health_port_timeout`
+
+- **Type:** `duration`
+- **Default:** `5s`
+- **Set with:** `PITCHFORK_HEALTH_PORT_TIMEOUT`
+
+Default per-connect timeout for `health_port`
+
+Maximum time to wait for a TCP connection to a `health_port` to establish before counting the probe as failed.
+
 ## `supervisor.http_client_timeout`
 
 - **Type:** `duration`

--- a/docs/cli/daemons/add.md
+++ b/docs/cli/daemons/add.md
@@ -49,6 +49,9 @@ Examples:
 - **`--ready-http <READY_HTTP>`** — HTTP endpoint URL to poll for readiness
 - **`--ready-port <READY_PORT>`** — TCP port to check for readiness (a number or Tera template)
 - **`--ready-cmd <READY_CMD>`** — Shell command to poll for readiness
+- **`--health-cmd <HEALTH_CMD>`** — Shell command to poll for health (exit code 0 = healthy)
+- **`--health-http <HEALTH_HTTP>`** — HTTP endpoint URL to poll for health
+- **`--health-port <HEALTH_PORT>`** — TCP port to probe for health (connection success = healthy)
 - **`--expected-port <EXPECTED_PORT>`** — Ports the daemon is expected to bind to (can be specified multiple times or comma-separated)
 - **`--bump [BUMP]`** — Automatically find an available port if the expected port is in use
 - **`--depends <DEPENDS>`** — Daemon dependencies that must start first (can be specified multiple times)

--- a/docs/cli/restart.md
+++ b/docs/cli/restart.md
@@ -35,5 +35,8 @@ Examples:
 - **`--http <HTTP>`** — Wait until HTTP endpoint returns 2xx status before considering daemon ready
 - **`--port <PORT>`** — Wait until TCP port is listening before considering daemon ready
 - **`--cmd <CMD>`** — Shell command to poll for readiness (exit code 0 = ready)
+- **`--health-cmd <HEALTH_CMD>`** — Shell command to poll for health (exit code 0 = healthy)
+- **`--health-http <HEALTH_HTTP>`** — HTTP endpoint URL to poll for health
+- **`--health-port <HEALTH_PORT>`** — TCP port to probe for health (connection success = healthy)
 - **`-q --quiet`** — Suppress startup log output
 - **`-h --help`** — Print help

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -42,5 +42,8 @@ Examples:
 - **`--expected-port <EXPECTED_PORT>`** — Port(s) the daemon is expected to bind to (can be specified multiple times or comma-separated)
 - **`--bump [BUMP]`** — Automatically find an available port if the expected port is in use
 - **`--cmd <CMD>`** — Shell command to poll for readiness (exit code 0 = ready)
+- **`--health-cmd <HEALTH_CMD>`** — Shell command to poll for health (exit code 0 = healthy)
+- **`--health-http <HEALTH_HTTP>`** — HTTP endpoint URL to poll for health
+- **`--health-port <HEALTH_PORT>`** — TCP port to probe for health (connection success = healthy)
 - **`-q --quiet`** — Suppress startup log output
 - **`-h --help`** — Print help

--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -44,6 +44,9 @@ Examples:
 - **`--http <HTTP>`** — Wait until HTTP endpoint returns 2xx status before considering daemon ready
 - **`--port <PORT>`** — Wait until TCP port is listening before considering daemon ready
 - **`--cmd <CMD>`** — Shell command to poll for readiness (exit code 0 = ready)
+- **`--health-cmd <HEALTH_CMD>`** — Shell command to poll for health (exit code 0 = healthy)
+- **`--health-http <HEALTH_HTTP>`** — HTTP endpoint URL to poll for health
+- **`--health-port <HEALTH_PORT>`** — TCP port to probe for health (connection success = healthy)
 - **`--expected-port <EXPECTED_PORT>`** — Ports the daemon is expected to bind to (can be specified multiple times or comma-separated)
 - **`--bump [BUMP]`** — Automatically find an available port if the expected port is in use
 - **`-q --quiet`** — Suppress startup log output

--- a/docs/guides/ready-checks.md
+++ b/docs/guides/ready-checks.md
@@ -206,13 +206,13 @@ health_port = { port = 6379, interval = "10s", retries = 3 }
 The command form treats exit code 0 as healthy; the HTTP form accepts any 2xx
 status, or exactly the `status` codes you list; the port form considers a TCP
 connection to `127.0.0.1:<port>` a success (connection refused/reset counts as
-failed). `health_port` has no `timeout` — a loopback connect either succeeds
-or fails immediately. When a daemon omits a field, it falls back to the
+failed). When a daemon omits a field, it falls back to the
 `supervisor.health_check_interval`, `supervisor.health_cmd_timeout`,
-`supervisor.health_http_timeout`, and `supervisor.health_check_retries`
-settings, which default to `interval` 10s, `timeout` 10s for `health_cmd` and
-5s for `health_http`, and `retries` 3. `health_port` uses the same
-`interval`/`retries` defaults but has no timeout setting.
+`supervisor.health_http_timeout`, `supervisor.health_port_timeout`, and
+`supervisor.health_check_retries` settings, which default to `interval` 10s,
+`timeout` 10s for `health_cmd`, 5s for `health_http` and `health_port`, and
+`retries` 3. `health_port` has no per-daemon `timeout` field; its connect
+timeout comes only from `supervisor.health_port_timeout`.
 
 ::: tip
 The health check starts as soon as the daemon is running, so the

--- a/docs/guides/ready-checks.md
+++ b/docs/guides/ready-checks.md
@@ -155,9 +155,103 @@ pitchfork metadata, and resolved `$PORT`, `$PORT0`, `$PORT1`, ... variables.
 Use this when you need more complex readiness checks than the built-in options provide.
 :::
 
+## Health Checks
+
+Ready checks gate startup: they run once, and startup fails if they never succeed.
+Health checks run periodically for the daemon's whole lifetime. If a probe fails
+`retries` consecutive times, pitchfork kills the daemon and treats it exactly
+like a crash: the monitor records `Errored`, the `retry` setting restarts it as
+usual, and the `on_retry` hook fires. A successful probe resets the
+consecutive-failure counter, and a restarted daemon gets a fresh failure budget.
+
+**CLI:**
+```bash
+pitchfork run myapp --health-cmd "curl -sf http://localhost:3000/health" -- node server.js
+pitchfork start myapp --health-http http://localhost:3000/health
+pitchfork restart myapp --health-cmd "pg_isready -h localhost"
+pitchfork start myapp --health-port 8443
+```
+
+`--health-cmd` and `--health-http` take the string shorthand form on
+`pitchfork daemons add`, `pitchfork start`, `pitchfork run`, and
+`pitchfork restart`; `--health-port` takes a plain TCP port number.
+
+**Config:**
+```toml
+[daemons.api]
+run = "node server.js"
+health_cmd = "curl -sf http://localhost:3000/health"
+
+[daemons.database]
+run = "postgres -D /var/lib/pgsql/data"
+health_cmd = { run = "pg_isready -h localhost", interval = "10s", timeout = "10s", retries = 3 }
+
+[daemons.webserver]
+run = "nginx"
+health_http = "http://localhost:3000/health"
+
+[daemons.web]
+run = "./web"
+health_http = { url = "http://localhost:3000/health", status = [200], interval = "10s", timeout = "5s", retries = 3 }
+
+[daemons.database]
+run = "postgres -D /var/lib/pgsql/data"
+health_port = 5432
+
+[daemons.cache]
+run = "./cache-server"
+health_port = { port = 6379, interval = "10s", retries = 3 }
+```
+
+The command form treats exit code 0 as healthy; the HTTP form accepts any 2xx
+status, or exactly the `status` codes you list; the port form considers a TCP
+connection to `127.0.0.1:<port>` a success (connection refused/reset counts as
+failed). `health_port` has no `timeout` — a loopback connect either succeeds
+or fails immediately. When a daemon omits a field, it falls back to the
+`supervisor.health_check_interval`, `supervisor.health_cmd_timeout`,
+`supervisor.health_http_timeout`, and `supervisor.health_check_retries`
+settings, which default to `interval` 10s, `timeout` 10s for `health_cmd` and
+5s for `health_http`, and `retries` 3. `health_port` uses the same
+`interval`/`retries` defaults but has no timeout setting.
+
+::: tip
+The health check starts as soon as the daemon is running, so the
+`retries * interval` window doubles as the startup grace period: a daemon that
+is still becoming ready has that long before a healthy probe is required.
+Slow-starting daemons should raise `interval` or `retries`. If multiple probe
+kinds (`health_cmd`, `health_http`, `health_port`) are configured, all run
+every interval and any one failing counts as an unhealthy probe.
+:::
+
+**Best for:** long-running processes that stay alive but stop working. The
+classic case is an SSH tunnel, which keeps running after the connection drops
+and would pass any pid-based check:
+
+```toml
+[daemons.tunnel]
+run = "ssh -N -L 8443:localhost:443 tunnel-host"
+retry = 3
+health_cmd = { run = "openssl s_client -connect localhost:8443 -brief </dev/null", interval = "10s", retries = 3 }
+```
+
+The probe makes a real TLS connection through the tunnel; once it fails 3
+times in a row, pitchfork kills the tunnel and `retry` restarts it.
+
+A plain TCP-connect probe is the cheaper equivalent — it only verifies that
+something accepts connections on the forwarded port, without the TLS
+handshake:
+
+```toml
+[daemons.tunnel]
+run = "ssh -N -L 8443:localhost:443 tunnel-host"
+retry = 3
+health_port = 8443
+```
+
 ## Templates
 
-All ready check fields (`ready_output`, `ready_http`, `ready_port`, `ready_cmd`) accept
+All ready check fields (`ready_output`, `ready_http`, `ready_port`, `ready_cmd`)
+and health check fields (`health_cmd`, `health_http`, `health_port`) accept
 [Tera templates](/guides/configuration-templates) to reference resolved values from
 daemons started earlier in the dependency order:
 
@@ -175,6 +269,16 @@ depends = ["redis"]
 
 `ready_port` templates must render to a port number (1-65535); otherwise the daemon
 fails to start with an error.
+
+Health checks can reference the same resolved values:
+
+```toml
+[daemons.worker]
+run = "worker --redis-port {{ daemons.redis.port }}"
+# Health: redis must keep answering pings on the resolved (possibly bumped) port
+depends = ["redis"]
+health_cmd = "redis-cli -p {{ daemons.redis.port }} ping"
+```
 
 ## Behaviors
 

--- a/docs/guides/ready-checks.md
+++ b/docs/guides/ready-checks.md
@@ -200,7 +200,7 @@ health_port = 5432
 
 [daemons.cache]
 run = "./cache-server"
-health_port = { port = 6379, interval = "10s", retries = 3 }
+health_port = { port = 6379, interval = "10s", retries = 3, timeout = "5s" }
 ```
 
 The command form treats exit code 0 as healthy; the HTTP form accepts any 2xx
@@ -211,8 +211,8 @@ failed). When a daemon omits a field, it falls back to the
 `supervisor.health_http_timeout`, `supervisor.health_port_timeout`, and
 `supervisor.health_check_retries` settings, which default to `interval` 10s,
 `timeout` 10s for `health_cmd`, 5s for `health_http` and `health_port`, and
-`retries` 3. `health_port` has no per-daemon `timeout` field; its connect
-timeout comes only from `supervisor.health_port_timeout`.
+`retries` 3. `health_port` also accepts a per-daemon `timeout` field, falling
+back to `supervisor.health_port_timeout` when omitted.
 
 ::: tip
 The health check starts as soon as the daemon is running, so the

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -112,6 +112,134 @@
         "daemons"
       ]
     },
+    "HealthCmd": {
+      "description": "Command health check: a shell command string, or { run, interval, timeout, retries } object with periodic probing",
+      "oneOf": [
+        {
+          "description": "Shell command that returns exit code 0 when healthy",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "interval": {
+              "description": "Time between health probes (e.g. '10s', '5m'). Omit to use the `supervisor.health_check_interval` setting (default 10s).",
+              "type": "string"
+            },
+            "retries": {
+              "description": "Consecutive failed probes before the daemon is killed. Omit to use the `supervisor.health_check_retries` setting (default 3).",
+              "type": "integer",
+              "minimum": 1
+            },
+            "run": {
+              "description": "Shell command that returns exit code 0 when healthy",
+              "type": "string"
+            },
+            "timeout": {
+              "description": "Per-probe timeout (e.g. '10s', '5m'). Omit to use the `supervisor.health_cmd_timeout` setting (default 10s).",
+              "type": "string"
+            }
+          },
+          "required": [
+            "run"
+          ]
+        }
+      ]
+    },
+    "HealthHttp": {
+      "description": "HTTP health check: a URL string accepting any 2xx response, or { url, status, interval, timeout, retries } object with periodic probing",
+      "oneOf": [
+        {
+          "description": "HTTP URL to poll for health; any 2xx response is healthy",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "interval": {
+              "description": "Time between health probes (e.g. '10s', '5m'). Omit to use the `supervisor.health_check_interval` setting (default 10s).",
+              "type": "string"
+            },
+            "retries": {
+              "description": "Consecutive failed probes before the daemon is killed. Omit to use the `supervisor.health_check_retries` setting (default 3).",
+              "type": "integer",
+              "minimum": 1
+            },
+            "status": {
+              "description": "Exact HTTP status codes that indicate health. Omit to accept any 2xx response.",
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "maximum": 599,
+                "minimum": 100
+              }
+            },
+            "timeout": {
+              "description": "Per-request timeout (e.g. '5s', '30s'). Omit to use the `supervisor.health_http_timeout` setting (default 5s).",
+              "type": "string"
+            },
+            "url": {
+              "description": "HTTP URL to poll for health",
+              "type": "string"
+            }
+          },
+          "required": [
+            "url"
+          ]
+        }
+      ]
+    },
+    "HealthPort": {
+      "description": "TCP port health check: a port number, a template string rendering to one, or a { port, interval, retries } object with periodic probing",
+      "oneOf": [
+        {
+          "description": "TCP port number to probe for health",
+          "type": "integer",
+          "maximum": 65535,
+          "minimum": 1
+        },
+        {
+          "description": "Tera template that renders to a port number",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "interval": {
+              "description": "Time between health probes (e.g. '10s', '5m'). Omit to use the `supervisor.health_check_interval` setting (default 10s).",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port number to probe for health",
+              "type": "integer",
+              "maximum": 65535,
+              "minimum": 1
+            },
+            "retries": {
+              "description": "Consecutive failed probes before the daemon is killed. Omit to use the `supervisor.health_check_retries` setting (default 3).",
+              "type": "integer",
+              "minimum": 1
+            },
+            "template": {
+              "description": "Tera template that renders to a port number",
+              "type": "string"
+            }
+          },
+          "oneOf": [
+            {
+              "required": [
+                "port"
+              ]
+            },
+            {
+              "required": [
+                "template"
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "MemoryLimit": {
       "description": "A byte size, as either a human-readable string (e.g. \"1.5 KiB\") or a number of bytes",
       "type": [
@@ -274,6 +402,39 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "health_cmd": {
+          "description": "Shell command to poll for health (exit code 0 = healthy)",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HealthCmd"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "health_http": {
+          "description": "HTTP endpoint URL to poll for health",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HealthHttp"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "health_port": {
+          "description": "TCP port to probe for health (connection success = healthy).\nAccepts a port number, a Tera template string that renders to one, or an\nobject with optional per-check `interval` and `retries`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HealthPort"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "hooks": {
           "description": "Lifecycle hooks (on_ready, on_fail, on_retry)",
@@ -1136,6 +1297,35 @@
         },
         "file_watch_debounce": {
           "description": "File watch debounce duration",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "health_check_interval": {
+          "description": "Default time between health probes",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "health_check_retries": {
+          "description": "Default consecutive health-check failures before killing a daemon",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "health_cmd_timeout": {
+          "description": "Default per-probe timeout for health_cmd",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "health_http_timeout": {
+          "description": "Default per-request timeout for health_http",
           "type": [
             "string",
             "null"

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -190,7 +190,7 @@
       ]
     },
     "HealthPort": {
-      "description": "TCP port health check: a port number, a template string rendering to one, or a { port, interval, retries } object with periodic probing",
+      "description": "TCP port health check: a port number, a template string rendering to one, or a { port, interval, retries, timeout } object with periodic probing",
       "oneOf": [
         {
           "description": "TCP port number to probe for health",
@@ -222,6 +222,10 @@
             },
             "template": {
               "description": "Tera template that renders to a port number",
+              "type": "string"
+            },
+            "timeout": {
+              "description": "Per-connect timeout (e.g. '5s', '30s'). Omit to use the `supervisor.health_port_timeout` setting (default 5s).",
               "type": "string"
             }
           },

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -430,7 +430,7 @@
           ]
         },
         "health_port": {
-          "description": "TCP port to probe for health (connection success = healthy).\nAccepts a port number, a Tera template string that renders to one, or an\nobject with optional per-check `interval` and `retries`.",
+          "description": "TCP port to probe for health (connection success = healthy).\nAccepts a port number, a Tera template string that renders to one, or an\nobject with optional per-check `interval`, `retries`, and `timeout`.",
           "anyOf": [
             {
               "$ref": "#/$defs/HealthPort"

--- a/docs/public/schema.json
+++ b/docs/public/schema.json
@@ -1331,6 +1331,13 @@
             "null"
           ]
         },
+        "health_port_timeout": {
+          "description": "Default per-connect timeout for health_port",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "http_client_timeout": {
           "description": "Timeout for HTTP ready checks",
           "type": [

--- a/mise.lock
+++ b/mise.lock
@@ -139,44 +139,44 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633
 provenance = "github-attestations"
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.6.0"
+version = "0.7.1"
 backend = "github:jdx/mr-boxington"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:019c98cdf8ff28e8967919ea9a549b2a7d05f8636957fc443d2fe7d00d22a5ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792954"
+checksum = "sha256:ab5a0ab99f735aff7ac1fea08db47e62b1cbbe163ed2d04d8674461565094a89"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/535171008"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:019c98cdf8ff28e8967919ea9a549b2a7d05f8636957fc443d2fe7d00d22a5ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792954"
+checksum = "sha256:6ac47931c31a257c1d6fb80b633df32b552334ee4cac1105e45a1e35bc509b27"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.1/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/535171011"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:156bb820fd035f846b6efb5d7210a3b816ec8842005c904f4bf40fe0a1be245e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792966"
+checksum = "sha256:64a633af470b660f39a832925c1ca29cc25d5f0cba0516da4e97f1a4797e2125"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/535171026"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:156bb820fd035f846b6efb5d7210a3b816ec8842005c904f4bf40fe0a1be245e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792966"
+checksum = "sha256:997b0d0438c97b690a502b8aec896b89d643ba94e5dbe6a0d7ae7abd13871dd7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.1/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/535171025"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:bbd19a27974cdbfe7fa4a6ffef3cb29150b12ccdf3a17d2dc1e0afdd09675f25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792953"
+checksum = "sha256:b2df305e782a10b94b3e46d3ac626006a4777b4772c8ac898b0479225b5c147c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.1/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/535171009"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:4a0958560ecba3253cd1d4459abf6b05b70e739e40f207ac1c17df4cd6a9e8e7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792956"
+checksum = "sha256:0b86b33c1062247b9c05dd55fe35b202791179bac640f2076c7dc4075eeedb8b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.1/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/535171023"
 provenance = "github-attestations"
 
 [[tools."github:jdx/tak"]]

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1375,6 +1375,9 @@ config {
     prop "supervisor.health_http_timeout" type="duration" default="5s" help="Default per-request timeout for `health_http`" long_help="Default per-request timeout for `health_http`\n\nMaximum time to wait for a response from a `health_http` endpoint before counting the probe as failed." {
         env "PITCHFORK_HEALTH_HTTP_TIMEOUT"
     }
+    prop "supervisor.health_port_timeout" type="duration" default="5s" help="Default per-connect timeout for `health_port`" long_help="Default per-connect timeout for `health_port`\n\nMaximum time to wait for a TCP connection to a `health_port` to establish before counting the probe as failed." {
+        env "PITCHFORK_HEALTH_PORT_TIMEOUT"
+    }
     prop "supervisor.http_client_timeout" type="duration" default="5s" help="Timeout for HTTP ready checks" long_help="Timeout for HTTP ready checks\n\nMaximum time to wait for a response when checking `ready_http` endpoints.\n\nIncrease if your services take a while to respond during startup." {
         env "PITCHFORK_HTTP_CLIENT_TIMEOUT"
     }

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -217,6 +217,15 @@ Examples:
         flag --ready-cmd help="Shell command to poll for readiness" {
             arg <READY_CMD>
         }
+        flag --health-cmd help="Shell command to poll for health (exit code 0 = healthy)" {
+            arg <HEALTH_CMD>
+        }
+        flag --health-http help="HTTP endpoint URL to poll for health" {
+            arg <HEALTH_HTTP>
+        }
+        flag --health-port help="TCP port to probe for health (connection success = healthy)" {
+            arg <HEALTH_PORT>
+        }
         flag --expected-port help="Ports the daemon is expected to bind to (can be specified multiple times or comma-separated)" var=#true delimiter=, {
             arg <EXPECTED_PORT>
         }
@@ -824,6 +833,15 @@ Examples:
     flag --cmd help="Shell command to poll for readiness (exit code 0 = ready)" {
         arg <CMD>
     }
+    flag --health-cmd help="Shell command to poll for health (exit code 0 = healthy)" {
+        arg <HEALTH_CMD>
+    }
+    flag --health-http help="HTTP endpoint URL to poll for health" {
+        arg <HEALTH_HTTP>
+    }
+    flag --health-port help="TCP port to probe for health (connection success = healthy)" {
+        arg <HEALTH_PORT>
+    }
     flag "-q --quiet" help="Suppress startup log output"
     flag "-h --help" help="Print help" action=help builtin=#true
     arg "[ID]..." help="ID of the daemon(s) to restart" {
@@ -879,6 +897,15 @@ Examples:
     }
     flag --cmd help="Shell command to poll for readiness (exit code 0 = ready)" {
         arg <CMD>
+    }
+    flag --health-cmd help="Shell command to poll for health (exit code 0 = healthy)" {
+        arg <HEALTH_CMD>
+    }
+    flag --health-http help="HTTP endpoint URL to poll for health" {
+        arg <HEALTH_HTTP>
+    }
+    flag --health-port help="TCP port to probe for health (connection success = healthy)" {
+        arg <HEALTH_PORT>
     }
     flag "-q --quiet" help="Suppress startup log output"
     flag "-h --help" help="Print help" action=help builtin=#true
@@ -1013,6 +1040,15 @@ Examples:
     }
     flag --cmd help="Shell command to poll for readiness (exit code 0 = ready)" {
         arg <CMD>
+    }
+    flag --health-cmd help="Shell command to poll for health (exit code 0 = healthy)" {
+        arg <HEALTH_CMD>
+    }
+    flag --health-http help="HTTP endpoint URL to poll for health" {
+        arg <HEALTH_HTTP>
+    }
+    flag --health-port help="TCP port to probe for health (connection success = healthy)" {
+        arg <HEALTH_PORT>
     }
     flag --expected-port help="Ports the daemon is expected to bind to (can be specified multiple times or comma-separated)" var=#true delimiter=, {
         arg <EXPECTED_PORT>
@@ -1326,6 +1362,18 @@ config {
     }
     prop "supervisor.file_watch_debounce" type="duration" default="1s" help="File watch debounce duration" long_help="File watch debounce duration\n\nWhen using `watch` patterns to auto-restart daemons on file changes, this controls how long to wait after the last change before triggering a restart.\n\nThis prevents rapid restart cycles when many files change at once (e.g., during a build or git checkout)." {
         env "PITCHFORK_FILE_WATCH_DEBOUNCE"
+    }
+    prop "supervisor.health_check_interval" type="duration" default="10s" help="Default time between health probes" long_help="Default time between health probes\n\nWhen a daemon has `health_cmd`, `health_http` or `health_port` configured but does not set its own `interval`, the supervisor probes it this often." {
+        env "PITCHFORK_HEALTH_CHECK_INTERVAL"
+    }
+    prop "supervisor.health_check_retries" type="int" default=3 help="Default consecutive health-check failures before killing a daemon" long_help="Default consecutive health-check failures before killing a daemon\n\nWhen a daemon's `health_cmd`, `health_http` or `health_port` fails this many times in a row, the daemon is killed as a crash so the retry logic restarts it. Individual daemons can override this with `retries` in their health check configuration." {
+        env "PITCHFORK_HEALTH_CHECK_RETRIES"
+    }
+    prop "supervisor.health_cmd_timeout" type="duration" default="10s" help="Default per-probe timeout for `health_cmd`" long_help="Default per-probe timeout for `health_cmd`\n\nMaximum time to wait for a `health_cmd` shell command to finish before counting the probe as failed and cancelling it." {
+        env "PITCHFORK_HEALTH_CMD_TIMEOUT"
+    }
+    prop "supervisor.health_http_timeout" type="duration" default="5s" help="Default per-request timeout for `health_http`" long_help="Default per-request timeout for `health_http`\n\nMaximum time to wait for a response from a `health_http` endpoint before counting the probe as failed." {
+        env "PITCHFORK_HEALTH_HTTP_TIMEOUT"
     }
     prop "supervisor.http_client_timeout" type="duration" default="5s" help="Timeout for HTTP ready checks" long_help="Timeout for HTTP ready checks\n\nMaximum time to wait for a response when checking `ready_http` endpoints.\n\nIncrease if your services take a while to respond during startup." {
         env "PITCHFORK_HTTP_CLIENT_TIMEOUT"

--- a/src/cli/daemons/add.rs
+++ b/src/cli/daemons/add.rs
@@ -2,9 +2,9 @@ use crate::Result;
 use crate::cli::daemons::resolve_config_path;
 use crate::daemon_id::DaemonId;
 use crate::pitchfork_toml::{
-    CronRetrigger, PitchforkToml, PitchforkTomlAuto, PitchforkTomlCron, PitchforkTomlDaemon,
-    PitchforkTomlHooks, PortBump, PortConfig, ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort, Retry,
-    namespace_from_path,
+    CronRetrigger, HealthCmd, HealthHttp, HealthPort, PitchforkToml, PitchforkTomlAuto,
+    PitchforkTomlCron, PitchforkTomlDaemon, PitchforkTomlHooks, PortBump, PortConfig, ReadyCmd,
+    ReadyHttp, ReadyOutput, ReadyPort, Retry, namespace_from_path,
 };
 use crate::settings::settings;
 use indexmap::IndexMap;
@@ -81,6 +81,15 @@ pub struct Add {
     /// Shell command to poll for readiness
     #[usage(long)]
     ready_cmd: Option<String>,
+    /// Shell command to poll for health (exit code 0 = healthy)
+    #[usage(long)]
+    health_cmd: Option<String>,
+    /// HTTP endpoint URL to poll for health
+    #[usage(long)]
+    health_http: Option<String>,
+    /// TCP port to probe for health (connection success = healthy)
+    #[usage(long)]
+    health_port: Option<u16>,
     /// Ports the daemon is expected to bind to (can be specified multiple times or comma-separated)
     #[usage(long = "expected-port", delimiter = ',')]
     expected_port: Vec<u16>,
@@ -254,6 +263,9 @@ impl Add {
                 ready_http: self.ready_http.clone().map(ReadyHttp::new),
                 ready_port: self.ready_port.clone(),
                 ready_cmd: self.ready_cmd.clone().map(ReadyCmd::new),
+                health_cmd: self.health_cmd.clone().map(HealthCmd::new),
+                health_http: self.health_http.clone().map(HealthHttp::new),
+                health_port: self.health_port.map(HealthPort::new),
                 port: {
                     let expect = self.expected_port.clone();
                     let bump = match self.bump {

--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -74,6 +74,15 @@ pub struct Restart {
     /// Shell command to poll for readiness (exit code 0 = ready)
     #[usage(long)]
     cmd: Option<String>,
+    /// Shell command to poll for health (exit code 0 = healthy)
+    #[usage(long)]
+    health_cmd: Option<String>,
+    /// HTTP endpoint URL to poll for health
+    #[usage(long)]
+    health_http: Option<String>,
+    /// TCP port to probe for health (connection success = healthy)
+    #[usage(long)]
+    health_port: Option<u16>,
     /// Suppress startup log output
     #[usage(short, long)]
     quiet: bool,
@@ -113,6 +122,9 @@ impl Restart {
             http: self.http.clone(),
             port: self.port,
             cmd: self.cmd.clone(),
+            health_cmd: self.health_cmd.clone(),
+            health_http: self.health_http.clone(),
+            health_port: self.health_port,
             quiet: self.quiet,
             ..Default::default()
         };

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -66,6 +66,15 @@ pub struct Run {
     /// Shell command to poll for readiness (exit code 0 = ready)
     #[usage(long)]
     cmd: Option<String>,
+    /// Shell command to poll for health (exit code 0 = healthy)
+    #[usage(long)]
+    health_cmd: Option<String>,
+    /// HTTP endpoint URL to poll for health
+    #[usage(long)]
+    health_http: Option<String>,
+    /// TCP port to probe for health (connection success = healthy)
+    #[usage(long)]
+    health_port: Option<u16>,
     /// Suppress startup log output
     #[usage(short, long)]
     quiet: bool,
@@ -87,6 +96,9 @@ impl Run {
             http: self.http.clone(),
             port: self.port,
             cmd: self.cmd.clone(),
+            health_cmd: self.health_cmd.clone(),
+            health_http: self.health_http.clone(),
+            health_port: self.health_port,
             expected_port: (!self.expected_port.is_empty()).then_some(self.expected_port.clone()),
             auto_bump_port: match self.bump {
                 None => None,

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -92,6 +92,15 @@ pub struct Start {
     /// Shell command to poll for readiness (exit code 0 = ready)
     #[usage(long)]
     cmd: Option<String>,
+    /// Shell command to poll for health (exit code 0 = healthy)
+    #[usage(long)]
+    health_cmd: Option<String>,
+    /// HTTP endpoint URL to poll for health
+    #[usage(long)]
+    health_http: Option<String>,
+    /// TCP port to probe for health (connection success = healthy)
+    #[usage(long)]
+    health_port: Option<u16>,
     /// Ports the daemon is expected to bind to (can be specified multiple times or comma-separated)
     #[usage(long, delimiter = ',')]
     expected_port: Vec<u16>,
@@ -152,6 +161,9 @@ impl Start {
             http: self.http.clone(),
             port: self.port,
             cmd: self.cmd.clone(),
+            health_cmd: self.health_cmd.clone(),
+            health_http: self.health_http.clone(),
+            health_port: self.health_port,
             expected_port: (!self.expected_port.is_empty()).then_some(self.expected_port.clone()),
             auto_bump_port: match self.bump {
                 None => None,

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -752,9 +752,9 @@ impl JsonSchema for HealthHttp {
 
 /// TCP port health check configuration.
 /// TOML forms:
-///   health_port = 8443                             # literal port
-///   health_port = "{{ daemons.redis.port }}"       # template
-///   health_port = { port = 8443, interval = "10s", retries = 3 }
+///   health_port = 8443                                  # literal port
+///   health_port = "{{ daemons.redis.port }}"            # template
+///   health_port = { port = 8443, interval = "10s", retries = 3, timeout = "5s" }
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct HealthPort {
     /// TCP port number to probe for health. `None` when the port is
@@ -767,6 +767,8 @@ pub struct HealthPort {
     pub interval: Option<std::time::Duration>,
     /// Consecutive failed probes before the daemon is killed. None = the `supervisor.health_check_retries` setting (default 3).
     pub retries: Option<u32>,
+    /// Per-connect timeout. None = the `supervisor.health_port_timeout` setting (default 5s).
+    pub timeout: Option<std::time::Duration>,
 }
 
 impl HealthPort {
@@ -776,6 +778,7 @@ impl HealthPort {
             template: None,
             interval: None,
             retries: None,
+            timeout: None,
         }
     }
 
@@ -785,6 +788,7 @@ impl HealthPort {
             template: Some(template.into()),
             interval: None,
             retries: None,
+            timeout: None,
         }
     }
 
@@ -842,11 +846,13 @@ pub struct HealthPortRaw {
     interval: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     retries: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout: Option<String>,
 }
 
 impl Serialize for HealthPort {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        if self.interval.is_none() && self.retries.is_none() {
+        if self.interval.is_none() && self.retries.is_none() && self.timeout.is_none() {
             if let Some(port) = self.port {
                 return s.serialize_u16(port);
             }
@@ -860,6 +866,7 @@ impl Serialize for HealthPort {
             template: self.template.clone(),
             interval: format_timeout(self.interval),
             retries: self.retries,
+            timeout: format_timeout(self.timeout),
         }
         .serialize(s)
     }
@@ -874,7 +881,7 @@ impl<'de> Deserialize<'de> for HealthPort {
 
             fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
                 f.write_str(
-                    "a port number, a template string, or an object with 'port'/'template' and optional 'interval'/'retries'",
+                    "a port number, a template string, or an object with 'port'/'template' and optional 'interval'/'retries'/'timeout'",
                 )
             }
 
@@ -922,11 +929,13 @@ impl<'de> Deserialize<'de> for HealthPort {
                     )));
                 }
                 let interval = parse_interval(&raw.interval).map_err(serde::de::Error::custom)?;
+                let timeout = parse_timeout(&raw.timeout).map_err(serde::de::Error::custom)?;
                 Ok(HealthPort {
                     port: raw.port,
                     template: raw.template,
                     interval,
                     retries: raw.retries,
+                    timeout,
                 })
             }
         }
@@ -942,7 +951,7 @@ impl JsonSchema for HealthPort {
 
     fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
         schemars::json_schema!({
-            "description": "TCP port health check: a port number, a template string rendering to one, or a { port, interval, retries } object with periodic probing",
+            "description": "TCP port health check: a port number, a template string rendering to one, or a { port, interval, retries, timeout } object with periodic probing",
             "oneOf": [
                 { "type": "integer", "minimum": 1, "maximum": 65535, "description": "TCP port number to probe for health" },
                 { "type": "string", "description": "Tera template that renders to a port number" },
@@ -952,7 +961,8 @@ impl JsonSchema for HealthPort {
                         "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "TCP port number to probe for health" },
                         "template": { "type": "string", "description": "Tera template that renders to a port number" },
                         "interval": { "type": "string", "description": "Time between health probes (e.g. '10s', '5m'). Omit to use the `supervisor.health_check_interval` setting (default 10s)." },
-                        "retries": { "type": "integer", "minimum": 1, "description": "Consecutive failed probes before the daemon is killed. Omit to use the `supervisor.health_check_retries` setting (default 3)." }
+                        "retries": { "type": "integer", "minimum": 1, "description": "Consecutive failed probes before the daemon is killed. Omit to use the `supervisor.health_check_retries` setting (default 3)." },
+                        "timeout": { "type": "string", "description": "Per-connect timeout (e.g. '5s', '30s'). Omit to use the `supervisor.health_port_timeout` setting (default 5s)." }
                     },
                     "oneOf": [
                         { "required": ["port"] },
@@ -2423,6 +2433,7 @@ health_port = { port = 8443, retries = 0 }
                 template: None,
                 interval: Some(Duration::from_secs(10)),
                 retries: Some(3),
+                timeout: Some(Duration::from_secs(5)),
             }),
         };
         let serialized = toml::to_string(&daemon).unwrap();

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -134,6 +134,25 @@ fn parse_timeout(raw: &Option<String>) -> std::result::Result<Option<std::time::
         .transpose()
 }
 
+/// Like `parse_timeout` but rejects a zero duration: health probes pass the
+/// timeout straight into `tokio::time::timeout`, where `0s` fails every probe
+/// immediately and eventually crash-kills a healthy daemon.
+fn parse_positive_timeout(
+    raw: &Option<String>,
+) -> std::result::Result<Option<std::time::Duration>, String> {
+    raw.as_ref()
+        .map(|s| {
+            let duration =
+                humantime::parse_duration(s).map_err(|e| format!("invalid timeout: {e}"))?;
+            if duration.is_zero() {
+                Err("invalid timeout: must be greater than 0".to_string())
+            } else {
+                Ok(duration)
+            }
+        })
+        .transpose()
+}
+
 /// Parse a humantime duration for an `interval` field. Same as `parse_timeout`
 /// but reports the correct field name in the error.
 fn parse_interval(
@@ -523,7 +542,7 @@ impl StringOrStruct for HealthCmd {
             return Err(format!("health_cmd retries must be >= 1: {retries}"));
         }
         let interval = parse_interval(&raw.interval)?;
-        let timeout = parse_timeout(&raw.timeout)?;
+        let timeout = parse_positive_timeout(&raw.timeout)?;
         Ok(Self {
             run: raw.run,
             interval,
@@ -672,7 +691,7 @@ impl StringOrStruct for HealthHttp {
             return Err(format!("health_http retries must be >= 1: {retries}"));
         }
         let interval = parse_interval(&raw.interval)?;
-        let timeout = parse_timeout(&raw.timeout)?;
+        let timeout = parse_positive_timeout(&raw.timeout)?;
         Ok(Self {
             url: raw.url,
             status: raw.status,
@@ -929,7 +948,8 @@ impl<'de> Deserialize<'de> for HealthPort {
                     )));
                 }
                 let interval = parse_interval(&raw.interval).map_err(serde::de::Error::custom)?;
-                let timeout = parse_timeout(&raw.timeout).map_err(serde::de::Error::custom)?;
+                let timeout =
+                    parse_positive_timeout(&raw.timeout).map_err(serde::de::Error::custom)?;
                 Ok(HealthPort {
                     port: raw.port,
                     template: raw.template,
@@ -2301,6 +2321,48 @@ health_port = { port = 8443, interval = "0s" }
         .unwrap_err();
         assert!(
             err.to_string().contains("invalid interval"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_cmd_zero_timeout_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_cmd = { run = "pg_isready", timeout = "0s" }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid timeout"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_http_zero_timeout_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_http = { url = "http://localhost:3000/health", timeout = "0s" }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid timeout"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_port_zero_timeout_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_port = { port = 8443, timeout = "0s" }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid timeout"),
             "unexpected error: {err}"
         );
     }

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -442,6 +442,511 @@ impl JsonSchema for ReadyCmd {
 }
 
 // ---------------------------------------------------------------------------
+// HealthCmd
+// ---------------------------------------------------------------------------
+
+/// Command health check configuration.
+/// TOML forms:
+///   health_cmd = "openssl s_client -connect localhost:8443 -brief </dev/null"
+///   health_cmd = { run = "...", interval = "10s", timeout = "10s", retries = 3 }
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HealthCmd {
+    /// Shell command to run. Exit code 0 = healthy.
+    pub run: String,
+    /// Time between probes. None = the `supervisor.health_check_interval` setting (default 10s).
+    pub interval: Option<std::time::Duration>,
+    /// Per-probe timeout. None = the `supervisor.health_cmd_timeout` setting (default 10s).
+    pub timeout: Option<std::time::Duration>,
+    /// Consecutive failed probes before the daemon is killed. None = the `supervisor.health_check_retries` setting (default 3).
+    pub retries: Option<u32>,
+}
+
+impl HealthCmd {
+    pub fn new(run: impl Into<String>) -> Self {
+        Self {
+            run: run.into(),
+            interval: None,
+            timeout: None,
+            retries: None,
+        }
+    }
+}
+
+impl std::fmt::Display for HealthCmd {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.run)
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+#[doc(hidden)]
+pub struct HealthCmdRaw {
+    run: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    interval: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retries: Option<u32>,
+}
+
+impl StringOrStruct for HealthCmd {
+    type Short = String;
+    type Raw = HealthCmdRaw;
+
+    fn from_short(run: String) -> Self {
+        Self::new(run)
+    }
+
+    fn from_raw(raw: HealthCmdRaw) -> std::result::Result<Self, String> {
+        if let Some(retries) = raw.retries
+            && retries < 1
+        {
+            return Err(format!("health_cmd retries must be >= 1: {retries}"));
+        }
+        let interval = parse_timeout(&raw.interval)?;
+        let timeout = parse_timeout(&raw.timeout)?;
+        Ok(Self {
+            run: raw.run,
+            interval,
+            timeout,
+            retries: raw.retries,
+        })
+    }
+
+    fn is_shorthand(&self) -> bool {
+        self.interval.is_none() && self.timeout.is_none() && self.retries.is_none()
+    }
+
+    fn to_short(&self) -> String {
+        self.run.clone()
+    }
+
+    fn to_raw(&self) -> HealthCmdRaw {
+        HealthCmdRaw {
+            run: self.run.clone(),
+            interval: format_timeout(self.interval),
+            timeout: format_timeout(self.timeout),
+            retries: self.retries,
+        }
+    }
+}
+
+impl Serialize for HealthCmd {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.string_or_struct_serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for HealthCmd {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Self::string_or_struct_deserialize(d)
+    }
+}
+
+impl JsonSchema for HealthCmd {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("HealthCmd")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "Command health check: a shell command string, or { run, interval, timeout, retries } object with periodic probing",
+            "oneOf": [
+                { "type": "string", "description": "Shell command that returns exit code 0 when healthy" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "run": { "type": "string", "description": "Shell command that returns exit code 0 when healthy" },
+                        "interval": { "type": "string", "description": "Time between health probes (e.g. '10s', '5m'). Omit to use the `supervisor.health_check_interval` setting (default 10s)." },
+                        "timeout": { "type": "string", "description": "Per-probe timeout (e.g. '10s', '5m'). Omit to use the `supervisor.health_cmd_timeout` setting (default 10s)." },
+                        "retries": { "type": "integer", "minimum": 1, "description": "Consecutive failed probes before the daemon is killed. Omit to use the `supervisor.health_check_retries` setting (default 3)." }
+                    },
+                    "required": ["run"]
+                }
+            ]
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HealthHttp
+// ---------------------------------------------------------------------------
+
+/// HTTP health check configuration.
+/// TOML forms:
+///   health_http = "http://localhost:3000/health"
+///   health_http = { url = "...", status = [200], interval = "10s", timeout = "5s", retries = 3 }
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HealthHttp {
+    pub url: String,
+    /// Exact accepted status codes; empty = any 2xx.
+    pub status: Vec<u16>,
+    /// Time between probes. None = the `supervisor.health_check_interval` setting (default 10s).
+    pub interval: Option<std::time::Duration>,
+    /// Per-request timeout. None = the `supervisor.health_http_timeout` setting (default 5s).
+    pub timeout: Option<std::time::Duration>,
+    /// Consecutive failed probes before the daemon is killed. None = the `supervisor.health_check_retries` setting (default 3).
+    pub retries: Option<u32>,
+}
+
+impl HealthHttp {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            status: vec![],
+            interval: None,
+            timeout: None,
+            retries: None,
+        }
+    }
+}
+
+impl std::fmt::Display for HealthHttp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.status.is_empty() {
+            f.write_str(&self.url)
+        } else {
+            let status = self
+                .status
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            write!(f, "{} (status: {})", self.url, status)
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+#[doc(hidden)]
+pub struct HealthHttpRaw {
+    url: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    status: Vec<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    interval: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retries: Option<u32>,
+}
+
+impl StringOrStruct for HealthHttp {
+    type Short = String;
+    type Raw = HealthHttpRaw;
+
+    fn from_short(url: String) -> Self {
+        Self::new(url)
+    }
+
+    fn from_raw(raw: HealthHttpRaw) -> std::result::Result<Self, String> {
+        for status in &raw.status {
+            if !(100..=599).contains(status) {
+                return Err(format!(
+                    "health_http status must be between 100 and 599: {status}"
+                ));
+            }
+        }
+        if let Some(retries) = raw.retries
+            && retries < 1
+        {
+            return Err(format!("health_http retries must be >= 1: {retries}"));
+        }
+        let interval = parse_timeout(&raw.interval)?;
+        let timeout = parse_timeout(&raw.timeout)?;
+        Ok(Self {
+            url: raw.url,
+            status: raw.status,
+            interval,
+            timeout,
+            retries: raw.retries,
+        })
+    }
+
+    fn is_shorthand(&self) -> bool {
+        self.status.is_empty()
+            && self.interval.is_none()
+            && self.timeout.is_none()
+            && self.retries.is_none()
+    }
+
+    fn to_short(&self) -> String {
+        self.url.clone()
+    }
+
+    fn to_raw(&self) -> HealthHttpRaw {
+        HealthHttpRaw {
+            url: self.url.clone(),
+            status: self.status.clone(),
+            interval: format_timeout(self.interval),
+            timeout: format_timeout(self.timeout),
+            retries: self.retries,
+        }
+    }
+}
+
+impl Serialize for HealthHttp {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.string_or_struct_serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for HealthHttp {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Self::string_or_struct_deserialize(d)
+    }
+}
+
+impl JsonSchema for HealthHttp {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("HealthHttp")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "HTTP health check: a URL string accepting any 2xx response, or { url, status, interval, timeout, retries } object with periodic probing",
+            "oneOf": [
+                { "type": "string", "description": "HTTP URL to poll for health; any 2xx response is healthy" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "url": { "type": "string", "description": "HTTP URL to poll for health" },
+                        "status": {
+                            "type": "array",
+                            "description": "Exact HTTP status codes that indicate health. Omit to accept any 2xx response.",
+                            "items": { "type": "integer", "minimum": 100, "maximum": 599 }
+                        },
+                        "interval": { "type": "string", "description": "Time between health probes (e.g. '10s', '5m'). Omit to use the `supervisor.health_check_interval` setting (default 10s)." },
+                        "timeout": { "type": "string", "description": "Per-request timeout (e.g. '5s', '30s'). Omit to use the `supervisor.health_http_timeout` setting (default 5s)." },
+                        "retries": { "type": "integer", "minimum": 1, "description": "Consecutive failed probes before the daemon is killed. Omit to use the `supervisor.health_check_retries` setting (default 3)." }
+                    },
+                    "required": ["url"]
+                }
+            ]
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HealthPort
+// ---------------------------------------------------------------------------
+
+/// TCP port health check configuration.
+/// TOML forms:
+///   health_port = 8443                             # literal port
+///   health_port = "{{ daemons.redis.port }}"       # template
+///   health_port = { port = 8443, interval = "10s", retries = 3 }
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HealthPort {
+    /// TCP port number to probe for health. `None` when the port is
+    /// provided as a template.
+    pub port: Option<u16>,
+    /// Tera template string that renders to a port number. `None` when a
+    /// literal port is used.
+    pub template: Option<String>,
+    /// Time between probes. None = the `supervisor.health_check_interval` setting (default 10s).
+    pub interval: Option<std::time::Duration>,
+    /// Consecutive failed probes before the daemon is killed. None = the `supervisor.health_check_retries` setting (default 3).
+    pub retries: Option<u32>,
+}
+
+impl HealthPort {
+    pub fn new(port: u16) -> Self {
+        Self {
+            port: Some(port),
+            template: None,
+            interval: None,
+            retries: None,
+        }
+    }
+
+    pub fn from_template(template: impl Into<String>) -> Self {
+        Self {
+            port: None,
+            template: Some(template.into()),
+            interval: None,
+            retries: None,
+        }
+    }
+
+    /// The resolved port number. `None` if this is an unrendered template.
+    pub fn as_port(&self) -> Option<u16> {
+        self.port
+    }
+}
+
+impl From<u16> for HealthPort {
+    fn from(port: u16) -> Self {
+        Self::new(port)
+    }
+}
+
+impl std::str::FromStr for HealthPort {
+    type Err = String;
+
+    /// Numeric strings must be a valid port (1-65535); anything else
+    /// (non-empty) is treated as a Tera template.
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.is_empty() {
+            Err("health_port cannot be empty".to_string())
+        } else if let Ok(n) = s.parse::<i64>() {
+            u16::try_from(n)
+                .ok()
+                .filter(|&p| p > 0)
+                .map(Self::new)
+                .ok_or_else(|| format!("health_port out of range (1-65535): {n}"))
+        } else {
+            Ok(Self::from_template(s.to_string()))
+        }
+    }
+}
+
+impl std::fmt::Display for HealthPort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (&self.port, &self.template) {
+            (Some(port), _) => write!(f, "{port}"),
+            (None, Some(template)) => f.write_str(template),
+            (None, None) => Ok(()),
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+#[doc(hidden)]
+pub struct HealthPortRaw {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    port: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    template: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    interval: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retries: Option<u32>,
+}
+
+impl Serialize for HealthPort {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        if self.interval.is_none() && self.retries.is_none() {
+            if let Some(port) = self.port {
+                return s.serialize_u16(port);
+            }
+            if let Some(template) = &self.template {
+                return s.serialize_str(template);
+            }
+            return s.serialize_none();
+        }
+        HealthPortRaw {
+            port: self.port,
+            template: self.template.clone(),
+            interval: format_timeout(self.interval),
+            retries: self.retries,
+        }
+        .serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for HealthPort {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct V;
+
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = HealthPort;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str(
+                    "a port number, a template string, or an object with 'port'/'template' and optional 'interval'/'retries'",
+                )
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                u16::try_from(v)
+                    .ok()
+                    .filter(|&p| p > 0)
+                    .map(HealthPort::new)
+                    .ok_or_else(|| E::custom(format!("health_port out of range (1-65535): {v}")))
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                if v < 0 {
+                    Err(E::custom("health_port cannot be negative"))
+                } else {
+                    self.visit_u64(v as u64)
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                v.parse().map_err(E::custom)
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                map: A,
+            ) -> Result<Self::Value, A::Error> {
+                let raw =
+                    HealthPortRaw::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+                if raw.port.is_none() && raw.template.is_none() {
+                    return Err(serde::de::Error::custom(
+                        "health_port object must have either 'port' or 'template'",
+                    ));
+                }
+                if let Some(port) = raw.port
+                    && port == 0
+                {
+                    return Err(serde::de::Error::custom("port must be between 1 and 65535"));
+                }
+                if let Some(retries) = raw.retries
+                    && retries < 1
+                {
+                    return Err(serde::de::Error::custom(format!(
+                        "health_port retries must be >= 1: {retries}"
+                    )));
+                }
+                let interval = parse_timeout(&raw.interval).map_err(serde::de::Error::custom)?;
+                Ok(HealthPort {
+                    port: raw.port,
+                    template: raw.template,
+                    interval,
+                    retries: raw.retries,
+                })
+            }
+        }
+
+        d.deserialize_any(V)
+    }
+}
+
+impl JsonSchema for HealthPort {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("HealthPort")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "TCP port health check: a port number, a template string rendering to one, or a { port, interval, retries } object with periodic probing",
+            "oneOf": [
+                { "type": "integer", "minimum": 1, "maximum": 65535, "description": "TCP port number to probe for health" },
+                { "type": "string", "description": "Tera template that renders to a port number" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "TCP port number to probe for health" },
+                        "template": { "type": "string", "description": "Tera template that renders to a port number" },
+                        "interval": { "type": "string", "description": "Time between health probes (e.g. '10s', '5m'). Omit to use the `supervisor.health_check_interval` setting (default 10s)." },
+                        "retries": { "type": "integer", "minimum": 1, "description": "Consecutive failed probes before the daemon is killed. Omit to use the `supervisor.health_check_retries` setting (default 3)." }
+                    },
+                    "oneOf": [
+                        { "required": ["port"] },
+                        { "required": ["template"] }
+                    ]
+                }
+            ]
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // ReadyPort
 // ---------------------------------------------------------------------------
 
@@ -1532,5 +2037,316 @@ pub struct Dir(pub std::path::PathBuf);
 impl Default for Dir {
     fn default() -> Self {
         Self(crate::env::CWD.clone())
+    }
+}
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// Minimal wrapper exercising the same TOML shape as `[daemons.<name>]`.
+    #[derive(Debug, serde::Deserialize, serde::Serialize)]
+    struct TestDaemon {
+        health_cmd: Option<HealthCmd>,
+        health_http: Option<HealthHttp>,
+        health_port: Option<HealthPort>,
+    }
+
+    #[test]
+    fn test_health_cmd_string_form() {
+        let daemon: TestDaemon = toml::from_str(
+            "health_cmd = 'openssl s_client -connect localhost:8443 -brief </dev/null'",
+        )
+        .unwrap();
+        let hc = daemon.health_cmd.unwrap();
+        assert_eq!(
+            hc.run,
+            "openssl s_client -connect localhost:8443 -brief </dev/null"
+        );
+        assert!(hc.interval.is_none());
+        assert!(hc.timeout.is_none());
+        assert!(hc.retries.is_none());
+    }
+
+    #[test]
+    fn test_health_cmd_object_form() {
+        let daemon: TestDaemon = toml::from_str(
+            r#"
+health_cmd = { run = "curl -f http://localhost:3000/health", interval = "10s", timeout = "10s", retries = 3 }
+"#,
+        )
+        .unwrap();
+        let hc = daemon.health_cmd.unwrap();
+        assert_eq!(hc.run, "curl -f http://localhost:3000/health");
+        assert_eq!(hc.interval, Some(Duration::from_secs(10)));
+        assert_eq!(hc.timeout, Some(Duration::from_secs(10)));
+        assert_eq!(hc.retries, Some(3));
+    }
+
+    #[test]
+    fn test_health_http_string_form() {
+        let daemon: TestDaemon =
+            toml::from_str(r#"health_http = "http://localhost:3000/health""#).unwrap();
+        let hh = daemon.health_http.unwrap();
+        assert_eq!(hh.url, "http://localhost:3000/health");
+        assert!(hh.status.is_empty());
+        assert!(hh.interval.is_none());
+        assert!(hh.timeout.is_none());
+        assert!(hh.retries.is_none());
+    }
+
+    #[test]
+    fn test_health_http_object_form() {
+        let daemon: TestDaemon = toml::from_str(
+            r#"
+health_http = { url = "http://localhost:3000/health", status = [200, 401], interval = "10s", timeout = "5s", retries = 3 }
+"#,
+        )
+        .unwrap();
+        let hh = daemon.health_http.unwrap();
+        assert_eq!(hh.url, "http://localhost:3000/health");
+        assert_eq!(hh.status, vec![200, 401]);
+        assert_eq!(hh.interval, Some(Duration::from_secs(10)));
+        assert_eq!(hh.timeout, Some(Duration::from_secs(5)));
+        assert_eq!(hh.retries, Some(3));
+    }
+
+    #[test]
+    fn test_health_serialize_roundtrip() {
+        let daemon = TestDaemon {
+            health_cmd: Some(HealthCmd {
+                run: "curl -f http://localhost:3000/health".to_string(),
+                interval: Some(Duration::from_secs(5)),
+                timeout: None,
+                retries: Some(2),
+            }),
+            health_http: Some(HealthHttp {
+                url: "http://localhost:3000/health".to_string(),
+                status: vec![200],
+                interval: None,
+                timeout: Some(Duration::from_secs(5)),
+                retries: Some(2),
+            }),
+            health_port: None,
+        };
+        let serialized = toml::to_string(&daemon).unwrap();
+        let back: TestDaemon = toml::from_str(&serialized).unwrap();
+        assert_eq!(back.health_cmd, daemon.health_cmd);
+        assert_eq!(back.health_http, daemon.health_http);
+    }
+
+    #[test]
+    fn test_health_serialize_shorthand_roundtrip() {
+        let daemon = TestDaemon {
+            health_cmd: Some(HealthCmd::new("pg_isready -h localhost")),
+            health_http: Some(HealthHttp::new("http://localhost:3000/health")),
+            health_port: None,
+        };
+        let serialized = toml::to_string(&daemon).unwrap();
+        assert!(serialized.contains("health_cmd = \"pg_isready -h localhost\""));
+        assert!(serialized.contains("health_http = \"http://localhost:3000/health\""));
+        let back: TestDaemon = toml::from_str(&serialized).unwrap();
+        assert_eq!(back.health_cmd, daemon.health_cmd);
+        assert_eq!(back.health_http, daemon.health_http);
+    }
+
+    #[test]
+    fn test_health_port_object_missing_port_and_template_rejected() {
+        let err = toml::from_str::<TestDaemon>("health_port = { retries = 2 }").unwrap_err();
+        let err = format!("{err:?}");
+        assert!(
+            err.contains("health_port object must have either 'port' or 'template'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_http_invalid_status_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_http = { url = "http://localhost:3000/health", status = [99] }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("health_http status must be between 100 and 599"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_cmd_invalid_timeout_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_cmd = { run = "pg_isready", timeout = "not-a-duration" }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid timeout"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_http_invalid_timeout_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_http = { url = "http://localhost:3000/health", timeout = "not-a-duration" }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid timeout"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_cmd_retries_zero_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_cmd = { run = "pg_isready", retries = 0 }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("health_cmd retries must be >= 1"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_http_retries_zero_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_http = { url = "http://localhost:3000/health", retries = 0 }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("health_http retries must be >= 1"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_port_literal_form() {
+        let daemon: TestDaemon = toml::from_str("health_port = 8443").unwrap();
+        let hp = daemon.health_port.unwrap();
+        assert_eq!(hp.port, Some(8443));
+        assert!(hp.template.is_none());
+        assert!(hp.interval.is_none());
+        assert!(hp.retries.is_none());
+    }
+
+    #[test]
+    fn test_health_port_template_string_form() {
+        let daemon: TestDaemon =
+            toml::from_str(r#"health_port = "{{ daemons.redis.port }}""#).unwrap();
+        let hp = daemon.health_port.unwrap();
+        assert!(hp.port.is_none());
+        assert_eq!(hp.template.as_deref(), Some("{{ daemons.redis.port }}"));
+        assert!(hp.interval.is_none());
+        assert!(hp.retries.is_none());
+    }
+
+    #[test]
+    fn test_health_port_object_form() {
+        let daemon: TestDaemon = toml::from_str(
+            r#"
+health_port = { port = 8443, interval = "10s", retries = 3 }
+"#,
+        )
+        .unwrap();
+        let hp = daemon.health_port.unwrap();
+        assert_eq!(hp.port, Some(8443));
+        assert!(hp.template.is_none());
+        assert_eq!(hp.interval, Some(Duration::from_secs(10)));
+        assert_eq!(hp.retries, Some(3));
+    }
+
+    #[test]
+    fn test_health_port_out_of_range_rejected() {
+        let err = toml::from_str::<TestDaemon>("health_port = 0").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("health_port out of range (1-65535)"),
+            "unexpected error: {err}"
+        );
+        let err = toml::from_str::<TestDaemon>("health_port = 70000").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("health_port out of range (1-65535)"),
+            "unexpected error: {err}"
+        );
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_port = { port = 0 }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("between 1 and 65535"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_port_invalid_interval_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_port = { port = 8443, interval = "not-a-duration" }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid timeout"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_port_retries_zero_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_port = { port = 8443, retries = 0 }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("health_port retries must be >= 1"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_port_serialize_roundtrip() {
+        let daemon = TestDaemon {
+            health_cmd: None,
+            health_http: None,
+            health_port: Some(HealthPort {
+                port: Some(8443),
+                template: None,
+                interval: Some(Duration::from_secs(10)),
+                retries: Some(3),
+            }),
+        };
+        let serialized = toml::to_string(&daemon).unwrap();
+        let back: TestDaemon = toml::from_str(&serialized).unwrap();
+        assert_eq!(back.health_port, daemon.health_port);
+
+        let shorthand = TestDaemon {
+            health_cmd: None,
+            health_http: None,
+            health_port: Some(HealthPort::new(8443)),
+        };
+        let serialized = toml::to_string(&shorthand).unwrap();
+        assert!(serialized.contains("health_port = 8443"));
     }
 }

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -134,6 +134,16 @@ fn parse_timeout(raw: &Option<String>) -> std::result::Result<Option<std::time::
         .transpose()
 }
 
+/// Parse a humantime duration for an `interval` field. Same as `parse_timeout`
+/// but reports the correct field name in the error.
+fn parse_interval(
+    raw: &Option<String>,
+) -> std::result::Result<Option<std::time::Duration>, String> {
+    raw.as_ref()
+        .map(|s| humantime::parse_duration(s).map_err(|e| format!("invalid interval: {e}")))
+        .transpose()
+}
+
 /// Format a `Duration` as a humantime string, or `None` when unset.
 fn format_timeout(timeout: Option<std::time::Duration>) -> Option<String> {
     timeout.map(|d| humantime::format_duration(d).to_string())
@@ -903,7 +913,7 @@ impl<'de> Deserialize<'de> for HealthPort {
                         "health_port retries must be >= 1: {retries}"
                     )));
                 }
-                let interval = parse_timeout(&raw.interval).map_err(serde::de::Error::custom)?;
+                let interval = parse_interval(&raw.interval).map_err(serde::de::Error::custom)?;
                 Ok(HealthPort {
                     port: raw.port,
                     template: raw.template,
@@ -2306,7 +2316,7 @@ health_port = { port = 8443, interval = "not-a-duration" }
         )
         .unwrap_err();
         assert!(
-            err.to_string().contains("invalid timeout"),
+            err.to_string().contains("invalid interval"),
             "unexpected error: {err}"
         );
     }

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -140,7 +140,15 @@ fn parse_interval(
     raw: &Option<String>,
 ) -> std::result::Result<Option<std::time::Duration>, String> {
     raw.as_ref()
-        .map(|s| humantime::parse_duration(s).map_err(|e| format!("invalid interval: {e}")))
+        .map(|s| {
+            let duration =
+                humantime::parse_duration(s).map_err(|e| format!("invalid interval: {e}"))?;
+            if duration.is_zero() {
+                Err("invalid interval: must be greater than 0".to_string())
+            } else {
+                Ok(duration)
+            }
+        })
         .transpose()
 }
 
@@ -2236,6 +2244,48 @@ health_cmd = { run = "pg_isready", interval = "not-a-duration" }
         let err = toml::from_str::<TestDaemon>(
             r#"
 health_http = { url = "http://localhost:3000/health", interval = "not-a-duration" }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid interval"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_cmd_zero_interval_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_cmd = { run = "pg_isready", interval = "0s" }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid interval"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_http_zero_interval_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_http = { url = "http://localhost:3000/health", interval = "0s" }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid interval"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_port_zero_interval_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_port = { port = 8443, interval = "0s" }
 "#,
         )
         .unwrap_err();

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -514,7 +514,7 @@ impl StringOrStruct for HealthCmd {
         {
             return Err(format!("health_cmd retries must be >= 1: {retries}"));
         }
-        let interval = parse_timeout(&raw.interval)?;
+        let interval = parse_interval(&raw.interval)?;
         let timeout = parse_timeout(&raw.timeout)?;
         Ok(Self {
             run: raw.run,
@@ -663,7 +663,7 @@ impl StringOrStruct for HealthHttp {
         {
             return Err(format!("health_http retries must be >= 1: {retries}"));
         }
-        let interval = parse_timeout(&raw.interval)?;
+        let interval = parse_interval(&raw.interval)?;
         let timeout = parse_timeout(&raw.timeout)?;
         Ok(Self {
             url: raw.url,
@@ -2213,6 +2213,34 @@ health_http = { url = "http://localhost:3000/health", timeout = "not-a-duration"
         .unwrap_err();
         assert!(
             err.to_string().contains("invalid timeout"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_cmd_invalid_interval_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_cmd = { run = "pg_isready", interval = "not-a-duration" }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid interval"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_health_http_invalid_interval_rejected() {
+        let err = toml::from_str::<TestDaemon>(
+            r#"
+health_http = { url = "http://localhost:3000/health", interval = "not-a-duration" }
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid interval"),
             "unexpected error: {err}"
         );
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,8 +1,8 @@
 use crate::daemon_id::DaemonId;
 use crate::daemon_status::DaemonStatus;
 use crate::pitchfork_toml::{
-    CpuLimit, CronRetrigger, Dir, MemoryLimit, PortConfig, ReadyCmd, ReadyHttp, ReadyOutput,
-    ReadyPort, Retry, StopConfig, WatchMode,
+    CpuLimit, CronRetrigger, Dir, HealthCmd, HealthHttp, HealthPort, MemoryLimit, PortConfig,
+    ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort, Retry, StopConfig, WatchMode,
 };
 use indexmap::IndexMap;
 use std::fmt::Display;
@@ -85,6 +85,12 @@ pub struct Daemon {
     pub ready_port: Option<ReadyPort>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_cmd: Option<ReadyCmd>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub health_cmd: Option<HealthCmd>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub health_http: Option<HealthHttp>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub health_port: Option<HealthPort>,
     /// Port configuration (expected ports and auto-bump settings)
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub port: Option<PortConfig>,
@@ -171,6 +177,9 @@ pub struct RunOptions {
     pub ready_http: Option<ReadyHttp>,
     pub ready_port: Option<ReadyPort>,
     pub ready_cmd: Option<ReadyCmd>,
+    pub health_cmd: Option<HealthCmd>,
+    pub health_http: Option<HealthHttp>,
+    pub health_port: Option<HealthPort>,
     pub port: Option<PortConfig>,
     pub wait_ready: bool,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -261,6 +270,9 @@ impl Daemon {
             ready_http: self.ready_http.clone(),
             ready_port: self.ready_port.clone(),
             ready_cmd: self.ready_cmd.clone(),
+            health_cmd: self.health_cmd.clone(),
+            health_http: self.health_http.clone(),
+            health_port: self.health_port.clone(),
             port: self.port.clone(),
             wait_ready: false,
             depends: self.depends.clone(),

--- a/src/ipc/batch.rs
+++ b/src/ipc/batch.rs
@@ -9,8 +9,8 @@ use crate::daemon_id::DaemonId;
 use crate::deps::{compute_reverse_stop_order, resolve_dependencies};
 use crate::ipc::client::IpcClient;
 use crate::pitchfork_toml::{
-    PitchforkToml, PitchforkTomlDaemon, ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort,
-    is_dot_config_pitchfork, is_global_config,
+    HealthCmd, HealthHttp, HealthPort, PitchforkToml, PitchforkTomlDaemon, ReadyCmd, ReadyHttp,
+    ReadyOutput, ReadyPort, is_dot_config_pitchfork, is_global_config,
 };
 use chrono::{DateTime, Local};
 use indexmap::IndexMap;
@@ -85,6 +85,12 @@ pub struct StartOptions {
     pub port: Option<u16>,
     /// Override ready command
     pub cmd: Option<String>,
+    /// Override health check command
+    pub health_cmd: Option<String>,
+    /// Override health check HTTP endpoint
+    pub health_http: Option<String>,
+    /// Override health check TCP port
+    pub health_port: Option<u16>,
     /// Ports the daemon is expected to bind to (None = not specified, use config)
     pub expected_port: Option<Vec<u16>>,
     /// Port auto-bump configuration (None = use config, Some = override)
@@ -146,6 +152,11 @@ pub async fn build_run_options(
             run_opts.ready_port.clone()
         };
         run_opts.ready_cmd = merge_ready_cmd_override(run_opts.ready_cmd, opts.cmd.clone());
+        run_opts.health_cmd =
+            merge_health_cmd_override(run_opts.health_cmd, opts.health_cmd.clone());
+        run_opts.health_http =
+            merge_health_http_override(run_opts.health_http, opts.health_http.clone());
+        run_opts.health_port = merge_health_port_override(run_opts.health_port, opts.health_port);
         if let Some(ref expected) = opts.expected_port {
             run_opts.port.get_or_insert_with(Default::default).expect = expected.clone();
         }
@@ -216,6 +227,49 @@ fn merge_ready_cmd_override(
         }
         (None, Some(cmd)) => Some(ReadyCmd::new(cmd)),
         (ready_cmd, None) => ready_cmd,
+    }
+}
+
+fn merge_health_cmd_override(
+    configured: Option<HealthCmd>,
+    override_cmd: Option<String>,
+) -> Option<HealthCmd> {
+    match (configured, override_cmd) {
+        (Some(mut health_cmd), Some(cmd)) => {
+            health_cmd.run = cmd;
+            Some(health_cmd)
+        }
+        (None, Some(cmd)) => Some(HealthCmd::new(cmd)),
+        (health_cmd, None) => health_cmd,
+    }
+}
+
+fn merge_health_http_override(
+    configured: Option<HealthHttp>,
+    override_url: Option<String>,
+) -> Option<HealthHttp> {
+    match (configured, override_url) {
+        (Some(mut health_http), Some(url)) => {
+            health_http.url = url;
+            Some(health_http)
+        }
+        (None, Some(url)) => Some(HealthHttp::new(url)),
+        (health_http, None) => health_http,
+    }
+}
+
+fn merge_health_port_override(
+    configured: Option<HealthPort>,
+    override_port: Option<u16>,
+) -> Option<HealthPort> {
+    match (configured, override_port) {
+        (Some(mut health_port), Some(port)) => {
+            health_port.port = Some(port);
+            health_port.template = None;
+            Some(health_port)
+        }
+        (None, Some(port)) => Some(HealthPort::new(port)),
+        (health_port, None) => health_port,
     }
 }
 
@@ -667,6 +721,9 @@ impl IpcClient {
                             adhoc_daemon.dir.clone().unwrap_or_default(),
                             adhoc_daemon.env.clone(),
                             adhoc_daemon.ready_http.clone(),
+                            adhoc_daemon.health_cmd.clone(),
+                            adhoc_daemon.health_http.clone(),
+                            adhoc_daemon.health_port.clone(),
                             is_explicit,
                             &opts,
                         );
@@ -827,6 +884,9 @@ impl IpcClient {
         dir: PathBuf,
         env: Option<IndexMap<String, String>>,
         ready_http: Option<ReadyHttp>,
+        health_cmd: Option<HealthCmd>,
+        health_http: Option<HealthHttp>,
+        health_port: Option<HealthPort>,
         is_explicitly_requested: bool,
         opts: &StartOptions,
     ) -> tokio::task::JoinHandle<SpawnTaskResult> {
@@ -836,6 +896,9 @@ impl IpcClient {
         let http = merge_ready_http_override(ready_http, opts.http.clone());
         let port = opts.port;
         let ready_cmd = opts.cmd.clone().map(ReadyCmd::new);
+        let health_cmd = merge_health_cmd_override(health_cmd, opts.health_cmd.clone());
+        let health_http = merge_health_http_override(health_http, opts.health_http.clone());
+        let health_port = merge_health_port_override(health_port, opts.health_port);
         let expected_port = opts.expected_port.clone();
         let auto_bump_port = opts.auto_bump_port;
         let retry = opts.retry.unwrap_or_default();
@@ -855,6 +918,9 @@ impl IpcClient {
                 ready_http: http,
                 ready_port: port.map(ReadyPort::new),
                 ready_cmd,
+                health_cmd,
+                health_http,
+                health_port,
                 port: crate::config_types::PortConfig::from_parts(
                     expected_port.unwrap_or_default(),
                     auto_bump_port.unwrap_or_default(),
@@ -1070,6 +1136,9 @@ impl IpcClient {
             ready_http: merge_ready_http_override(None, opts.http),
             ready_port: opts.port.map(ReadyPort::new),
             ready_cmd: opts.cmd.clone().map(ReadyCmd::new),
+            health_cmd: opts.health_cmd.clone().map(HealthCmd::new),
+            health_http: opts.health_http.clone().map(HealthHttp::new),
+            health_port: opts.health_port.map(HealthPort::new),
             port: crate::config_types::PortConfig::from_parts(
                 opts.expected_port.unwrap_or_default(),
                 opts.auto_bump_port.unwrap_or_default(),

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -15,9 +15,9 @@ use std::time::SystemTime;
 
 // Re-export config value types so existing `use crate::pitchfork_toml::X` paths keep working.
 pub use crate::config_types::{
-    CpuLimit, CronRetrigger, Dir, MemoryLimit, OnOutputHook, PitchforkTomlAuto, PitchforkTomlCron,
-    PitchforkTomlHooks, PortBump, PortConfig, ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort, Retry,
-    StopConfig, StopSignal, WatchMode,
+    CpuLimit, CronRetrigger, Dir, HealthCmd, HealthHttp, HealthPort, MemoryLimit, OnOutputHook,
+    PitchforkTomlAuto, PitchforkTomlCron, PitchforkTomlHooks, PortBump, PortConfig, ReadyCmd,
+    ReadyHttp, ReadyOutput, ReadyPort, Retry, StopConfig, StopSignal, WatchMode,
 };
 
 /// Raw slug entry as read from TOML (uses String for dir path).
@@ -180,6 +180,12 @@ struct PitchforkTomlDaemonRaw {
     pub ready_port: Option<ReadyPort>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ready_cmd: Option<ReadyCmd>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub health_cmd: Option<HealthCmd>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub health_http: Option<HealthHttp>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub health_port: Option<HealthPort>,
     /// New port configuration (preferred)
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub port: Option<PortConfig>,
@@ -1283,6 +1289,9 @@ impl PitchforkToml {
                 ready_http: raw_daemon.ready_http,
                 ready_port: raw_daemon.ready_port,
                 ready_cmd: raw_daemon.ready_cmd,
+                health_cmd: raw_daemon.health_cmd,
+                health_http: raw_daemon.health_http,
+                health_port: raw_daemon.health_port,
                 port,
                 boot_start: raw_daemon.boot_start,
                 depends,
@@ -1434,6 +1443,9 @@ impl PitchforkToml {
                     ready_http: daemon.ready_http.clone(),
                     ready_port: daemon.ready_port.clone(),
                     ready_cmd: daemon.ready_cmd.clone(),
+                    health_cmd: daemon.health_cmd.clone(),
+                    health_http: daemon.health_http.clone(),
+                    health_port: daemon.health_port.clone(),
                     port: port.cloned(),
                     // Deprecated fields: written for backward compatibility with older pitchfork versions
                     expected_port: port.map(|p| p.expect.clone()).unwrap_or_default(),
@@ -1817,6 +1829,14 @@ pub struct PitchforkTomlDaemon {
     pub ready_port: Option<ReadyPort>,
     /// Shell command to poll for readiness (exit code 0 = ready)
     pub ready_cmd: Option<ReadyCmd>,
+    /// Shell command to poll for health (exit code 0 = healthy)
+    pub health_cmd: Option<HealthCmd>,
+    /// HTTP endpoint URL to poll for health
+    pub health_http: Option<HealthHttp>,
+    /// TCP port to probe for health (connection success = healthy).
+    /// Accepts a port number, a Tera template string that renders to one, or an
+    /// object with optional per-check `interval` and `retries`.
+    pub health_port: Option<HealthPort>,
     /// Port configuration: expected ports and auto-bump settings
     pub port: Option<PortConfig>,
     /// Whether to start this daemon automatically on system boot
@@ -1938,6 +1958,9 @@ impl PitchforkTomlDaemon {
             ready_http: self.ready_http.clone(),
             ready_port: self.ready_port.clone(),
             ready_cmd: self.ready_cmd.clone(),
+            health_cmd: self.health_cmd.clone(),
+            health_http: self.health_http.clone(),
+            health_port: self.health_port.clone(),
             port: self.port.clone(),
             wait_ready: false,
             depends: self.depends.clone(),

--- a/src/pitchfork_toml.rs
+++ b/src/pitchfork_toml.rs
@@ -1835,7 +1835,7 @@ pub struct PitchforkTomlDaemon {
     pub health_http: Option<HealthHttp>,
     /// TCP port to probe for health (connection success = healthy).
     /// Accepts a port number, a Tera template string that renders to one, or an
-    /// object with optional per-check `interval` and `retries`.
+    /// object with optional per-check `interval`, `retries`, and `timeout`.
     pub health_port: Option<HealthPort>,
     /// Port configuration: expected ports and auto-bump settings
     pub port: Option<PortConfig>,

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -256,11 +256,14 @@ impl Procs {
         // A start-time check alone cannot prevent the numeric PID/PGID from
         // being recycled before killpg. Linux closes that race with a pidfd.
         // Other Unix platforms have no durable process handle, so they do the
-        // next best thing: re-verify the start time here, inside the blocking
-        // operation and immediately before the signal. A daemon that exits in
-        // the microseconds remaining is indistinguishable from one that died
-        // a moment earlier, and the close-enough window is bounded by one
-        // refresh + one killpg instead of an arbitrary await pause.
+        // next best thing: re-read the start time fresh from the kernel here,
+        // inside the blocking operation and immediately before the signal, so
+        // the check-to-signal gap is just the adjacency of two syscalls in one
+        // thread — no await, no scheduler boundary. For that gap to matter, the
+        // kernel would have to wrap the entire sequential PID space (XNU
+        // allocates monotonically from lastpid and refuses IDs still in use as
+        // a proc, pgrp, or session) and hand the exact PGID to a new group
+        // leader between the two syscalls, which is not reachable in practice.
         #[cfg(not(target_os = "linux"))]
         if let Some(expected) = expected_start_time {
             if !self.start_time_matches(pid, expected) {

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -98,7 +98,7 @@ impl Procs {
         process_start_token(pid)
     }
 
-    #[cfg(any(target_os = "linux", windows))]
+    #[cfg(any(unix, windows))]
     fn start_time_matches(&self, pid: u32, expected: u64) -> bool {
         self.start_time(pid) == Some(expected)
     }
@@ -197,14 +197,23 @@ impl Procs {
     /// Identity is refreshed inside the blocking kill operation, immediately
     /// before signaling. Linux holds a pidfd and Windows holds an open process
     /// handle across termination so the validated PID cannot be recycled.
-    /// Unix platforms without a durable process handle fail closed.
+    /// Unix platforms without a durable process handle re-verify the start
+    /// time inside the blocking operation, right before the signal — the
+    /// same check-then-signal atomicity tokio affords in one closure. Pass
+    /// `None` to fail closed (refuse to signal anything).
     pub async fn kill_process_group_if_start_time_matches_async(
         &self,
         pid: u32,
-        expected_start_time: u64,
+        expected_start_time: Option<u64>,
         stop_signal: i32,
         stop_timeout: Option<std::time::Duration>,
     ) -> Result<bool> {
+        let Some(expected_start_time) = expected_start_time else {
+            warn!(
+                "no recorded start time for pid {pid}; refusing to signal it (identity cannot be bound to a process generation)"
+            );
+            return Ok(false);
+        };
         tokio::task::spawn_blocking(move || {
             PROCS.kill_process_group(pid, stop_signal, stop_timeout, Some(expected_start_time))
         })
@@ -245,14 +254,19 @@ impl Procs {
         }
 
         // A start-time check alone cannot prevent the numeric PID/PGID from
-        // being recycled before killpg. Linux closes that race with a pidfd;
-        // other Unix platforms must refuse identity-checked termination.
+        // being recycled before killpg. Linux closes that race with a pidfd.
+        // Other Unix platforms have no durable process handle, so they do the
+        // next best thing: re-verify the start time here, inside the blocking
+        // operation and immediately before the signal. A daemon that exits in
+        // the microseconds remaining is indistinguishable from one that died
+        // a moment earlier, and the close-enough window is bounded by one
+        // refresh + one killpg instead of an arbitrary await pause.
         #[cfg(not(target_os = "linux"))]
-        if expected_start_time.is_some() {
-            warn!(
-                "cannot securely identify process group {pgid} on this platform; refusing to signal it"
-            );
-            return Ok(false);
+        if let Some(expected) = expected_start_time {
+            if !self.start_time_matches(pid, expected) {
+                debug!("process {pid} identity changed before killpg; refusing to signal it");
+                return Ok(false);
+            }
         }
 
         debug!("killing process group {pgid} with {signal_name}");
@@ -1274,7 +1288,7 @@ mod tests {
         let killed = PROCS
             .kill_process_group_if_start_time_matches_async(
                 pid,
-                actual_start_time.saturating_add(1),
+                Some(actual_start_time.saturating_add(1)),
                 libc::SIGTERM,
                 Some(Duration::from_millis(100)),
             )
@@ -1285,9 +1299,13 @@ mod tests {
         assert!(PROCS.is_running(pid), "mismatched process must survive");
     }
 
-    #[cfg(not(target_os = "linux"))]
+    /// On Unix platforms without a durable process handle the generation
+    /// check runs inside the blocking operation, immediately before the
+    /// signal: a matching generation is signalled, a mismatched one is
+    /// refused at the last moment.
+    #[cfg(all(unix, not(target_os = "linux")))]
     #[tokio::test]
-    async fn orphan_identity_checked_group_kill_fails_closed_without_pidfd() {
+    async fn identity_checked_group_kill_reverifies_inside_blocking_op() {
         let mut command = Command::new("sleep");
         command
             .arg("30")
@@ -1315,17 +1333,17 @@ mod tests {
         let killed = PROCS
             .kill_process_group_if_start_time_matches_async(
                 pid,
-                actual_start_time,
+                Some(actual_start_time),
                 libc::SIGTERM,
                 Some(Duration::from_millis(100)),
             )
             .await
             .expect("identity-checked kill should not error");
 
-        assert!(!killed);
+        assert!(killed, "matching generation must be signalled");
         assert!(
-            PROCS.is_running(pid),
-            "process must survive when identity cannot be pinned"
+            !PROCS.is_running(pid),
+            "signalled process group must be gone"
         );
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -718,6 +718,41 @@ pub struct SettingsSupervisor {
     #[usage(env = "PITCHFORK_FILE_WATCH_DEBOUNCE", default = "1s", ty = "duration")]
     pub file_watch_debounce: String,
 
+    /// Default time between health probes
+    ///
+    /// When a daemon has `health_cmd`, `health_http` or `health_port`
+    /// configured but does not set its own `interval`, the supervisor probes
+    /// it this often.
+    #[usage(
+        env = "PITCHFORK_HEALTH_CHECK_INTERVAL",
+        default = "10s",
+        ty = "duration"
+    )]
+    pub health_check_interval: String,
+
+    /// Default consecutive health-check failures before killing a daemon
+    ///
+    /// When a daemon's `health_cmd`, `health_http` or `health_port` fails this
+    /// many times in a row, the daemon is killed as a crash so the retry logic
+    /// restarts it. Individual daemons can override this with `retries` in
+    /// their health check configuration.
+    #[usage(env = "PITCHFORK_HEALTH_CHECK_RETRIES", default = 3)]
+    pub health_check_retries: i64,
+
+    /// Default per-probe timeout for `health_cmd`
+    ///
+    /// Maximum time to wait for a `health_cmd` shell command to finish before
+    /// counting the probe as failed and cancelling it.
+    #[usage(env = "PITCHFORK_HEALTH_CMD_TIMEOUT", default = "10s", ty = "duration")]
+    pub health_cmd_timeout: String,
+
+    /// Default per-request timeout for `health_http`
+    ///
+    /// Maximum time to wait for a response from a `health_http` endpoint before
+    /// counting the probe as failed.
+    #[usage(env = "PITCHFORK_HEALTH_HTTP_TIMEOUT", default = "5s", ty = "duration")]
+    pub health_http_timeout: String,
+
     /// Timeout for HTTP ready checks
     ///
     /// Maximum time to wait for a response when checking `ready_http` endpoints.
@@ -1085,6 +1120,9 @@ duration_getters! {
     proxy_auto_start_timeout => proxy.auto_start_timeout, "30s";
     supervisor_cron_check_interval => supervisor.cron_check_interval, "10s";
     supervisor_file_watch_debounce => supervisor.file_watch_debounce, "1s";
+    supervisor_health_check_interval => supervisor.health_check_interval, "10s";
+    supervisor_health_cmd_timeout => supervisor.health_cmd_timeout, "10s";
+    supervisor_health_http_timeout => supervisor.health_http_timeout, "5s";
     supervisor_http_client_timeout => supervisor.http_client_timeout, "5s";
     supervisor_log_flush_interval => supervisor.log_flush_interval, "500ms";
     supervisor_ready_check_interval => supervisor.ready_check_interval, "500ms";
@@ -1627,6 +1665,14 @@ settings_partial! {
         cron_check_interval: String,
         /// File watch debounce duration
         file_watch_debounce: String,
+        /// Default time between health probes
+        health_check_interval: String,
+        /// Default consecutive health-check failures before killing a daemon
+        health_check_retries: i64,
+        /// Default per-probe timeout for health_cmd
+        health_cmd_timeout: String,
+        /// Default per-request timeout for health_http
+        health_http_timeout: String,
         /// Timeout for HTTP ready checks
         http_client_timeout: String,
         /// Daemon log buffer flush interval
@@ -1817,9 +1863,10 @@ mod tests {
             .iter()
             .map(|meta| meta.key)
             .collect();
-        assert_eq!(keys.len(), 68, "{keys:?}");
+        assert_eq!(keys.len(), 72, "{keys:?}");
         assert!(keys.contains(&"general.autostop_delay"));
         assert!(keys.contains(&"logs.archive_hook.command"));
+        assert!(keys.contains(&"supervisor.health_check_interval"));
         assert!(keys.contains(&"supervisor.watch_interval"));
 
         let registry = Settings::SETTINGS_REGISTRY;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1401,6 +1401,17 @@ fn readable_settings_file(path: &Path) -> bool {
 /// matching the previous loader, which rejected invalid durations at load
 /// time. A value equal to the declared default is left alone (the
 /// `logs.time_retention` default is the empty string, meaning "disabled").
+/// Duration settings where `0s` is never meaningful: the value is passed
+/// straight into `tokio::time::timeout` for a health probe, so a zero
+/// timeout fails every probe immediately and would crash-kill a healthy
+/// daemon after the retry threshold. Same defect family as the per-daemon
+/// health timeout rejection in `config_types.rs` (`parse_positive_timeout`).
+const NON_ZERO_DURATION_KEYS: &[&str] = &[
+    "supervisor.health_cmd_timeout",
+    "supervisor.health_http_timeout",
+    "supervisor.health_port_timeout",
+];
+
 fn sanitize_durations(resolved: &mut Resolved) {
     let registry = Settings::SETTINGS_REGISTRY;
     for id in registry.ids() {
@@ -1415,22 +1426,28 @@ fn sanitize_durations(resolved: &mut Resolved) {
             Some(Const::Str(s)) => s,
             _ => "",
         };
-        if text == default_text || humantime::parse_duration(text).is_ok() {
+        if text == default_text {
             continue;
         }
-        let text = text.clone();
+        let reason = match humantime::parse_duration(text) {
+            Err(_) => Some(format!("invalid duration {text:?}")),
+            Ok(d) if d.is_zero() && NON_ZERO_DURATION_KEYS.contains(&meta.key) => Some(format!(
+                "supervisor health probe timeout must be greater than 0, got {text:?}"
+            )),
+            Ok(_) => None,
+        };
+        let Some(reason) = reason else {
+            continue;
+        };
         let origin = resolved
             .origin(id)
             .map(|o| o.describe().to_string())
             .unwrap_or_default();
-        warn!(
-            "invalid duration {:?} for {} (set by {}), using default",
-            text, meta.key, origin
-        );
+        warn!("{reason} (set by {origin}), using default");
         resolved.coerced(
             id,
             Value::String(default_text.to_string()),
-            format!("invalid duration {text:?}; the default stands"),
+            format!("{reason}; the default stands"),
         );
     }
 }
@@ -2076,6 +2093,34 @@ mod tests {
         let settings = Settings::read(&resolved).unwrap();
         assert_eq!(settings.general.autostop_delay, "1m");
         assert_eq!(settings.general_autostop_delay(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_zero_health_timeout_from_env_falls_back_to_default() {
+        // A zero health probe timeout goes straight into tokio::time::timeout
+        // and fails every probe immediately; the sanitize pass falls back to
+        // the schema default like any other invalid duration.
+        let env = EnvLayer::new([
+            ("PITCHFORK_HEALTH_CMD_TIMEOUT".to_string(), "0s".to_string()),
+            (
+                "PITCHFORK_HEALTH_HTTP_TIMEOUT".to_string(),
+                "0s".to_string(),
+            ),
+            (
+                "PITCHFORK_HEALTH_PORT_TIMEOUT".to_string(),
+                "0s".to_string(),
+            ),
+        ]);
+        let mut resolved = resolve(Settings::SETTINGS_REGISTRY, Layers::new().then(&env)).unwrap();
+        sanitize_durations(&mut resolved);
+        let settings = Settings::read(&resolved).unwrap();
+        assert_eq!(settings.supervisor.health_cmd_timeout, "10s");
+        assert_eq!(
+            settings.supervisor_health_cmd_timeout(),
+            Duration::from_secs(10)
+        );
+        assert_eq!(settings.supervisor.health_http_timeout, "5s");
+        assert_eq!(settings.supervisor.health_port_timeout, "5s");
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -753,6 +753,13 @@ pub struct SettingsSupervisor {
     #[usage(env = "PITCHFORK_HEALTH_HTTP_TIMEOUT", default = "5s", ty = "duration")]
     pub health_http_timeout: String,
 
+    /// Default per-connect timeout for `health_port`
+    ///
+    /// Maximum time to wait for a TCP connection to a `health_port` to
+    /// establish before counting the probe as failed.
+    #[usage(env = "PITCHFORK_HEALTH_PORT_TIMEOUT", default = "5s", ty = "duration")]
+    pub health_port_timeout: String,
+
     /// Timeout for HTTP ready checks
     ///
     /// Maximum time to wait for a response when checking `ready_http` endpoints.
@@ -1123,6 +1130,7 @@ duration_getters! {
     supervisor_health_check_interval => supervisor.health_check_interval, "10s";
     supervisor_health_cmd_timeout => supervisor.health_cmd_timeout, "10s";
     supervisor_health_http_timeout => supervisor.health_http_timeout, "5s";
+    supervisor_health_port_timeout => supervisor.health_port_timeout, "5s";
     supervisor_http_client_timeout => supervisor.http_client_timeout, "5s";
     supervisor_log_flush_interval => supervisor.log_flush_interval, "500ms";
     supervisor_ready_check_interval => supervisor.ready_check_interval, "500ms";
@@ -1673,6 +1681,8 @@ settings_partial! {
         health_cmd_timeout: String,
         /// Default per-request timeout for health_http
         health_http_timeout: String,
+        /// Default per-connect timeout for health_port
+        health_port_timeout: String,
         /// Timeout for HTTP ready checks
         http_client_timeout: String,
         /// Daemon log buffer flush interval
@@ -1863,7 +1873,7 @@ mod tests {
             .iter()
             .map(|meta| meta.key)
             .collect();
-        assert_eq!(keys.len(), 72, "{keys:?}");
+        assert_eq!(keys.len(), 73, "{keys:?}");
         assert!(keys.contains(&"general.autostop_delay"));
         assert!(keys.contains(&"logs.archive_hook.command"));
         assert!(keys.contains(&"supervisor.health_check_interval"));

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -287,7 +287,7 @@ impl Supervisor {
             match PROCS
                 .kill_process_group_if_start_time_matches_async(
                     pid,
-                    expected_start_time,
+                    Some(expected_start_time),
                     stop_cfg.signal.into(),
                     stop_cfg.timeout,
                 )

--- a/src/supervisor/health.rs
+++ b/src/supervisor/health.rs
@@ -186,9 +186,14 @@ impl Supervisor {
     /// probe (or the resource-limit observation) ran, not a fresh read: the
     /// kill is refused if the recorded daemon has since moved to a new process
     /// generation, because a restarted daemon that reuses the PID must not be
-    /// killed for its predecessor's failures. The signal itself is issued via
-    /// [`PROCS::kill_process_group_if_start_time_matches_async`], which binds
-    /// the start-time check and the kill into one atomic operation.
+    /// killed for its predecessor's failures. On Linux and Windows the signal
+    /// is issued via [`PROCS::kill_process_group_if_start_time_matches_async`],
+    /// which binds the start-time check and the kill into one atomic
+    /// operation (pidfd on Linux, an open process handle on Windows). Other
+    /// Unix platforms lack a durable process handle, so that checked kill is
+    /// refused there; the enforcement falls back to a best-effort signal after
+    /// the identity checks above have already confirmed the recorded
+    /// generation, so a failed daemon can still be terminated and restarted.
     ///
     /// `reason` names the enforcement in log lines (e.g. "due to resource
     /// limit violation" or "due to health check failure (2 consecutive
@@ -247,31 +252,46 @@ impl Supervisor {
             .await;
             return;
         }
-        // Fail closed when no start time was ever recorded: the kill cannot be
-        // bound to a process generation, so refuse rather than risk signalling
-        // a recycled PID.
-        let Some(expected_start_time) = expected_start_time else {
-            warn!(
-                "daemon {id} has no recorded start time; cannot securely kill pid {pid} {reason}"
-            );
-            return;
-        };
         let stop_cfg = daemon.stop_signal.unwrap_or_default();
         let stop_signal: i32 = stop_cfg.signal.into();
-        match PROCS
-            .kill_process_group_if_start_time_matches_async(
-                pid,
-                expected_start_time,
-                stop_signal,
-                stop_cfg.timeout,
-            )
-            .await
-        {
+        // Linux (pidfd) and Windows (open process handle) can pin the process
+        // identity across the kill, so use the atomically identity-checked
+        // path there. Fail closed when no start time was ever recorded: the
+        // kill cannot be bound to a process generation, so refuse rather than
+        // risk signalling a recycled PID.
+        #[cfg(any(target_os = "linux", windows))]
+        let kill_result = {
+            let Some(expected_start_time) = expected_start_time else {
+                warn!(
+                    "daemon {id} has no recorded start time; cannot securely kill pid {pid} {reason}"
+                );
+                return;
+            };
+            PROCS
+                .kill_process_group_if_start_time_matches_async(
+                    pid,
+                    expected_start_time,
+                    stop_signal,
+                    stop_cfg.timeout,
+                )
+                .await
+        };
+        // Other Unix platforms (macOS, BSD, ...) have no durable process
+        // handle, so an identity-checked process-group kill is refused there
+        // and a failed daemon would never be terminated (and thus never
+        // restarted). Fall back to a best-effort signal: the identity checks
+        // above just confirmed the recorded generation against the live
+        // process, and the window between that check and the killpg is
+        // negligible next to the probe period — far less exposure than
+        // leaving a failed daemon running forever.
+        #[cfg(all(unix, not(target_os = "linux")))]
+        let kill_result = PROCS
+            .kill_process_group_async(pid, stop_signal, stop_cfg.timeout)
+            .await;
+        match kill_result {
             Ok(true) => {}
             Ok(false) => {
-                warn!(
-                    "could not securely kill daemon {id} (pid {pid}) {reason}; retaining running state"
-                );
+                warn!("could not kill daemon {id} (pid {pid}) {reason}; retaining running state");
             }
             Err(err) => {
                 error!("failed to kill daemon {id} (pid {pid}) {reason}: {err}");

--- a/src/supervisor/health.rs
+++ b/src/supervisor/health.rs
@@ -179,6 +179,14 @@ impl Supervisor {
     pub(crate) async fn kill_daemon_as_crash(&self, id: &DaemonId, pid: u32, reason: &str) {
         info!("killing daemon {id} (pid {pid}) {reason}");
         let daemon = self.get_daemon(id).await;
+        // A probe can complete long after the daemon it watched stopped or
+        // restarted, by which point `pid` may have been recycled. If the daemon
+        // no longer records this pid, there is nothing of ours left to kill —
+        // and signalling the recycled pid could hit an unrelated process group.
+        if daemon.as_ref().and_then(|d| d.pid) != Some(pid) {
+            warn!("daemon {id} no longer owns pid {pid}; not killing it {reason}");
+            return;
+        }
         // Never signal a process group that provably isn't the daemon's: a
         // recycled PID would mean killing an unrelated process tree.
         let recorded_start_time = daemon.as_ref().and_then(|d| d.start_time);
@@ -247,6 +255,11 @@ fn effective_http_timeout(http: &HealthHttp) -> Duration {
         .unwrap_or_else(|| settings().supervisor_health_http_timeout())
 }
 
+/// Effective per-connect timeout for a TCP port health check.
+fn effective_port_timeout() -> Duration {
+    settings().supervisor_health_port_timeout()
+}
+
 /// Effective failure threshold. With multiple probe kinds configured, the
 /// strictest budget wins so any kind can trigger the kill within its own
 /// retries; with one kind, its value (or the default) applies.
@@ -263,7 +276,12 @@ fn effective_retries(
     .into_iter()
     .flatten()
     .min()
-    .unwrap_or_else(|| settings().supervisor.health_check_retries.max(1) as u32)
+    .unwrap_or_else(|| {
+        settings()
+            .supervisor
+            .health_check_retries
+            .clamp(1, u32::MAX as i64) as u32
+    })
 }
 
 /// Run one command health probe. Healthy = exit code 0; spawn failures, io
@@ -317,13 +335,19 @@ async fn health_http_probe(id: &DaemonId, http: &HealthHttp, client: &reqwest::C
 }
 
 /// Run one TCP port health probe. Healthy = a connection to 127.0.0.1:<port>
-/// succeeds; connection refused/reset counts as failed. The connect is to
-/// loopback, so it either succeeds or fails immediately — no timeout needed.
+/// succeeds; connection refused/reset counts as failed. The connect is bounded
+/// by `supervisor.health_port_timeout` so a saturated accept backlog cannot
+/// stall the probe loop indefinitely.
 async fn health_port_probe(id: &DaemonId, port: u16) -> bool {
-    match tokio::net::TcpStream::connect(("127.0.0.1", port)).await {
-        Ok(_) => true,
-        Err(e) => {
+    let timeout = effective_port_timeout();
+    match tokio::time::timeout(timeout, tokio::net::TcpStream::connect(("127.0.0.1", port))).await {
+        Ok(Ok(_)) => true,
+        Ok(Err(e)) => {
             debug!("daemon {id} health check (port) connect to {port} failed: {e}");
+            false
+        }
+        Err(_) => {
+            debug!("daemon {id} health check (port) connect to {port} timed out after {timeout:?}");
             false
         }
     }

--- a/src/supervisor/health.rs
+++ b/src/supervisor/health.rs
@@ -75,6 +75,7 @@ impl Supervisor {
     /// for a daemon that is still becoming ready.
     async fn run_health_checks(&self, id: DaemonId) {
         let mut last_pid: Option<u32> = None;
+        let mut last_start_time: Option<u64> = None;
         let mut consecutive_failures: u32 = 0;
         let mut http_client: Option<reqwest::Client> = None;
         loop {
@@ -98,10 +99,13 @@ impl Supervisor {
                 return;
             };
             // A restarted daemon (crashed and retried, or restarted by the
-            // user) gets a fresh failure budget.
-            if daemon.pid != last_pid {
+            // user) gets a fresh failure budget. PID alone is not enough to
+            // detect a restart: the OS may reuse the same PID for a new
+            // process, so the start time disambiguates process generations.
+            if process_identity_changed(last_pid, last_start_time, daemon.pid, daemon.start_time) {
                 consecutive_failures = 0;
                 last_pid = daemon.pid;
+                last_start_time = daemon.start_time;
             }
             let retries =
                 effective_retries(&daemon.health_cmd, &daemon.health_http, &daemon.health_port);
@@ -218,6 +222,18 @@ impl Supervisor {
             error!("failed to kill daemon {id} (pid {pid}) {reason}: {e}");
         }
     }
+}
+
+/// Whether a daemon's process identity changed since the last probe, meaning
+/// the failure budget must reset. A PID alone can be reused by the OS after a
+/// restart, so the start time disambiguates process generations.
+fn process_identity_changed(
+    last_pid: Option<u32>,
+    last_start_time: Option<u64>,
+    current_pid: Option<u32>,
+    current_start_time: Option<u64>,
+) -> bool {
+    last_pid != current_pid || last_start_time != current_start_time
 }
 
 /// Build the shared HTTP client used for daemon health probes.
@@ -552,6 +568,33 @@ mod tests {
             }),
             override_
         );
+    }
+
+    #[test]
+    fn process_identity_changed_resets_on_reused_pid() {
+        // Same PID, different start time: a new process generation.
+        assert!(process_identity_changed(
+            Some(42),
+            Some(100),
+            Some(42),
+            Some(200)
+        ));
+        // Same PID, same start time: the same process.
+        assert!(!process_identity_changed(
+            Some(42),
+            Some(100),
+            Some(42),
+            Some(100)
+        ));
+        // Different PID: a new process regardless of start time.
+        assert!(process_identity_changed(
+            Some(42),
+            Some(100),
+            Some(43),
+            Some(100)
+        ));
+        // First probe (no last identity yet): always a fresh budget.
+        assert!(process_identity_changed(None, None, Some(42), Some(100)));
     }
 
     #[tokio::test]

--- a/src/supervisor/health.rs
+++ b/src/supervisor/health.rs
@@ -126,8 +126,9 @@ impl Supervisor {
             }
             // A port that is None (unrendered template) skips the probe and
             // does not count as a failure.
-            if let Some(port) = daemon.health_port.as_ref().and_then(|p| p.as_port())
-                && !health_port_probe(&id, port).await
+            if let Some(health_port) = daemon.health_port.as_ref()
+                && let Some(port) = health_port.as_port()
+                && !health_port_probe(&id, port, effective_port_timeout(health_port)).await
             {
                 failed_kinds.push("port");
             }
@@ -256,8 +257,9 @@ fn effective_http_timeout(http: &HealthHttp) -> Duration {
 }
 
 /// Effective per-connect timeout for a TCP port health check.
-fn effective_port_timeout() -> Duration {
-    settings().supervisor_health_port_timeout()
+fn effective_port_timeout(port: &HealthPort) -> Duration {
+    port.timeout
+        .unwrap_or_else(|| settings().supervisor_health_port_timeout())
 }
 
 /// Effective failure threshold. With multiple probe kinds configured, the
@@ -336,10 +338,9 @@ async fn health_http_probe(id: &DaemonId, http: &HealthHttp, client: &reqwest::C
 
 /// Run one TCP port health probe. Healthy = a connection to 127.0.0.1:<port>
 /// succeeds; connection refused/reset counts as failed. The connect is bounded
-/// by `supervisor.health_port_timeout` so a saturated accept backlog cannot
-/// stall the probe loop indefinitely.
-async fn health_port_probe(id: &DaemonId, port: u16) -> bool {
-    let timeout = effective_port_timeout();
+/// by the per-daemon `health_port.timeout` (or `supervisor.health_port_timeout`)
+/// so a saturated accept backlog cannot stall the probe loop indefinitely.
+async fn health_port_probe(id: &DaemonId, port: u16, timeout: Duration) -> bool {
     match tokio::time::timeout(timeout, tokio::net::TcpStream::connect(("127.0.0.1", port))).await {
         Ok(Ok(_)) => true,
         Ok(Err(e)) => {
@@ -397,6 +398,7 @@ mod tests {
             template: None,
             interval,
             retries,
+            timeout: None,
         })
     }
 
@@ -533,16 +535,35 @@ mod tests {
         );
     }
 
+    #[test]
+    fn effective_port_timeout_defaults_and_overrides() {
+        assert_eq!(
+            effective_port_timeout(&HealthPort::new(8443)),
+            settings().supervisor_health_port_timeout()
+        );
+        let override_ = Duration::from_secs(9);
+        assert_eq!(
+            effective_port_timeout(&HealthPort {
+                port: Some(8443),
+                template: None,
+                interval: None,
+                retries: None,
+                timeout: Some(override_),
+            }),
+            override_
+        );
+    }
+
     #[tokio::test]
     async fn health_port_probe_connects_to_listening_port() {
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
             .await
             .unwrap();
         let port = listener.local_addr().unwrap().port();
-        assert!(health_port_probe(&DaemonId::new("ns", "x"), port).await);
+        assert!(health_port_probe(&DaemonId::new("ns", "x"), port, Duration::from_secs(5)).await);
 
         // A closed port must count as failed.
         drop(listener);
-        assert!(!health_port_probe(&DaemonId::new("ns", "x"), port).await);
+        assert!(!health_port_probe(&DaemonId::new("ns", "x"), port, Duration::from_secs(5)).await);
     }
 }

--- a/src/supervisor/health.rs
+++ b/src/supervisor/health.rs
@@ -1,0 +1,528 @@
+//! Per-daemon health checks.
+//!
+//! Daemons with `health_cmd`, `health_http` and/or `health_port` configured
+//! get a background task, spawned lazily by the interval watcher, that probes
+//! on the configured interval and kills the daemon after `retries` consecutive
+//! failures. The kill goes through [`Supervisor::kill_daemon_as_crash`], so the
+//! monitor observes a non-zero exit and records `Errored` — making the death
+//! look exactly like a crash and letting the existing retry logic restart the
+//! daemon.
+
+use super::{ExitObservation, SUPERVISOR, Supervisor, signalling_pid_is_authorized};
+use crate::config_types::{HealthCmd, HealthHttp, HealthPort};
+use crate::daemon::Daemon;
+use crate::daemon_id::DaemonId;
+use crate::daemon_status::DaemonStatus;
+use crate::env;
+use crate::procs::PROCS;
+use crate::settings::settings;
+use crate::supervisor::lifecycle::spawn_cmd_probe;
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tokio::time;
+
+impl Supervisor {
+    /// Prune finished health-check tasks and spawn new ones for daemons that
+    /// are running with a health check configured and no live task.
+    ///
+    /// Called from the interval watcher on every tick.
+    pub(crate) async fn manage_health_tasks(&self, tasks: &mut HashMap<DaemonId, JoinHandle<()>>) {
+        tasks.retain(|id, handle| {
+            if handle.is_finished() {
+                debug!("health check task for daemon {id} finished");
+                false
+            } else {
+                true
+            }
+        });
+
+        let pitchfork_id = DaemonId::pitchfork();
+        let to_spawn: Vec<DaemonId> = {
+            let state = self.state_file.lock().await;
+            state
+                .daemons
+                .values()
+                .filter(|d| {
+                    d.id != pitchfork_id
+                        && d.status.is_running()
+                        && d.pid.is_some()
+                        && (d.health_cmd.is_some()
+                            || d.health_http.is_some()
+                            || d.health_port.is_some())
+                        && !tasks.contains_key(&d.id)
+                })
+                .map(|d| d.id.clone())
+                .collect()
+        };
+        for id in to_spawn {
+            info!("starting health checks for daemon {id}");
+            let task_id = id.clone();
+            let handle = tokio::spawn(async move {
+                SUPERVISOR.run_health_checks(task_id).await;
+            });
+            tasks.insert(id, handle);
+        }
+    }
+
+    /// Body of a per-daemon health-check task.
+    ///
+    /// Loops: sleep one interval, re-read the daemon (exiting when it is gone,
+    /// no longer running, or has lost its health configuration), run all
+    /// configured probes, and kill the daemon as a crash once the consecutive
+    /// failure count reaches the retry threshold. A restart resets the failure
+    /// budget, so the `retries * interval` window doubles as the grace period
+    /// for a daemon that is still becoming ready.
+    async fn run_health_checks(&self, id: DaemonId) {
+        let mut last_pid: Option<u32> = None;
+        let mut consecutive_failures: u32 = 0;
+        let mut http_client: Option<reqwest::Client> = None;
+        loop {
+            let Some(daemon) = self.current_health_target(&id).await else {
+                debug!("health checks for daemon {id}: not running or not configured, stopping");
+                return;
+            };
+            time::sleep(effective_interval(
+                &daemon.health_cmd,
+                &daemon.health_http,
+                &daemon.health_port,
+            ))
+            .await;
+
+            // Re-read after the sleep: the daemon may have stopped or restarted
+            // while we waited.
+            let Some(daemon) = self.current_health_target(&id).await else {
+                return;
+            };
+            let Some(pid) = daemon.pid else {
+                return;
+            };
+            // A restarted daemon (crashed and retried, or restarted by the
+            // user) gets a fresh failure budget.
+            if daemon.pid != last_pid {
+                consecutive_failures = 0;
+                last_pid = daemon.pid;
+            }
+            let retries =
+                effective_retries(&daemon.health_cmd, &daemon.health_http, &daemon.health_port);
+
+            // A daemon is unhealthy if ANY configured probe fails; all
+            // configured probes always run.
+            let mut failed_kinds: Vec<&str> = Vec::new();
+            if let Some(cmd) = &daemon.health_cmd
+                && !health_cmd_probe(&id, &daemon, cmd).await
+            {
+                failed_kinds.push("cmd");
+            }
+            if let Some(http) = &daemon.health_http {
+                if http_client.is_none() {
+                    http_client = Some(supervisor_http_client());
+                }
+                if let Some(client) = http_client.as_ref()
+                    && !health_http_probe(&id, http, client).await
+                {
+                    failed_kinds.push("http");
+                }
+            }
+            // A port that is None (unrendered template) skips the probe and
+            // does not count as a failure.
+            if let Some(port) = daemon.health_port.as_ref().and_then(|p| p.as_port())
+                && !health_port_probe(&id, port).await
+            {
+                failed_kinds.push("port");
+            }
+
+            if failed_kinds.is_empty() {
+                consecutive_failures = 0;
+                continue;
+            }
+            consecutive_failures += 1;
+            warn!(
+                "daemon {id} health check failed ({}): {consecutive_failures}/{retries} consecutive failures",
+                failed_kinds.join("/"),
+            );
+            if consecutive_failures >= retries {
+                let reason = format!(
+                    "due to health check failure ({consecutive_failures} consecutive failures)"
+                );
+                self.kill_daemon_as_crash(&id, pid, &reason).await;
+                return;
+            }
+        }
+    }
+
+    /// Read the daemon from state, returning it only while it is a valid
+    /// health-check target: running, has a pid, and has at least one probe
+    /// configured.
+    async fn current_health_target(&self, id: &DaemonId) -> Option<Daemon> {
+        let daemon = self.get_daemon(id).await?;
+        if daemon.status.is_running()
+            && daemon.pid.is_some()
+            && (daemon.health_cmd.is_some()
+                || daemon.health_http.is_some()
+                || daemon.health_port.is_some())
+        {
+            Some(daemon)
+        } else {
+            None
+        }
+    }
+
+    /// Kill a daemon without setting `Stopping`, so the monitor observes a
+    /// non-zero exit and records `Errored` — making the death look exactly
+    /// like a crash and letting the retry checker restart the daemon when
+    /// configured. Shared by resource-limit and health-check enforcement.
+    ///
+    /// `reason` names the enforcement in log lines (e.g. "due to resource
+    /// limit violation" or "due to health check failure (2 consecutive
+    /// failures)").
+    pub(crate) async fn kill_daemon_as_crash(&self, id: &DaemonId, pid: u32, reason: &str) {
+        info!("killing daemon {id} (pid {pid}) {reason}");
+        let daemon = self.get_daemon(id).await;
+        // Never signal a process group that provably isn't the daemon's: a
+        // recycled PID would mean killing an unrelated process tree.
+        let recorded_start_time = daemon.as_ref().and_then(|d| d.start_time);
+        if !signalling_pid_is_authorized(recorded_start_time, PROCS.start_time(pid)) {
+            warn!(
+                "pid {pid} recorded for daemon {id} belongs to another process now; not killing it {reason}"
+            );
+            // Leaving the record running would have the watchdog measure the
+            // stranger's usage / probe it on every tick and try to kill it
+            // again each time. The daemon died unobserved, so record that —
+            // the same terminal state orphan reconciliation would reach, and
+            // one that keeps the daemon eligible for retry.
+            self.finalize_if_pid(
+                id,
+                pid,
+                DaemonStatus::Errored(-1),
+                ExitObservation::Unobserved,
+            )
+            .await;
+            return;
+        }
+        let stop_cfg = daemon.and_then(|d| d.stop_signal).unwrap_or_default();
+        let stop_signal: i32 = stop_cfg.signal.into();
+        if let Err(e) = PROCS
+            .kill_process_group_async(pid, stop_signal, stop_cfg.timeout)
+            .await
+        {
+            error!("failed to kill daemon {id} (pid {pid}) {reason}: {e}");
+        }
+    }
+}
+
+/// Build the shared HTTP client used for daemon health probes.
+///
+/// Mirrors the readiness-check client in lifecycle.rs: the total timeout comes
+/// from the `supervisor.http_client_timeout` setting, with the per-probe
+/// timeout layered on top by the caller so a hung request cannot outlive the
+/// configured budget.
+pub(crate) fn supervisor_http_client() -> reqwest::Client {
+    let timeout = settings().supervisor_http_client_timeout();
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .build()
+        .unwrap_or_default()
+}
+
+/// Effective probe interval: the first health check that sets one, else the
+/// default.
+fn effective_interval(
+    cmd: &Option<HealthCmd>,
+    http: &Option<HealthHttp>,
+    port: &Option<HealthPort>,
+) -> Duration {
+    cmd.as_ref()
+        .and_then(|c| c.interval)
+        .or_else(|| http.as_ref().and_then(|h| h.interval))
+        .or_else(|| port.as_ref().and_then(|p| p.interval))
+        .unwrap_or_else(|| settings().supervisor_health_check_interval())
+}
+
+/// Effective per-probe timeout for a command health check.
+fn effective_cmd_timeout(cmd: &HealthCmd) -> Duration {
+    cmd.timeout
+        .unwrap_or_else(|| settings().supervisor_health_cmd_timeout())
+}
+
+/// Effective per-request timeout for an HTTP health check.
+fn effective_http_timeout(http: &HealthHttp) -> Duration {
+    http.timeout
+        .unwrap_or_else(|| settings().supervisor_health_http_timeout())
+}
+
+/// Effective failure threshold. With multiple probe kinds configured, the
+/// strictest budget wins so any kind can trigger the kill within its own
+/// retries; with one kind, its value (or the default) applies.
+fn effective_retries(
+    cmd: &Option<HealthCmd>,
+    http: &Option<HealthHttp>,
+    port: &Option<HealthPort>,
+) -> u32 {
+    [
+        cmd.as_ref().and_then(|c| c.retries),
+        http.as_ref().and_then(|h| h.retries),
+        port.as_ref().and_then(|p| p.retries),
+    ]
+    .into_iter()
+    .flatten()
+    .min()
+    .unwrap_or_else(|| settings().supervisor.health_check_retries.max(1) as u32)
+}
+
+/// Run one command health probe. Healthy = exit code 0; spawn failures, io
+/// errors and timeouts all count as failed. On timeout the probe is cancelled
+/// so its child process is killed.
+async fn health_cmd_probe(id: &DaemonId, daemon: &Daemon, cmd: &HealthCmd) -> bool {
+    let dir = daemon.dir.as_deref().unwrap_or_else(|| env::CWD.as_path());
+    let probe = spawn_cmd_probe(
+        id,
+        &cmd.run,
+        dir,
+        daemon.retry_count,
+        daemon.env.as_ref(),
+        &daemon.resolved_port,
+    );
+    let timeout = effective_cmd_timeout(cmd);
+    match tokio::time::timeout(timeout, probe.result_rx).await {
+        Ok(Ok(Ok(status))) => status.success(),
+        // Spawn failure (channel closed) or io error: treated as failed.
+        Ok(_) => false,
+        // Timed out: cancel the probe so the child process is killed.
+        Err(_) => {
+            let _ = probe.cancel_tx.send(());
+            false
+        }
+    }
+}
+
+/// Run one HTTP health probe. Healthy = the response status is in the
+/// configured list, or any 2xx when the list is empty. Connection errors and
+/// timeouts count as failed.
+async fn health_http_probe(id: &DaemonId, http: &HealthHttp, client: &reqwest::Client) -> bool {
+    let timeout = effective_http_timeout(http);
+    let response = match tokio::time::timeout(timeout, client.get(&http.url).send()).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(e)) => {
+            debug!("daemon {id} health check (http) request failed: {e}");
+            return false;
+        }
+        Err(_) => {
+            debug!("daemon {id} health check (http) timed out after {timeout:?}");
+            return false;
+        }
+    };
+    let status = response.status().as_u16();
+    if http.status.is_empty() {
+        (200..300).contains(&status)
+    } else {
+        http.status.contains(&status)
+    }
+}
+
+/// Run one TCP port health probe. Healthy = a connection to 127.0.0.1:<port>
+/// succeeds; connection refused/reset counts as failed. The connect is to
+/// loopback, so it either succeeds or fails immediately — no timeout needed.
+async fn health_port_probe(id: &DaemonId, port: u16) -> bool {
+    match tokio::net::TcpStream::connect(("127.0.0.1", port)).await {
+        Ok(_) => true,
+        Err(e) => {
+            debug!("daemon {id} health check (port) connect to {port} failed: {e}");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn health_cmd(
+        run: &str,
+        interval: Option<Duration>,
+        timeout: Option<Duration>,
+        retries: Option<u32>,
+    ) -> Option<HealthCmd> {
+        Some(HealthCmd {
+            run: run.into(),
+            interval,
+            timeout,
+            retries,
+        })
+    }
+
+    fn health_http(
+        url: &str,
+        status: Vec<u16>,
+        interval: Option<Duration>,
+        timeout: Option<Duration>,
+        retries: Option<u32>,
+    ) -> Option<HealthHttp> {
+        Some(HealthHttp {
+            url: url.into(),
+            status,
+            interval,
+            timeout,
+            retries,
+        })
+    }
+
+    fn health_port(
+        port: u16,
+        interval: Option<Duration>,
+        retries: Option<u32>,
+    ) -> Option<HealthPort> {
+        Some(HealthPort {
+            port: Some(port),
+            template: None,
+            interval,
+            retries,
+        })
+    }
+
+    #[test]
+    fn effective_interval_defaults_to_10s() {
+        assert_eq!(
+            effective_interval(&None, &None, &None),
+            settings().supervisor_health_check_interval()
+        );
+        assert_eq!(
+            effective_interval(
+                &health_cmd("true", None, None, None),
+                &None,
+                &health_port(8443, None, None)
+            ),
+            settings().supervisor_health_check_interval()
+        );
+    }
+
+    #[test]
+    fn effective_interval_prefers_cmd_then_http_then_port_override() {
+        let cmd_interval = Duration::from_secs(2);
+        let http_interval = Duration::from_secs(7);
+        let port_interval = Duration::from_secs(11);
+        assert_eq!(
+            effective_interval(
+                &health_cmd("true", Some(cmd_interval), None, None),
+                &None,
+                &None
+            ),
+            cmd_interval
+        );
+        assert_eq!(
+            effective_interval(
+                &None,
+                &health_http("http://x", vec![], Some(http_interval), None, None),
+                &health_port(8443, Some(port_interval), None),
+            ),
+            http_interval
+        );
+        // port wins when only it is set.
+        assert_eq!(
+            effective_interval(&None, &None, &health_port(8443, Some(port_interval), None),),
+            port_interval
+        );
+        // cmd wins when all three are set — one sleep per loop, cmd listed first.
+        assert_eq!(
+            effective_interval(
+                &health_cmd("true", Some(cmd_interval), None, None),
+                &health_http("http://x", vec![], Some(http_interval), None, None),
+                &health_port(8443, Some(port_interval), None),
+            ),
+            cmd_interval
+        );
+    }
+
+    #[test]
+    fn effective_cmd_timeout_defaults_and_overrides() {
+        assert_eq!(
+            effective_cmd_timeout(&HealthCmd::new("true")),
+            settings().supervisor_health_cmd_timeout()
+        );
+        let override_ = Duration::from_secs(3);
+        assert_eq!(
+            effective_cmd_timeout(&HealthCmd {
+                run: "true".into(),
+                interval: None,
+                timeout: Some(override_),
+                retries: None,
+            }),
+            override_
+        );
+    }
+
+    #[test]
+    fn effective_http_timeout_defaults_and_overrides() {
+        assert_eq!(
+            effective_http_timeout(&HealthHttp::new("http://x")),
+            settings().supervisor_health_http_timeout()
+        );
+        let override_ = Duration::from_secs(2);
+        assert_eq!(
+            effective_http_timeout(&HealthHttp {
+                url: "http://x".into(),
+                status: vec![],
+                interval: None,
+                timeout: Some(override_),
+                retries: None,
+            }),
+            override_
+        );
+    }
+
+    #[test]
+    fn effective_retries_defaults_and_takes_strictest_budget() {
+        assert_eq!(
+            effective_retries(&None, &None, &None),
+            settings().supervisor.health_check_retries.max(1) as u32
+        );
+        assert_eq!(
+            effective_retries(&health_cmd("true", None, None, Some(2)), &None, &None),
+            2
+        );
+        assert_eq!(
+            effective_retries(
+                &None,
+                &health_http("http://x", vec![], None, None, Some(5)),
+                &None
+            ),
+            5
+        );
+        assert_eq!(
+            effective_retries(&None, &None, &health_port(8443, None, Some(4))),
+            4
+        );
+        // Mixed kinds: the lowest threshold wins, so any probe can trigger
+        // the kill within its own budget.
+        assert_eq!(
+            effective_retries(
+                &health_cmd("true", None, None, Some(5)),
+                &health_http("http://x", vec![], None, None, Some(2)),
+                &health_port(8443, None, Some(3)),
+            ),
+            2
+        );
+        // A kind without retries still counts its default.
+        assert_eq!(
+            effective_retries(
+                &health_cmd("true", None, None, None),
+                &health_http("http://x", vec![], None, None, Some(1)),
+                &None,
+            ),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn health_port_probe_connects_to_listening_port() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let port = listener.local_addr().unwrap().port();
+        assert!(health_port_probe(&DaemonId::new("ns", "x"), port).await);
+
+        // A closed port must count as failed.
+        drop(listener);
+        assert!(!health_port_probe(&DaemonId::new("ns", "x"), port).await);
+    }
+}

--- a/src/supervisor/health.rs
+++ b/src/supervisor/health.rs
@@ -186,14 +186,13 @@ impl Supervisor {
     /// probe (or the resource-limit observation) ran, not a fresh read: the
     /// kill is refused if the recorded daemon has since moved to a new process
     /// generation, because a restarted daemon that reuses the PID must not be
-    /// killed for its predecessor's failures. On Linux and Windows the signal
-    /// is issued via [`PROCS::kill_process_group_if_start_time_matches_async`],
-    /// which binds the start-time check and the kill into one atomic
-    /// operation (pidfd on Linux, an open process handle on Windows). Other
-    /// Unix platforms lack a durable process handle, so that checked kill is
-    /// refused there; the enforcement falls back to a best-effort signal after
-    /// the identity checks above have already confirmed the recorded
-    /// generation, so a failed daemon can still be terminated and restarted.
+    /// killed for its predecessor's failures. The signal is issued via
+    /// [`PROCS::kill_process_group_if_start_time_matches_async`], which binds
+    /// the start-time check and the kill into one blocking operation — pinned
+    /// atomically by a pidfd on Linux and an open process handle on Windows,
+    /// and re-verified immediately before the signal on other Unix platforms,
+    /// so a PID recycled between the checks above and the killpg is still
+    /// rejected there.
     ///
     /// `reason` names the enforcement in log lines (e.g. "due to resource
     /// limit violation" or "due to health check failure (2 consecutive
@@ -254,39 +253,28 @@ impl Supervisor {
         }
         let stop_cfg = daemon.stop_signal.unwrap_or_default();
         let stop_signal: i32 = stop_cfg.signal.into();
-        // Linux (pidfd) and Windows (open process handle) can pin the process
-        // identity across the kill, so use the atomically identity-checked
-        // path there. Fail closed when no start time was ever recorded: the
-        // kill cannot be bound to a process generation, so refuse rather than
-        // risk signalling a recycled PID.
-        #[cfg(any(target_os = "linux", windows))]
-        let kill_result = {
-            let Some(expected_start_time) = expected_start_time else {
-                warn!(
-                    "daemon {id} has no recorded start time; cannot securely kill pid {pid} {reason}"
-                );
-                return;
-            };
-            PROCS
-                .kill_process_group_if_start_time_matches_async(
-                    pid,
-                    expected_start_time,
-                    stop_signal,
-                    stop_cfg.timeout,
-                )
-                .await
+        // Fail closed when no start time was ever recorded: the kill cannot
+        // be bound to a process generation, so refuse rather than risk
+        // signalling a recycled PID.
+        let Some(expected_start_time) = expected_start_time else {
+            warn!(
+                "daemon {id} has no recorded start time; cannot securely kill pid {pid} {reason}"
+            );
+            return;
         };
-        // Other Unix platforms (macOS, BSD, ...) have no durable process
-        // handle, so an identity-checked process-group kill is refused there
-        // and a failed daemon would never be terminated (and thus never
-        // restarted). Fall back to a best-effort signal: the identity checks
-        // above just confirmed the recorded generation against the live
-        // process, and the window between that check and the killpg is
-        // negligible next to the probe period — far less exposure than
-        // leaving a failed daemon running forever.
-        #[cfg(all(unix, not(target_os = "linux")))]
+        // The identity check runs inside the blocking kill operation,
+        // immediately before the signal: Linux and Windows pin the process
+        // identity with a pidfd / open process handle, and other Unix
+        // platforms re-verify the start time in the same closure, so a PID
+        // recycled after the checks above is still rejected at the last
+        // moment before killpg.
         let kill_result = PROCS
-            .kill_process_group_async(pid, stop_signal, stop_cfg.timeout)
+            .kill_process_group_if_start_time_matches_async(
+                pid,
+                Some(expected_start_time),
+                stop_signal,
+                stop_cfg.timeout,
+            )
             .await;
         match kill_result {
             Ok(true) => {}

--- a/src/supervisor/health.rs
+++ b/src/supervisor/health.rs
@@ -213,16 +213,12 @@ impl Supervisor {
 
 /// Build the shared HTTP client used for daemon health probes.
 ///
-/// Mirrors the readiness-check client in lifecycle.rs: the total timeout comes
-/// from the `supervisor.http_client_timeout` setting, with the per-probe
-/// timeout layered on top by the caller so a hung request cannot outlive the
-/// configured budget.
+/// No total timeout is set here: `health_http_probe` bounds each request with
+/// `effective_http_timeout`, so a per-daemon `health_http.timeout` larger than
+/// `supervisor.http_client_timeout` is honored rather than silently capped by
+/// a shared client timeout.
 pub(crate) fn supervisor_http_client() -> reqwest::Client {
-    let timeout = settings().supervisor_http_client_timeout();
-    reqwest::Client::builder()
-        .timeout(timeout)
-        .build()
-        .unwrap_or_default()
+    reqwest::Client::builder().build().unwrap_or_default()
 }
 
 /// Effective probe interval: the first health check that sets one, else the

--- a/src/supervisor/health.rs
+++ b/src/supervisor/health.rs
@@ -150,7 +150,11 @@ impl Supervisor {
                 let reason = format!(
                     "due to health check failure ({consecutive_failures} consecutive failures)"
                 );
-                self.kill_daemon_as_crash(&id, pid, &reason).await;
+                // The identity captured when these probes ran, not a fresh
+                // read: enforcement must refuse if the daemon restarted (and
+                // possibly reused the PID) while the probes were in flight.
+                self.kill_daemon_as_crash(&id, pid, daemon.start_time, &reason)
+                    .await;
                 return;
             }
         }
@@ -178,24 +182,54 @@ impl Supervisor {
     /// like a crash and letting the retry checker restart the daemon when
     /// configured. Shared by resource-limit and health-check enforcement.
     ///
+    /// `expected_start_time` is the process identity captured when the failing
+    /// probe (or the resource-limit observation) ran, not a fresh read: the
+    /// kill is refused if the recorded daemon has since moved to a new process
+    /// generation, because a restarted daemon that reuses the PID must not be
+    /// killed for its predecessor's failures. The signal itself is issued via
+    /// [`PROCS::kill_process_group_if_start_time_matches_async`], which binds
+    /// the start-time check and the kill into one atomic operation.
+    ///
     /// `reason` names the enforcement in log lines (e.g. "due to resource
     /// limit violation" or "due to health check failure (2 consecutive
     /// failures)").
-    pub(crate) async fn kill_daemon_as_crash(&self, id: &DaemonId, pid: u32, reason: &str) {
+    pub(crate) async fn kill_daemon_as_crash(
+        &self,
+        id: &DaemonId,
+        pid: u32,
+        expected_start_time: Option<u64>,
+        reason: &str,
+    ) {
         info!("killing daemon {id} (pid {pid}) {reason}");
-        let daemon = self.get_daemon(id).await;
         // A probe can complete long after the daemon it watched stopped or
         // restarted, by which point `pid` may have been recycled. If the daemon
         // no longer records this pid, there is nothing of ours left to kill —
         // and signalling the recycled pid could hit an unrelated process group.
-        if daemon.as_ref().and_then(|d| d.pid) != Some(pid) {
-            warn!("daemon {id} no longer owns pid {pid}; not killing it {reason}");
+        let daemon = match self.get_daemon(id).await {
+            Some(daemon) if daemon.pid == Some(pid) => daemon,
+            _ => {
+                warn!("daemon {id} no longer owns pid {pid}; not killing it {reason}");
+                return;
+            }
+        };
+        // The recorded daemon must still be the same process generation the
+        // failing probes observed. A daemon that crashed and was retried while
+        // the probes were in flight may reuse the PID, and killing it would
+        // take down the healthy new generation. Do not finalize — the new
+        // generation is alive and the health loop re-observes it with a fresh
+        // failure budget.
+        if !recorded_identity_matches(&daemon, pid, expected_start_time) {
+            warn!(
+                "daemon {id} restarted since the failing check (recorded start_time {:?}, expected {:?}); not killing it {reason}",
+                daemon.start_time, expected_start_time
+            );
             return;
         }
         // Never signal a process group that provably isn't the daemon's: a
-        // recycled PID would mean killing an unrelated process tree.
-        let recorded_start_time = daemon.as_ref().and_then(|d| d.start_time);
-        if !signalling_pid_is_authorized(recorded_start_time, PROCS.start_time(pid)) {
+        // recycled PID would mean killing an unrelated process tree. The
+        // recorded start time equals `expected_start_time` here, so this
+        // compares the expected generation against the live process.
+        if !signalling_pid_is_authorized(expected_start_time, PROCS.start_time(pid)) {
             warn!(
                 "pid {pid} recorded for daemon {id} belongs to another process now; not killing it {reason}"
             );
@@ -213,15 +247,45 @@ impl Supervisor {
             .await;
             return;
         }
-        let stop_cfg = daemon.and_then(|d| d.stop_signal).unwrap_or_default();
+        // Fail closed when no start time was ever recorded: the kill cannot be
+        // bound to a process generation, so refuse rather than risk signalling
+        // a recycled PID.
+        let Some(expected_start_time) = expected_start_time else {
+            warn!(
+                "daemon {id} has no recorded start time; cannot securely kill pid {pid} {reason}"
+            );
+            return;
+        };
+        let stop_cfg = daemon.stop_signal.unwrap_or_default();
         let stop_signal: i32 = stop_cfg.signal.into();
-        if let Err(e) = PROCS
-            .kill_process_group_async(pid, stop_signal, stop_cfg.timeout)
+        match PROCS
+            .kill_process_group_if_start_time_matches_async(
+                pid,
+                expected_start_time,
+                stop_signal,
+                stop_cfg.timeout,
+            )
             .await
         {
-            error!("failed to kill daemon {id} (pid {pid}) {reason}: {e}");
+            Ok(true) => {}
+            Ok(false) => {
+                warn!(
+                    "could not securely kill daemon {id} (pid {pid}) {reason}; retaining running state"
+                );
+            }
+            Err(err) => {
+                error!("failed to kill daemon {id} (pid {pid}) {reason}: {err}");
+            }
         }
     }
+}
+
+/// Whether the recorded daemon still matches the process identity captured
+/// when the probes ran. Enforcement must not proceed otherwise: a restarted
+/// daemon that reuses the PID would otherwise be killed for its
+/// predecessor's failures.
+fn recorded_identity_matches(daemon: &Daemon, pid: u32, expected_start_time: Option<u64>) -> bool {
+    daemon.pid == Some(pid) && daemon.start_time == expected_start_time
 }
 
 /// Whether a daemon's process identity changed since the last probe, meaning
@@ -595,6 +659,56 @@ mod tests {
         ));
         // First probe (no last identity yet): always a fresh budget.
         assert!(process_identity_changed(None, None, Some(42), Some(100)));
+    }
+
+    fn daemon_with(pid: Option<u32>, start_time: Option<u64>) -> Daemon {
+        Daemon {
+            id: DaemonId::new("ns", "x"),
+            pid,
+            start_time,
+            ..Daemon::default()
+        }
+    }
+
+    #[test]
+    fn recorded_identity_matches_on_same_generation() {
+        assert!(recorded_identity_matches(
+            &daemon_with(Some(42), Some(100)),
+            42,
+            Some(100)
+        ));
+    }
+
+    #[test]
+    fn recorded_identity_mismatches_on_different_pid() {
+        assert!(!recorded_identity_matches(
+            &daemon_with(Some(42), Some(100)),
+            43,
+            Some(100)
+        ));
+    }
+
+    #[test]
+    fn recorded_identity_mismatches_on_reused_pid_with_new_start_time() {
+        // Same PID, different start time: the OS recycled the PID for a new
+        // process generation. Killing it would take down the restarted
+        // daemon for its predecessor's failures.
+        assert!(!recorded_identity_matches(
+            &daemon_with(Some(42), Some(200)),
+            42,
+            Some(100)
+        ));
+    }
+
+    #[test]
+    fn recorded_identity_mismatches_when_record_lacks_start_time() {
+        // Expected identity captured at probe time is None while the record
+        // has one: nothing to bind the kill to, so fail closed.
+        assert!(!recorded_identity_matches(
+            &daemon_with(Some(42), Some(100)),
+            42,
+            None
+        ));
     }
 
     #[tokio::test]

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -88,9 +88,9 @@ pub(crate) fn get_or_compile_regex(pattern: &str) -> Option<Regex> {
 /// process to exit or the cancel signal. Dropping the handle without cancelling
 /// leaves the task running, but the child is started with `kill_on_drop(true)`
 /// so it will still be terminated when the task ends.
-struct CmdProbe {
-    cancel_tx: tokio::sync::oneshot::Sender<()>,
-    result_rx: tokio::sync::oneshot::Receiver<std::io::Result<std::process::ExitStatus>>,
+pub(crate) struct CmdProbe {
+    pub(crate) cancel_tx: tokio::sync::oneshot::Sender<()>,
+    pub(crate) result_rx: tokio::sync::oneshot::Receiver<std::io::Result<std::process::ExitStatus>>,
 }
 
 /// Spawn a readiness command probe and return a handle that can be used to wait
@@ -124,7 +124,7 @@ fn apply_runtime_env(
     }
 }
 
-fn spawn_cmd_probe(
+pub(crate) fn spawn_cmd_probe(
     id: &DaemonId,
     cmd: &str,
     dir: &std::path::Path,
@@ -157,7 +157,7 @@ fn spawn_cmd_probe(
     let mut child = match command.spawn() {
         Ok(child) => child,
         Err(e) => {
-            warn!("daemon {id}: failed to spawn readiness command probe: {e}");
+            warn!("daemon {id}: failed to spawn command probe: {e}");
             // Return a probe whose result channel is already closed. The caller will
             // treat this the same as a probe that exited non-zero and respawn after
             // the ready_check_interval, preserving the existing retry behaviour.

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -12,6 +12,7 @@
 
 mod adopt;
 mod autostop;
+mod health;
 mod hooks;
 mod ipc_handlers;
 mod lifecycle;

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1513,7 +1513,7 @@ async fn cleanup_orphaned_daemon(
     let termination_result = PROCS
         .kill_process_group_if_start_time_matches_async(
             pid,
-            expected_start_time,
+            Some(expected_start_time),
             stop_cfg.signal.into(),
             stop_cfg.timeout,
         )

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -11,6 +11,9 @@ use crate::daemon_status::DaemonStatus;
 use crate::error::FileError;
 use crate::pitchfork_toml::CpuLimit;
 use crate::pitchfork_toml::CronRetrigger;
+use crate::pitchfork_toml::HealthCmd;
+use crate::pitchfork_toml::HealthHttp;
+use crate::pitchfork_toml::HealthPort;
 use crate::pitchfork_toml::MemoryLimit;
 use crate::pitchfork_toml::PitchforkToml;
 use crate::pitchfork_toml::PortConfig;
@@ -74,6 +77,9 @@ pub(crate) struct UpsertDaemonOpts {
     pub ready_http: Option<ReadyHttp>,
     pub ready_port: Option<ReadyPort>,
     pub ready_cmd: Option<ReadyCmd>,
+    pub health_cmd: Option<HealthCmd>,
+    pub health_http: Option<HealthHttp>,
+    pub health_port: Option<HealthPort>,
     /// Port configuration
     pub port: Option<PortConfig>,
     /// Resolved ports actually used after auto-bump (may differ from expected)
@@ -159,6 +165,9 @@ impl UpsertDaemonOpts {
             o.ready_http = opts.ready_http.clone();
             o.ready_port = opts.ready_port.clone();
             o.ready_cmd = opts.ready_cmd.clone();
+            o.health_cmd = opts.health_cmd.clone();
+            o.health_http = opts.health_http.clone();
+            o.health_port = opts.health_port.clone();
             o.port = opts.port.clone();
             o.depends = Some(opts.depends.clone());
             o.env = opts.env.clone();
@@ -265,6 +274,15 @@ impl Supervisor {
             ready_cmd: opts
                 .ready_cmd
                 .or(existing.and_then(|d| d.ready_cmd.clone())),
+            health_cmd: opts
+                .health_cmd
+                .or(existing.and_then(|d| d.health_cmd.clone())),
+            health_http: opts
+                .health_http
+                .or(existing.and_then(|d| d.health_http.clone())),
+            health_port: opts
+                .health_port
+                .or(existing.and_then(|d| d.health_port.clone())),
             port: opts.port.or_else(|| existing.and_then(|d| d.port.clone())),
             resolved_port: if opts.resolved_port.is_empty() {
                 existing

--- a/src/supervisor/watchers.rs
+++ b/src/supervisor/watchers.rs
@@ -271,7 +271,8 @@ impl Supervisor {
                     mem_limit,
                 );
                 cpu_violation_counts.remove(&daemon.id);
-                self.stop_for_resource_violation(&daemon.id, pid).await;
+                self.stop_for_resource_violation(&daemon.id, pid, daemon.start_time)
+                    .await;
                 continue; // Don't check CPU if we're already killing
             }
 
@@ -290,7 +291,8 @@ impl Supervisor {
                             daemon.id, pid, count, stats.cpu_percent, cpu_limit.0,
                         );
                         cpu_violation_counts.remove(&daemon.id);
-                        self.stop_for_resource_violation(&daemon.id, pid).await;
+                        self.stop_for_resource_violation(&daemon.id, pid, daemon.start_time)
+                            .await;
                     } else {
                         debug!(
                             "daemon {} (pid {}) CPU {:.1}% > {}% ({}/{} consecutive violations)",
@@ -470,9 +472,24 @@ impl Supervisor {
     /// Instead, it kills the process group directly, which causes the monitor task
     /// to observe a non-zero exit and set the status to `Errored`. This allows
     /// the retry checker to restart the daemon if `retry` is configured.
-    async fn stop_for_resource_violation(&self, id: &DaemonId, pid: u32) {
-        self.kill_daemon_as_crash(id, pid, "due to resource limit violation")
-            .await;
+    ///
+    /// `expected_start_time` is the identity captured from the same daemon
+    /// snapshot the violation was observed in: enforcement refuses if the
+    /// daemon restarted in the meantime (see
+    /// [`Supervisor::kill_daemon_as_crash`]).
+    async fn stop_for_resource_violation(
+        &self,
+        id: &DaemonId,
+        pid: u32,
+        expected_start_time: Option<u64>,
+    ) {
+        self.kill_daemon_as_crash(
+            id,
+            pid,
+            expected_start_time,
+            "due to resource limit violation",
+        )
+        .await;
     }
 
     /// Start the cron watcher for scheduled daemon execution

--- a/src/supervisor/watchers.rs
+++ b/src/supervisor/watchers.rs
@@ -164,6 +164,9 @@ impl Supervisor {
             // Track consecutive CPU-over-limit samples per daemon.
             // Kept outside the state file because it is ephemeral runtime data.
             let mut cpu_violation_counts: HashMap<DaemonId, u32> = HashMap::new();
+            // Live per-daemon health-check tasks, spawned lazily once a daemon
+            // is running with a health check configured.
+            let mut health_tasks: HashMap<DaemonId, tokio::task::JoinHandle<()>> = HashMap::new();
             // Run log retention check no more than once per hour.
             let mut last_retention_check = tokio::time::Instant::now() - Duration::from_secs(3600);
             loop {
@@ -180,6 +183,8 @@ impl Supervisor {
                 {
                     error!("failed to check resource limits: {err}");
                 }
+                // Spawn/prune per-daemon health-check tasks.
+                SUPERVISOR.manage_health_tasks(&mut health_tasks).await;
                 // Apply log retention policy if configured.
                 if last_retention_check.elapsed() >= Duration::from_secs(3600) {
                     match SUPERVISOR.apply_log_retention().await {
@@ -466,37 +471,8 @@ impl Supervisor {
     /// to observe a non-zero exit and set the status to `Errored`. This allows
     /// the retry checker to restart the daemon if `retry` is configured.
     async fn stop_for_resource_violation(&self, id: &DaemonId, pid: u32) {
-        info!("killing daemon {id} (pid {pid}) due to resource limit violation");
-        let daemon = self.get_daemon(id).await;
-        // Never signal a process group that provably isn't the daemon's: a
-        // recycled PID would mean measuring one process tree and killing another.
-        let recorded_start_time = daemon.as_ref().and_then(|d| d.start_time);
-        if !super::signalling_pid_is_authorized(recorded_start_time, PROCS.start_time(pid)) {
-            warn!(
-                "pid {pid} recorded for daemon {id} belongs to another process now; not killing it for a resource violation"
-            );
-            // Leaving the record running would have the resource watcher
-            // measure the stranger's usage on every tick and try to kill it
-            // again each time. The daemon died unobserved, so record that —
-            // the same terminal state orphan reconciliation would reach, and
-            // one that keeps the daemon eligible for retry.
-            self.finalize_if_pid(
-                id,
-                pid,
-                DaemonStatus::Errored(-1),
-                super::ExitObservation::Unobserved,
-            )
+        self.kill_daemon_as_crash(id, pid, "due to resource limit violation")
             .await;
-            return;
-        }
-        let stop_cfg = daemon.and_then(|d| d.stop_signal).unwrap_or_default();
-        let stop_signal: i32 = stop_cfg.signal.into();
-        if let Err(e) = PROCS
-            .kill_process_group_async(pid, stop_signal, stop_cfg.timeout)
-            .await
-        {
-            error!("failed to kill daemon {id} (pid {pid}) after resource violation: {e}");
-        }
     }
 
     /// Start the cron watcher for scheduled daemon execution

--- a/src/template.rs
+++ b/src/template.rs
@@ -378,6 +378,7 @@ pub fn render_daemon_templates(
             .ok()
             .filter(|&p| p > 0)
             .ok_or_else(|| RenderError::InvalidPort {
+                field: "health_port",
                 template: template.clone(),
                 rendered: rendered.clone(),
             })?;
@@ -413,6 +414,7 @@ pub fn render_daemon_templates(
             .ok()
             .filter(|&p| p > 0)
             .ok_or_else(|| RenderError::InvalidPort {
+                field: "ready_port",
                 template: template.clone(),
                 rendered: rendered.clone(),
             })?;
@@ -502,9 +504,13 @@ pub enum RenderError {
         source: tera::Error,
     },
     #[error(
-        "ready_port template {template:?} rendered to {rendered:?}, expected a port number (1-65535)"
+        "{field} template {template:?} rendered to {rendered:?}, expected a port number (1-65535)"
     )]
-    InvalidPort { template: String, rendered: String },
+    InvalidPort {
+        field: &'static str,
+        template: String,
+        rendered: String,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,7 +1,8 @@
 //! Tera template rendering for pitchfork.toml configuration fields.
 //!
-//! Allows `run`, `env` values, `hooks.*`, and the readiness fields (`ready_cmd`,
-//! `ready_http`, `ready_port`, `ready_output`) to use Tera templates like
+//! Allows `run`, `env` values, `hooks.*`, the readiness fields (`ready_cmd`,
+//! `ready_http`, `ready_port`, `ready_output`), and the health check fields
+//! (`health_cmd`, `health_http`, `health_port`) to use Tera templates like
 //! `{{ daemons.redis.ports[0] }}` to reference computed values from other daemons.
 //!
 //! Templates are resolved level-by-level along the dependency order: each level
@@ -349,6 +350,42 @@ pub fn render_daemon_templates(
         config.ready_cmd = Some(crate::pitchfork_toml::ReadyCmd {
             run: renderer.render(&cmd.run)?,
             timeout: cmd.timeout,
+        });
+    }
+
+    if let Some(ref hc) = config.health_cmd {
+        config.health_cmd = Some(crate::pitchfork_toml::HealthCmd {
+            run: renderer.render(&hc.run)?,
+            interval: hc.interval,
+            timeout: hc.timeout,
+            retries: hc.retries,
+        });
+    }
+
+    if let Some(ref http) = config.health_http {
+        let mut http = http.clone();
+        http.url = renderer.render(&http.url)?;
+        config.health_http = Some(http);
+    }
+
+    if let Some(ref health_port) = config.health_port
+        && let Some(ref template) = health_port.template
+    {
+        let rendered = renderer.render(template)?;
+        let port = rendered
+            .trim()
+            .parse::<u16>()
+            .ok()
+            .filter(|&p| p > 0)
+            .ok_or_else(|| RenderError::InvalidPort {
+                template: template.clone(),
+                rendered: rendered.clone(),
+            })?;
+        config.health_port = Some(crate::config_types::HealthPort {
+            port: Some(port),
+            template: None,
+            interval: health_port.interval,
+            retries: health_port.retries,
         });
     }
 
@@ -764,6 +801,42 @@ mod tests {
     }
 
     #[test]
+    fn test_render_daemon_templates_health_fields() {
+        use crate::config_types::{HealthCmd, HealthHttp};
+        use std::time::Duration;
+
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut config = PitchforkTomlDaemon {
+            run: "echo".to_string(),
+            health_cmd: Some(HealthCmd {
+                run: "redis-cli -p {{ daemons.redis.port }} ping".to_string(),
+                interval: Some(Duration::from_secs(10)),
+                timeout: None,
+                retries: Some(3),
+            }),
+            health_http: Some(HealthHttp {
+                url: "http://localhost:{{ daemons.redis.port }}/health".to_string(),
+                status: vec![200],
+                interval: None,
+                timeout: Some(Duration::from_secs(5)),
+                retries: None,
+            }),
+            ..Default::default()
+        };
+
+        render_daemon_templates(&mut config, &mut ctx, None).unwrap();
+
+        let hc = config.health_cmd.unwrap();
+        assert_eq!(hc.run, "redis-cli -p 6379 ping");
+        assert_eq!(hc.interval, Some(Duration::from_secs(10)));
+        assert_eq!(hc.retries, Some(3));
+        let hh = config.health_http.unwrap();
+        assert_eq!(hh.url, "http://localhost:6379/health");
+        assert_eq!(hh.status, vec![200]);
+        assert_eq!(hh.timeout, Some(Duration::from_secs(5)));
+    }
+
+    #[test]
     fn test_render_daemon_templates_ready_port_invalid() {
         use crate::config_types::ReadyPort;
 
@@ -791,6 +864,61 @@ mod tests {
 
         render_daemon_templates(&mut config, &mut ctx, None).unwrap();
         assert_eq!(config.ready_port, Some(ReadyPort::new(8080)));
+    }
+
+    #[test]
+    fn test_render_daemon_templates_health_port() {
+        use crate::config_types::HealthPort;
+        use std::time::Duration;
+
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut config = PitchforkTomlDaemon {
+            run: "echo".to_string(),
+            health_port: Some(HealthPort {
+                port: None,
+                template: Some("{{ daemons.redis.port }}".to_string()),
+                interval: Some(Duration::from_secs(10)),
+                retries: Some(3),
+            }),
+            ..Default::default()
+        };
+
+        render_daemon_templates(&mut config, &mut ctx, None).unwrap();
+        let hp = config.health_port.unwrap();
+        assert_eq!(hp.port, Some(6379));
+        assert!(hp.template.is_none());
+        assert_eq!(hp.interval, Some(Duration::from_secs(10)));
+        assert_eq!(hp.retries, Some(3));
+    }
+
+    #[test]
+    fn test_render_daemon_templates_health_port_invalid() {
+        use crate::config_types::HealthPort;
+
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut config = PitchforkTomlDaemon {
+            run: "echo".to_string(),
+            health_port: Some(HealthPort::from_template("{{ name }}")),
+            ..Default::default()
+        };
+
+        let err = render_daemon_templates(&mut config, &mut ctx, None).unwrap_err();
+        assert!(matches!(err, RenderError::InvalidPort { .. }));
+    }
+
+    #[test]
+    fn test_render_daemon_templates_health_port_literal_untouched() {
+        use crate::config_types::HealthPort;
+
+        let mut ctx = make_context_with_daemon("redis", vec![6379]);
+        let mut config = PitchforkTomlDaemon {
+            run: "echo".to_string(),
+            health_port: Some(HealthPort::new(8080)),
+            ..Default::default()
+        };
+
+        render_daemon_templates(&mut config, &mut ctx, None).unwrap();
+        assert_eq!(config.health_port, Some(HealthPort::new(8080)));
     }
 
     #[test]

--- a/src/template.rs
+++ b/src/template.rs
@@ -387,6 +387,7 @@ pub fn render_daemon_templates(
             template: None,
             interval: health_port.interval,
             retries: health_port.retries,
+            timeout: health_port.timeout,
         });
     }
 
@@ -885,6 +886,7 @@ mod tests {
                 template: Some("{{ daemons.redis.port }}".to_string()),
                 interval: Some(Duration::from_secs(10)),
                 retries: Some(3),
+                timeout: Some(Duration::from_secs(5)),
             }),
             ..Default::default()
         };
@@ -895,6 +897,7 @@ mod tests {
         assert!(hp.template.is_none());
         assert_eq!(hp.interval, Some(Duration::from_secs(10)));
         assert_eq!(hp.retries, Some(3));
+        assert_eq!(hp.timeout, Some(Duration::from_secs(5)));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6,8 +6,9 @@ use crate::ipc::client::IpcClient;
 use crate::log_store::LogStore;
 use crate::log_store::sqlite::LOG_STORE;
 use crate::pitchfork_toml::{
-    CronRetrigger, PitchforkToml, PitchforkTomlAuto, PitchforkTomlCron, PitchforkTomlDaemon,
-    ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort, Retry, namespace_from_path,
+    CronRetrigger, HealthCmd, HealthHttp, HealthPort, PitchforkToml, PitchforkTomlAuto,
+    PitchforkTomlCron, PitchforkTomlDaemon, ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort, Retry,
+    namespace_from_path,
 };
 use crate::procs::{PROCS, ProcessStats};
 use crate::settings::settings;
@@ -355,6 +356,12 @@ pub struct EditorState {
     preserved_ready_http_timeout: Option<std::time::Duration>,
     /// Preserved ready_output timeout (no form UI yet)
     preserved_ready_output_timeout: Option<std::time::Duration>,
+    /// Preserved health_cmd parameters (only `run` has form UI)
+    preserved_health_cmd: Option<HealthCmd>,
+    /// Preserved health_http parameters (only `url` has form UI)
+    preserved_health_http: Option<HealthHttp>,
+    /// Preserved health_port parameters (only the port has form UI)
+    preserved_health_port: Option<HealthPort>,
 }
 
 impl EditorState {
@@ -374,6 +381,9 @@ impl EditorState {
             preserved_ready_http_status: None,
             preserved_ready_http_timeout: None,
             preserved_ready_output_timeout: None,
+            preserved_health_cmd: None,
+            preserved_health_http: None,
+            preserved_health_port: None,
         }
     }
 
@@ -398,6 +408,9 @@ impl EditorState {
                 .and_then(|h| (!h.status.is_empty()).then(|| h.status.clone())),
             preserved_ready_http_timeout: config.ready_http.as_ref().and_then(|h| h.timeout),
             preserved_ready_output_timeout: config.ready_output.as_ref().and_then(|o| o.timeout),
+            preserved_health_cmd: config.health_cmd.clone(),
+            preserved_health_http: config.health_http.clone(),
+            preserved_health_port: config.health_port.clone(),
         }
     }
 
@@ -449,6 +462,21 @@ impl EditorState {
                 "ready_port",
                 "Ready Port",
                 "TCP port to check for readiness (1-65535).",
+            ),
+            FormField::optional_text(
+                "health_cmd",
+                "Health Command",
+                "Shell command that must exit 0 for the daemon to stay healthy.",
+            ),
+            FormField::optional_text(
+                "health_http",
+                "Health HTTP URL",
+                "HTTP URL to poll for health (expects 2xx).",
+            ),
+            FormField::optional_port(
+                "health_port",
+                "Health Port",
+                "TCP port that must accept connections for the daemon to stay healthy (1-65535).",
             ),
             FormField::optional_bool(
                 "boot_start",
@@ -514,6 +542,26 @@ impl EditorState {
                 }
                 "ready_port" => {
                     field.value = FormFieldValue::OptionalPort(config.ready_port.clone())
+                }
+                "health_cmd" => {
+                    field.value = FormFieldValue::OptionalText(
+                        config.health_cmd.as_ref().map(|c| c.run.clone()),
+                    )
+                }
+                "health_http" => {
+                    field.value = FormFieldValue::OptionalText(
+                        config.health_http.as_ref().map(|h| h.url.clone()),
+                    )
+                }
+                "health_port" => {
+                    field.value =
+                        FormFieldValue::OptionalPort(config.health_port.as_ref().map(|hp| {
+                            ReadyPort {
+                                port: hp.port,
+                                template: hp.template.clone(),
+                                timeout: None,
+                            }
+                        }))
                 }
                 "boot_start" => field.value = FormFieldValue::OptionalBoolean(config.boot_start),
                 "depends" => {
@@ -596,6 +644,28 @@ impl EditorState {
                     })
                 }
                 ("ready_port", FormFieldValue::OptionalPort(p)) => config.ready_port = p.clone(),
+                ("health_cmd", FormFieldValue::OptionalText(s)) => {
+                    config.health_cmd = s.clone().map(|run| {
+                        let mut cmd = self.preserved_health_cmd.clone().unwrap_or_default();
+                        cmd.run = run;
+                        cmd
+                    })
+                }
+                ("health_http", FormFieldValue::OptionalText(s)) => {
+                    config.health_http = s.clone().map(|url| {
+                        let mut http = self.preserved_health_http.clone().unwrap_or_default();
+                        http.url = url;
+                        http
+                    })
+                }
+                ("health_port", FormFieldValue::OptionalPort(p)) => {
+                    config.health_port = p.clone().map(|port_value| {
+                        let mut hp = self.preserved_health_port.clone().unwrap_or_default();
+                        hp.port = port_value.port;
+                        hp.template = port_value.template;
+                        hp
+                    })
+                }
                 ("boot_start", FormFieldValue::OptionalBoolean(b)) => config.boot_start = *b,
                 ("depends", FormFieldValue::StringList(v)) => {
                     config.depends = v.iter().filter_map(|s| DaemonId::parse(s).ok()).collect()
@@ -804,6 +874,12 @@ impl EditorState {
                     valid = false;
                 }
                 ("ready_http", FormFieldValue::OptionalText(Some(url)))
+                    if !(url.starts_with("http://") || url.starts_with("https://")) =>
+                {
+                    field.error = Some("Must start with http:// or https://".to_string());
+                    valid = false;
+                }
+                ("health_http", FormFieldValue::OptionalText(Some(url)))
                     if !(url.starts_with("http://") || url.starts_with("https://")) =>
                 {
                     field.error = Some("Must start with http:// or https://".to_string());

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1677,6 +1677,27 @@ fn draw_details_overlay(f: &mut Frame, app: &App) {
             ]));
         }
 
+        if let Some(cmd) = &cfg.health_cmd {
+            lines.push(Line::from(vec![
+                Span::styled("Health cmd: ", Style::default().fg(GRAY)),
+                Span::styled(cmd.to_string(), Style::default().fg(Color::White)),
+            ]));
+        }
+
+        if let Some(http) = &cfg.health_http {
+            lines.push(Line::from(vec![
+                Span::styled("Health HTTP: ", Style::default().fg(GRAY)),
+                Span::styled(http.to_string(), Style::default().fg(Color::White)),
+            ]));
+        }
+
+        if let Some(port) = &cfg.health_port {
+            lines.push(Line::from(vec![
+                Span::styled("Health port: ", Style::default().fg(GRAY)),
+                Span::styled(port.to_string(), Style::default().fg(Color::White)),
+            ]));
+        }
+
         if cfg.boot_start.unwrap_or(false) {
             lines.push(Line::from(vec![
                 Span::styled("Boot start: ", Style::default().fg(GRAY)),

--- a/src/web/routes/api/daemons.rs
+++ b/src/web/routes/api/daemons.rs
@@ -34,6 +34,9 @@ pub struct ApiDaemonEntry {
     ready_http_url: Option<String>,
     ready_port: Option<u16>,
     ready_cmd: Option<String>,
+    health_cmd: Option<String>,
+    health_http_url: Option<String>,
+    health_port: Option<u16>,
     port_config: Option<String>,
     depends: Vec<String>,
     env: Option<Vec<String>>,
@@ -165,6 +168,9 @@ fn entry_to_api(
         ready_http_url: d.ready_http.as_ref().map(|r| r.url.clone()),
         ready_port: d.ready_port.as_ref().and_then(|p| p.as_port()),
         ready_cmd: d.ready_cmd.as_ref().map(|r| r.run.clone()),
+        health_cmd: d.health_cmd.as_ref().map(|c| c.run.clone()),
+        health_http_url: d.health_http.as_ref().map(|h| h.url.clone()),
+        health_port: d.health_port.as_ref().and_then(|p| p.as_port()),
         port_config: d.port.as_ref().map(|p| {
             if p.bump.0 == 0 {
                 p.expect

--- a/test/health.bats
+++ b/test/health.bats
@@ -1,0 +1,184 @@
+#!/usr/bin/env bats
+
+setup() {
+  export PITCHFORK_INTERVAL=2s
+  load test_helper/common_setup
+  _common_setup
+}
+
+teardown() {
+  _common_teardown
+}
+
+@test "health cmd failure kills daemon and retry restarts it" {
+  create_pitchfork_toml <<EOF
+[daemons.unhealthy]
+run = "echo started; sleep 300"
+retry = 1
+health_cmd = { run = "exit 1", interval = "1s", retries = 2 }
+EOF
+
+  run pitchfork start unhealthy
+  assert_success
+
+  local deadline
+  deadline=$(($(date +%s) + 40))
+
+  # The daemon must be killed through the crash path (health check named as
+  # the reason in the supervisor log), then restarted by the retry checker
+  # ("started" once per run), then killed again. End state: errored with
+  # exactly two runs.
+  while true; do
+    local sup_log status logs count
+    sup_log="$PITCHFORK_LOGS_DIR/pitchfork/pitchfork.log"
+    status=$(get_daemon_status unhealthy)
+    logs=$(read_logs unhealthy)
+    count=$(grep -c "started" <<< "$logs" || true)
+    if [[ "$status" == *"errored"* ]] \
+      && [[ $count -ge 2 ]] \
+      && grep -q "health check failure" "$sup_log" 2>/dev/null; then
+      break
+    fi
+    if [[ $(date +%s) -ge $deadline ]]; then
+      echo "timed out: status=$status runs=$count" >&2
+      break
+    fi
+    sleep 1
+  done
+
+  run pitchfork status unhealthy
+  assert_output --partial "errored"
+
+  run pitchfork logs unhealthy --raw
+  local count
+  count=$(grep -c "started" <<< "$output" || true)
+  [[ $count -eq 2 ]]
+
+  pitchfork stop unhealthy || true
+}
+
+@test "daemon with passing health cmd keeps running untouched" {
+  create_pitchfork_toml <<EOF
+[daemons.healthy]
+run = "sleep 300"
+health_cmd = { run = "exit 0", interval = "1s", retries = 2 }
+EOF
+
+  run pitchfork start healthy
+  assert_success
+  wait_for_status healthy running 30
+
+  local pid_before pid_after
+  pid_before=$(get_daemon_pid healthy)
+  [[ -n "$pid_before" ]]
+
+  # Several health intervals must pass without the daemon being touched.
+  sleep 5
+
+  pid_after=$(get_daemon_pid healthy)
+  [[ -n "$pid_after" ]]
+  [[ "$pid_after" == "$pid_before" ]]
+
+  run pitchfork status healthy
+  assert_output --partial "running"
+
+  pitchfork stop healthy
+}
+
+@test "health http failure kills daemon and retry restarts it" {
+  local port
+  port=$(python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1', 0)); print(s.getsockname()[1]); s.close()")
+  local http_script
+  http_script="$(script_path http_server.py)"
+
+  create_pitchfork_toml <<EOF
+[daemons.webhealth]
+run = "python3 -u $http_script 0 $port 500"
+retry = 1
+health_http = { url = "http://127.0.0.1:$port/health", interval = "1s", retries = 2 }
+EOF
+
+  run pitchfork start webhealth
+  assert_success
+
+  local deadline
+  deadline=$(($(date +%s) + 40))
+
+  while true; do
+    local status logs count
+    status=$(get_daemon_status webhealth)
+    logs=$(read_logs webhealth)
+    count=$(grep -c "Server listening on" <<< "$logs" || true)
+    if [[ "$status" == *"errored"* ]] && [[ $count -ge 2 ]]; then
+      break
+    fi
+    if [[ $(date +%s) -ge $deadline ]]; then
+      echo "timed out: status=$status runs=$count" >&2
+      break
+    fi
+    sleep 1
+  done
+
+  run pitchfork status webhealth
+  assert_output --partial "errored"
+
+  run pitchfork logs webhealth --raw
+  local count
+  count=$(grep -c "Server listening on" <<< "$output" || true)
+  [[ $count -eq 2 ]]
+
+  kill_port "$port"
+  pitchfork stop webhealth || true
+}
+
+@test "health port failure kills daemon and retry restarts it" {
+  local port
+  port=$(python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1', 0)); print(s.getsockname()[1]); s.close()")
+  local port_script
+  port_script="$(script_path health_port_server.py)"
+
+  create_pitchfork_toml <<EOF
+[daemons.porthealth]
+run = "python3 -u $port_script $port 3"
+retry = 1
+health_port = { port = $port, interval = "1s", retries = 2 }
+EOF
+
+  run pitchfork start porthealth
+  assert_success
+
+  # While the port is listening the probe passes and the daemon is untouched.
+  wait_for_status porthealth running 30
+
+  local deadline
+  deadline=$(($(date +%s) + 40))
+
+  # The script closes its listener after 3s, so the health probe must fail
+  # twice in a row, kill the daemon through the crash path, and the retry
+  # checker starts it once more ("Listening on" per run). End state: errored
+  # with exactly two runs.
+  while true; do
+    local status logs count
+    status=$(get_daemon_status porthealth)
+    logs=$(read_logs porthealth)
+    count=$(grep -c "Listening on" <<< "$logs" || true)
+    if [[ "$status" == *"errored"* ]] && [[ $count -ge 2 ]]; then
+      break
+    fi
+    if [[ $(date +%s) -ge $deadline ]]; then
+      echo "timed out: status=$status runs=$count" >&2
+      break
+    fi
+    sleep 1
+  done
+
+  run pitchfork status porthealth
+  assert_output --partial "errored"
+
+  run pitchfork logs porthealth --raw
+  local count
+  count=$(grep -c "Listening on" <<< "$output" || true)
+  [[ $count -eq 2 ]]
+
+  pitchfork stop porthealth || true
+}

--- a/test/scripts/health_port_server.py
+++ b/test/scripts/health_port_server.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Binds a TCP port, listens briefly, then closes the listener and idles.
+
+For health_port e2e tests: the daemon process must stay alive after the port
+stops accepting connections so the supervisor's health check (not process
+exit) triggers the crash path.
+
+Usage: health_port_server.py <port> <listen_seconds>
+"""
+import socket
+import sys
+import time
+
+port = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+listen_seconds = float(sys.argv[2]) if len(sys.argv) > 2 else 3
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", port))
+s.listen(5)
+print(f"Listening on 127.0.0.1:{port}")
+time.sleep(listen_seconds)
+s.close()
+print("Listener closed")
+time.sleep(3600)  # keep the process alive so the daemon stays "running"

--- a/tests/test_pitchfork_toml.rs
+++ b/tests/test_pitchfork_toml.rs
@@ -494,7 +494,7 @@ fn test_daemon_with_health_port_object() -> Result<()> {
     let toml_content = r#"
 [daemons.health_daemon]
 run = "echo 'server running'"
-health_port = { port = 8443, interval = "10s", retries = 3 }
+health_port = { port = 8443, interval = "10s", retries = 3, timeout = "5s" }
 "#;
 
     fs::write(&toml_path, toml_content).unwrap();
@@ -507,6 +507,7 @@ health_port = { port = 8443, interval = "10s", retries = 3 }
     assert!(hp.template.is_none());
     assert_eq!(hp.interval, Some(Duration::from_secs(10)));
     assert_eq!(hp.retries, Some(3));
+    assert_eq!(hp.timeout, Some(Duration::from_secs(5)));
 
     Ok(())
 }
@@ -520,7 +521,7 @@ fn test_daemon_health_port_write_roundtrip() -> Result<()> {
     let toml_content = r#"
 [daemons.health_daemon]
 run = "echo 'server running'"
-health_port = { port = 8443, interval = "10s", retries = 3 }
+health_port = { port = 8443, interval = "10s", retries = 3, timeout = "5s" }
 "#;
 
     fs::write(&toml_path, toml_content).unwrap();

--- a/tests/test_pitchfork_toml.rs
+++ b/tests/test_pitchfork_toml.rs
@@ -418,6 +418,318 @@ ready_http = { url = "http://localhost:8080/health", timeout = "not-a-duration" 
     assert!(err.contains("invalid timeout"), "unexpected error: {err}");
 }
 
+/// Test daemon with health checks
+#[test]
+fn test_daemon_with_health_checks() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_cmd = "openssl s_client -connect localhost:8443 -brief </dev/null"
+health_http = "http://localhost:8080/health"
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "health_daemon").unwrap();
+
+    assert_eq!(
+        daemon.health_cmd.as_ref().unwrap().run,
+        "openssl s_client -connect localhost:8443 -brief </dev/null"
+    );
+    assert!(daemon.health_cmd.as_ref().unwrap().interval.is_none());
+    assert_eq!(
+        daemon.health_http.as_ref().unwrap().url,
+        "http://localhost:8080/health"
+    );
+    assert!(daemon.health_http.as_ref().unwrap().status.is_empty());
+
+    Ok(())
+}
+
+/// Test daemon with health port (literal shorthand form)
+#[test]
+fn test_daemon_with_health_port() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_port = 8443
+
+[daemons.health_template]
+run = "echo 'server running'"
+health_port = "{{ daemons.redis.port }}"
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "health_daemon").unwrap();
+
+    let hp = daemon.health_port.as_ref().unwrap();
+    assert_eq!(hp.port, Some(8443));
+    assert!(hp.template.is_none());
+    assert!(hp.interval.is_none());
+    assert!(hp.retries.is_none());
+
+    let template_daemon = get_daemon_by_name(&pt, "health_template").unwrap();
+    let hp = template_daemon.health_port.as_ref().unwrap();
+    assert!(hp.port.is_none());
+    assert_eq!(hp.template, Some("{{ daemons.redis.port }}".to_string()));
+
+    Ok(())
+}
+
+/// Test daemon with structured health port config with all fields
+#[test]
+fn test_daemon_with_health_port_object() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_port = { port = 8443, interval = "10s", retries = 3 }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "health_daemon").unwrap();
+
+    let hp = daemon.health_port.as_ref().unwrap();
+    assert_eq!(hp.port, Some(8443));
+    assert!(hp.template.is_none());
+    assert_eq!(hp.interval, Some(Duration::from_secs(10)));
+    assert_eq!(hp.retries, Some(3));
+
+    Ok(())
+}
+
+/// Test daemon with a serialization roundtrip of health port config
+#[test]
+fn test_daemon_health_port_write_roundtrip() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_port = { port = 8443, interval = "10s", retries = 3 }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "health_daemon").unwrap();
+    let expected = daemon.health_port.clone();
+
+    pt.write()?;
+    let reloaded = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&reloaded, "health_daemon").unwrap();
+    assert_eq!(daemon.health_port, expected);
+
+    Ok(())
+}
+
+/// Test invalid health port is rejected
+#[test]
+fn test_daemon_with_invalid_health_port() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_port = 70000
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
+    let err = format!("{err:?}");
+    assert!(
+        err.contains("health_port out of range (1-65535)"),
+        "unexpected error: {err}"
+    );
+}
+
+/// Test invalid health port interval is rejected
+#[test]
+fn test_daemon_with_invalid_health_port_interval() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_port = { port = 8443, interval = "not-a-duration" }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
+    let err = format!("{err:?}");
+    assert!(err.contains("invalid timeout"), "unexpected error: {err}");
+}
+
+/// Test health port retries=0 is rejected
+#[test]
+fn test_daemon_with_zero_health_port_retries() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_port = { port = 8443, retries = 0 }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
+    let err = format!("{err:?}");
+    assert!(
+        err.contains("health_port retries must be >= 1"),
+        "unexpected error: {err}"
+    );
+}
+
+/// Test daemon with structured health check configs
+#[test]
+fn test_daemon_with_health_check_objects() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_cmd = { run = "curl -f http://localhost:8080/health", interval = "10s", timeout = "5s", retries = 3 }
+health_http = { url = "http://localhost:8080/health", status = [200, 401], interval = "15s", timeout = "5s", retries = 4 }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "health_daemon").unwrap();
+
+    let health_cmd = daemon.health_cmd.as_ref().unwrap();
+    assert_eq!(health_cmd.run, "curl -f http://localhost:8080/health");
+    assert_eq!(health_cmd.interval, Some(Duration::from_secs(10)));
+    assert_eq!(health_cmd.timeout, Some(Duration::from_secs(5)));
+    assert_eq!(health_cmd.retries, Some(3));
+
+    let health_http = daemon.health_http.as_ref().unwrap();
+    assert_eq!(health_http.url, "http://localhost:8080/health");
+    assert_eq!(health_http.status, vec![200, 401]);
+    assert_eq!(health_http.interval, Some(Duration::from_secs(15)));
+    assert_eq!(health_http.timeout, Some(Duration::from_secs(5)));
+    assert_eq!(health_http.retries, Some(4));
+
+    Ok(())
+}
+
+/// Test daemon with a serialization roundtrip of health check configs
+#[test]
+fn test_daemon_health_check_write_roundtrip() -> Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_cmd = { run = "curl -f http://localhost:8080/health", interval = "10s", retries = 3 }
+health_http = { url = "http://localhost:8080/health", status = [200], timeout = "5s" }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+    let pt = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&pt, "health_daemon").unwrap();
+    let expected_cmd = daemon.health_cmd.clone();
+    let expected_http = daemon.health_http.clone();
+
+    pt.write()?;
+    let reloaded = pitchfork_toml::PitchforkToml::read(&toml_path)?;
+    let daemon = get_daemon_by_name(&reloaded, "health_daemon").unwrap();
+    assert_eq!(daemon.health_cmd, expected_cmd);
+    assert_eq!(daemon.health_http, expected_http);
+
+    Ok(())
+}
+
+/// Test invalid health check HTTP status is rejected
+#[test]
+fn test_daemon_with_invalid_health_http_status() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_http = { url = "http://localhost:8080/health", status = [99] }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
+    let err = format!("{err:?}");
+    assert!(
+        err.contains("health_http status must be between 100 and 599"),
+        "unexpected error: {err}"
+    );
+}
+
+/// Test invalid health check timeout is rejected
+#[test]
+fn test_daemon_with_invalid_health_cmd_timeout() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    let toml_content = r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_cmd = { run = "curl -f http://localhost:8080/health", timeout = "not-a-duration" }
+"#;
+
+    fs::write(&toml_path, toml_content).unwrap();
+
+    let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
+    let err = format!("{err:?}");
+    assert!(err.contains("invalid timeout"), "unexpected error: {err}");
+}
+
+/// Test health check retries=0 is rejected
+#[test]
+fn test_daemon_with_zero_health_check_retries() {
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pitchfork.toml");
+
+    for config in [
+        r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_cmd = { run = "curl -f http://localhost:8080/health", retries = 0 }
+"#,
+        r#"
+[daemons.health_daemon]
+run = "echo 'server running'"
+health_http = { url = "http://localhost:8080/health", retries = 0 }
+"#,
+    ] {
+        fs::write(&toml_path, config).unwrap();
+        let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
+        let err = format!("{err:?}");
+        assert!(
+            err.contains("retries must be >= 1"),
+            "unexpected error: {err}"
+        );
+    }
+}
+
 /// Test daemon with structured port ready check including a timeout
 #[test]
 fn test_daemon_with_ready_port_timeout() -> Result<()> {

--- a/tests/test_pitchfork_toml.rs
+++ b/tests/test_pitchfork_toml.rs
@@ -574,7 +574,7 @@ health_port = { port = 8443, interval = "not-a-duration" }
 
     let err = pitchfork_toml::PitchforkToml::read(&toml_path).unwrap_err();
     let err = format!("{err:?}");
-    assert!(err.contains("invalid timeout"), "unexpected error: {err}");
+    assert!(err.contains("invalid interval"), "unexpected error: {err}");
 }
 
 /// Test health port retries=0 is rejected

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -42,6 +42,9 @@ export interface DaemonEntry {
   ready_http_url: string | null
   ready_port: number | null
   ready_cmd: string | null
+  health_cmd: string | null
+  health_http_url: string | null
+  health_port: number | null
   proxy_url: string | null
   pty: boolean | null
   proxy: boolean | null

--- a/ui/src/views/DaemonDetailView.vue
+++ b/ui/src/views/DaemonDetailView.vue
@@ -201,6 +201,18 @@ async function onToggle() {
           <div class="info-label">Ready Cmd</div>
           <div class="info-value">{{ daemon.ready_cmd }}</div>
         </div>
+        <div class="info-card" v-if="daemon.health_cmd">
+          <div class="info-label">Health Cmd</div>
+          <div class="info-value">{{ daemon.health_cmd }}</div>
+        </div>
+        <div class="info-card" v-if="daemon.health_http_url">
+          <div class="info-label">Health HTTP</div>
+          <div class="info-value">{{ daemon.health_http_url }}</div>
+        </div>
+        <div class="info-card" v-if="daemon.health_port">
+          <div class="info-label">Health Port</div>
+          <div class="info-value">{{ daemon.health_port }}</div>
+        </div>
         <div class="info-card" v-if="daemon.port_config">
           <div class="info-label">Port Config</div>
           <div class="info-value">{{ daemon.port_config }}</div>


### PR DESCRIPTION
Closes #102
Closes #783

## Summary

Adds **health checks** to pitchfork — periodic, repeating probes that are distinct from the existing one-shot `ready` checks. A health check runs on an interval and, once consecutive failures reach a retry threshold, kills the daemon as a crash (`Errored`), which feeds the existing retry / `on_retry` restart mechanism.

Implements the feature requested in https://github.com/jdx/pitchfork/discussions/783, completing the last open item (the "repeat the http check long-term" idea) from https://github.com/jdx/pitchfork/discussions/102.

## Probe kinds

Three kinds, each accepting a shorthand or an object TOML form:

```toml
[daemons.tunnel]
run = "ssh -N -L 8443:localhost:8443 user@host"

# 1. shell command — exit 0 = healthy
health_cmd = "openssl s_client -connect localhost:8443 -brief </dev/null"

# 2. HTTP endpoint — 2xx (or an explicit status list)
health_http = { url = "http://localhost:8443/health", status = [200] }

# 3. TCP port — connect to 127.0.0.1:<port>
health_port = 8443
```

Each also supports Tera templates and per-daemon `interval` / `timeout` (cmd, http) / `retries`.

## Configurable defaults

Probe defaults are exposed as `supervisor.*` settings; per-daemon fields override them:

- `supervisor.health_check_interval` (default `10s`)
- `supervisor.health_cmd_timeout` (default `10s`)
- `supervisor.health_http_timeout` (default `5s`)
- `supervisor.health_check_retries` (default `3`)

## Behavior

- The interval watcher lazily spawns one health-check task per running, health-configured daemon.
- Consecutive failures reaching `retries` kill the process group via the shared crash path (`kill_daemon_as_crash`), so the exit is observed as `Errored` and the existing retry / `on_retry` logic restarts it. A restart resets the failure budget.
- The kill is PID-identity-checked first (no killing a recycled PID).

## Wired through

Config → CLI (`--health-cmd` / `--health-http` / `--health-port` on `daemons add` / `start` / `run` / `restart`) → IPC → TUI → web UI → docs (`docs/guides/ready-checks.md`).

## Verification

- `cargo nextest run`: 771 passed
- BATS: 312 passed (includes new `test/health.bats` end-to-end cases for all three probe kinds)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean

*AI-assisted — Tool: opencode; model: venus/deepseek-v4-pro-official; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daemon health checks using shell commands, HTTP endpoints, or TCP ports.
  * Added configurable intervals, retries, timeouts, and HTTP status validation, including per-daemon port timeouts.
  * Added health-check options to daemon add, start, restart, and run commands.
  * Health-check details now appear in the CLI, web interface, and TUI.
* **Bug Fixes**
  * Port-template validation errors now identify the correct configuration field.
* **Documentation**
  * Added CLI, configuration, schema, and guide documentation.
* **Tests**
  * Added coverage for configuration validation and health-monitoring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->