### PR TITLE
chore(release): improve sponsor message

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -111,9 +111,9 @@ jobs:
 
           ## 💚 Sponsor pitchfork
 
-          pitchfork is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Development is sustained by sponsorships.
+          pitchfork is built and maintained by [@jdx](https://github.com/jdx), an open source developer at [**entire.io**](https://entire.io/), the title sponsor of his open source work.
 
-          If pitchfork has a place in your dev workflow, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Individual and company sponsorships are what keep the project healthy and moving forward.
+          If pitchfork has a place in your development workflow, please consider becoming an [individual or company sponsor](https://jdx.dev/sponsors.html). Your support funds ongoing development and helps keep pitchfork fast, free, and independent.
           EOF
           } > /tmp/release-notes.md
           gh release edit "$TAG" --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

- clarify Entire's sponsorship of jdx's open source work
- link the sponsorship call to action directly to the individual and company sponsor page
- tighten the release-note copy while preserving each CLI's tailored message

## Testing

- git diff --check
- parsed the updated workflow as YAML

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-note marketing copy only in CI; no runtime, auth, or publish logic changes.
> 
> **Overview**
> Updates the **Sponsor pitchfork** block that the `enhance-release` job appends to GitHub release notes after `communique generate`.
> 
> The Entire.io line is shortened: it now says jdx builds and maintains pitchfork as a developer **at** Entire.io and that Entire is the title sponsor of his open source work, instead of listing jdx.dev tools (mise, aube, hk, etc.) and a longer sponsorship explanation.
> 
> The sponsorship call-to-action is reworded to point readers to become **individual or company sponsors** on the same `jdx.dev/sponsors.html` link, with copy that ties support to ongoing development and keeping pitchfork fast, free, and independent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a62a93fd81f3493327bababb4532c9e8e37bd583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sponsorship message included in GitHub release notes.
  * Refined the maintainer and sponsor descriptions and refreshed the sponsorship call to action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->