### PR TITLE
chore: adopt mr-boxington 1.1 cargo shim

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
-        version: 0.6.0
+        version: 1.1.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,14 +1,6 @@
 name: Set up mbx
 description: Set up mbx with the GitHub Actions cache backend
 
-inputs:
-  cache-links:
-    description: Cache native links; "auto" enables this on Linux
-    default: auto
-  toolchain:
-    description: Rust toolchain named explicitly by the build
-    required: false
-
 runs:
   using: composite
   steps:
@@ -17,5 +9,3 @@ runs:
         version: 1.1.0
         backend: github
         cache-generation: v2
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,9 +12,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.1.0
         backend: github
+        cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,15 @@
 
 ## mbx build cache
 
-Compilation-heavy mise tasks and hk checks use `mbx`. If an mbx command fails
-or creates a development papercut, rerun the exact equivalent `cargo` command
-from `CONTRIBUTING.md`; this unblocks work without weakening the check. If Cargo
-succeeds, surface the mismatch and recommend a
+Mise installs mbx 1.1 and activates its transparent Cargo shim, so
+compilation-heavy mise tasks and hk checks use ordinary `cargo` commands. If
+the shim fails or creates a development papercut, rerun the exact equivalent
+command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
+weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
-the repository and commit, OS, `mbx --version`, both commands and outputs, the
-cache summary, and `MBX_BYPASS_LOG` details when relevant. Do not silently make
-Cargo the permanent path, and do not post externally without user authorization.
+the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
+and outputs. Do not permanently disable the shim, and do not post externally
+without user authorization.
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,9 @@ command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
 weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
 the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
-and outputs. Do not permanently disable the shim, and do not post externally
-without user authorization.
+and outputs. Redact secrets, absolute cache paths, remote URLs, namespaces, and
+other sensitive or identifying details. Do not permanently disable the shim,
+and do not post externally without user authorization.
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,22 +4,22 @@ See the [contributing guide](https://pitchfork.jdx.dev/contributing).
 
 ## mbx build cache
 
-The normal `mise run build`, `mise run test`, and `mise run lint` workflows use
-[mbx](https://mr-boxington.jdx.dev) for compilation-heavy Cargo work. If mbx
-appears to be the problem, first run `mise run build:ui`, then use the
-equivalent Cargo commands to unblock yourself without skipping or weakening the
-check:
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.1 and activates
+its transparent Cargo shim. The normal `mise run build`, `mise run test`, and
+`mise run lint` workflows therefore use the cache while invoking Cargo
+normally. To bypass mbx without skipping or weakening a check, first run
+`mise run build:ui`, then prefix the equivalent Cargo command with
+`MBX_DISABLE=1`:
 
 ```sh
-cargo build
-cargo nextest run
+MBX_DISABLE=1 cargo build
+MBX_DISABLE=1 cargo nextest run
 git submodule update --init --recursive
 mise run test:bats
-cargo clippy --manifest-path Cargo.toml --quiet -- -D warnings
+MBX_DISABLE=1 cargo clippy --manifest-path Cargo.toml --quiet -- -D warnings
 ```
 
-If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a
+If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
-Include the repository and commit, operating system, `mbx --version`, both
-commands and their output, the mbx cache summary, and an `MBX_BYPASS_LOG` when
-relevant (for example, `MBX_BYPASS_LOG=mbx-bypasses.log mise run build`).
+Include the repository and commit, operating system, `mbx --version`,
+`mbx doctor`, and both commands and their output.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,4 +22,6 @@ MBX_DISABLE=1 cargo clippy --manifest-path Cargo.toml --quiet -- -D warnings
 If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
 Include the repository and commit, operating system, `mbx --version`,
-`mbx doctor`, and both commands and their output.
+`mbx doctor`, and both commands and their output. Before posting, redact
+secrets, absolute cache paths, remote URLs, namespaces, and other sensitive or
+identifying details.

--- a/hk.pkl
+++ b/hk.pkl
@@ -4,7 +4,7 @@ import "package://github.com/jdx/hk/releases/download/v1.44.3/hk@1.44.3#/Builtin
 local linters = new Mapping<String, Step> {
     ["cargo_fmt"] = Builtins.cargo_fmt
     ["cargo_clippy"] = (Builtins.cargo_clippy) {
-        check = "mbx clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
+        check = "cargo clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
     }
     ["pkl"] {
         glob = "*.pkl"

--- a/mise.lock
+++ b/mise.lock
@@ -138,47 +138,6 @@ url = "https://github.com/jdx/communique/releases/download/v1.3.2/communique-x86
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633"
 provenance = "github-attestations"
 
-[[tools."github:jdx/mr-boxington"]]
-version = "0.6.0"
-backend = "github:jdx/mr-boxington"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:019c98cdf8ff28e8967919ea9a549b2a7d05f8636957fc443d2fe7d00d22a5ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792954"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:019c98cdf8ff28e8967919ea9a549b2a7d05f8636957fc443d2fe7d00d22a5ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792954"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:156bb820fd035f846b6efb5d7210a3b816ec8842005c904f4bf40fe0a1be245e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792966"
-provenance = "github-attestations"
-provenance_verified = true
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:156bb820fd035f846b6efb5d7210a3b816ec8842005c904f4bf40fe0a1be245e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792966"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:bbd19a27974cdbfe7fa4a6ffef3cb29150b12ccdf3a17d2dc1e0afdd09675f25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792953"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:4a0958560ecba3253cd1d4459abf6b05b70e739e40f207ac1c17df4cd6a9e8e7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792956"
-provenance = "github-attestations"
-
 [[tools."github:jdx/tak"]]
 version = "0.0.8"
 backend = "github:jdx/tak"
@@ -253,6 +212,47 @@ url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632123"
 checksum = "sha256:4ccf353e484997dd4975361b6433f3b2661f5db614f2b382cddcac7eaa74a604"
 url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632118"
+
+[[tools.mr-boxington]]
+version = "1.1.0"
+backend = "github:jdx/mr-boxington"
+
+[tools.mr-boxington."platforms.linux-arm64"]
+checksum = "sha256:ded60221f2217a6e0abfe0ba3583674bae63e5a7b696c4fa145827a3a0e352af"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232514"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-arm64-musl"]
+checksum = "sha256:70a882277389bd6e6b606fc291083a857a7ef0c742b60ba5a7822cc49fe7c4ac"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232511"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64"]
+checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools.mr-boxington."platforms.linux-x64-musl"]
+checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.macos-arm64"]
+checksum = "sha256:da96661534480fff35ec78e598124d208ac1f2624c6d3c287c9ae2a5852b0b29"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232513"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.windows-x64"]
+checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
+provenance = "github-attestations"
 
 [[tools.node]]
 version = "24.19.0"

--- a/mise.toml
+++ b/mise.toml
@@ -93,7 +93,7 @@ run = [
 ]
 
 [tools]
-mr-boxington = { version = "1.1.0", postinstall = "mbx setup --yes" }
+mr-boxington = { version = "1.1.0", postinstall = "mbx setup --global" }
 usage = "6.4.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change

--- a/mise.toml
+++ b/mise.toml
@@ -113,15 +113,20 @@ rust = "stable"
 # macOS where there is no usable cachegrind.
 # `depends` on build:ui because the release binary embeds ui/dist via
 # RustEmbed, and cargo will not compile without it.
-[tasks.perf]
+[tasks."perf:build"]
 depends = ["build:ui"]
+env = { MBX_DISABLE = "1" }
+run = "cargo build --release"
+
+[tasks.perf]
+depends = ["perf:build"]
 dir = "{{config_root}}"
-run = ["MBX_DISABLE=1 cargo build --release", "tak run"]
+run = "tak run"
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
 # `perf` workflow on every push to main; the notes are the history. Safe to run
 # locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
-depends = ["build:ui"]
+depends = ["perf:build"]
 dir = "{{config_root}}"
-run = ["MBX_DISABLE=1 cargo build --release", "tak run --record"]
+run = "tak run --record"

--- a/mise.toml
+++ b/mise.toml
@@ -116,7 +116,7 @@ rust = "stable"
 [tasks.perf]
 depends = ["build:ui"]
 dir = "{{config_root}}"
-run = ["cargo build --release", "tak run"]
+run = ["MBX_DISABLE=1 cargo build --release", "tak run"]
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
 # `perf` workflow on every push to main; the notes are the history. Safe to run
@@ -124,4 +124,4 @@ run = ["cargo build --release", "tak run"]
 [tasks."perf:record"]
 depends = ["build:ui"]
 dir = "{{config_root}}"
-run = ["cargo build --release", "tak run --record"]
+run = ["MBX_DISABLE=1 cargo build --release", "tak run --record"]

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ _.path = ["target/debug", "test/bats/bin"]
 [tasks.test]
 depends = ["build:ui"]
 run = [
-  "mbx nextest run",
+  "cargo nextest run",
   "git submodule update --init --recursive",
   "mise run test:bats",
 ]
@@ -50,7 +50,7 @@ run = "hk fix --all"
 
 [tasks.build]
 depends = ["build:ui"]
-run = ["mbx build"]
+run = ["cargo build"]
 
 [tasks."test:web-ui"]
 depends = ["build"]
@@ -93,7 +93,7 @@ run = [
 ]
 
 [tools]
-"github:jdx/mr-boxington" = "latest"
+mr-boxington = { version = "1.1.0", postinstall = "mbx setup --yes" }
 usage = "6.4.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change


### PR DESCRIPTION
## Summary

- adopt the `mr-boxington` mise shorthand at 1.1.0 with the setup post-install hook
- run compilation-heavy tasks through ordinary `cargo` commands and the transparent shim
- refresh the locked release and contributor/agent guidance

## Validation

- `MISE_LOCKED=1 mise install mr-boxington`
- `mise exec -- mbx --version` (`mbx 1.1.0`)
- `mise tasks ls`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect dev/CI build caching and task wiring only, not application runtime or security-sensitive paths; main risk is cache or shim misbehavior affecting local and CI compile workflows.
> 
> **Overview**
> Upgrades **mbx / mr-boxington** from **0.6.0** to **1.1.0** and wires it in through mise with `mbx setup --global` on install, so normal **`cargo`** invocations go through the transparent cache shim instead of explicit `mbx` wrappers.
> 
> **`mise.toml`** and **`hk.pkl`** now run `cargo build`, `cargo nextest run`, and `cargo clippy` directly; **`mise.lock`** pins the new release under the `mr-boxington` tool name. Performance tasks add **`perf:build`** with **`MBX_DISABLE=1`** so release benchmarks are not cache-shaped.
> 
> The **`.github/actions/mbx`** composite action bumps **mr-boxington-action** to **1.1.0**, sets **`cache-generation: v2`**, and drops the **`cache-links`** / **`toolchain`** inputs. **AGENTS.md** and **CONTRIBUTING.md** describe bypassing the shim with **`MBX_DISABLE=1`**, reporting issues with **`mbx doctor`**, and redacting sensitive details in discussions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342f94358dc488481b58a7356937eae0481d0200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated build cache tooling to version 1.1.0, enabling transparent caching while standard Cargo commands run normally.
  * Added a dedicated cache-bypass option for performance builds.
* **Bug Fixes**
  * Improved reliability of build, test, and lint workflows through the updated cache integration.
* **Documentation**
  * Updated setup, bypass, and troubleshooting guidance with diagnostic commands and sensitive-information redaction instructions.
  * Clarified how to temporarily disable the cache shim when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->