### PR TITLE
feat(hooks): inject PORT/PORT0..N into hook environments

### DIFF
--- a/docs/guides/lifecycle-hooks.md
+++ b/docs/guides/lifecycle-hooks.md
@@ -123,6 +123,8 @@ All hooks receive these environment variables:
 | `PITCHFORK_EXIT_CODE` | Exit code of the process (`on_fail`, `on_stop`, `on_exit`). On Unix, processes terminated by a signal (e.g. SIGTERM) have no POSIX exit code; in that case this is set to `-1`. |
 | `PITCHFORK_EXIT_REASON` | Why the daemon stopped. Typically `"stop"` (intentional stop by pitchfork) or `"fail"` (non-zero exit); `"exit"` indicates an unexpected clean exit (process quit on its own with code 0). Available in `on_stop` and `on_exit`. |
 | `PITCHFORK_MATCHED_LINE` | The raw output line that triggered the hook (`on_output` only) |
+| `PORT` | The daemon's first resolved port (same as `PORT0`); omitted when the daemon has no `port` config |
+| `PORT0..N` | One variable per resolved port (`PORT0`, `PORT1`, ...), matching what the daemon process itself receives |
 
 Any custom `env` variables from the daemon config are also passed to hooks.
 

--- a/docs/guides/lifecycle-hooks.md
+++ b/docs/guides/lifecycle-hooks.md
@@ -123,8 +123,8 @@ All hooks receive these environment variables:
 | `PITCHFORK_EXIT_CODE` | Exit code of the process (`on_fail`, `on_stop`, `on_exit`). On Unix, processes terminated by a signal (e.g. SIGTERM) have no POSIX exit code; in that case this is set to `-1`. |
 | `PITCHFORK_EXIT_REASON` | Why the daemon stopped. Typically `"stop"` (intentional stop by pitchfork) or `"fail"` (non-zero exit); `"exit"` indicates an unexpected clean exit (process quit on its own with code 0). Available in `on_stop` and `on_exit`. |
 | `PITCHFORK_MATCHED_LINE` | The raw output line that triggered the hook (`on_output` only) |
-| `PORT` | The daemon's first resolved port (same as `PORT0`); omitted when the daemon has no `port` config |
-| `PORT0..N` | One variable per resolved port (`PORT0`, `PORT1`, ...), matching what the daemon process itself receives |
+| `PITCHFORK_PORT` | The daemon's first resolved port (same as `PITCHFORK_PORT0`); omitted when the daemon has no `port` config |
+| `PITCHFORK_PORT0..N` | One variable per resolved port (`PITCHFORK_PORT0`, `PITCHFORK_PORT1`, ...), mirroring the daemon's own `PORT0..N` |
 
 Any custom `env` variables from the daemon config are also passed to hooks.
 

--- a/docs/guides/port-management.md
+++ b/docs/guides/port-management.md
@@ -39,7 +39,7 @@ run = "./start.sh --http-port $PORT0 --grpc-port $PORT1"
 port = [8080, 8443]
 ```
 
-Lifecycle hooks receive the same variables (see [hook environment variables](lifecycle-hooks.md#environment-variables)).
+Lifecycle hooks receive the same values as namespaced `PITCHFORK_PORT` / `PITCHFORK_PORT0..N` (see [hook environment variables](lifecycle-hooks.md#environment-variables)).
 
 ### Auto Port Bumping
 

--- a/docs/guides/port-management.md
+++ b/docs/guides/port-management.md
@@ -39,6 +39,8 @@ run = "./start.sh --http-port $PORT0 --grpc-port $PORT1"
 port = [8080, 8443]
 ```
 
+Lifecycle hooks receive the same variables (see [hook environment variables](lifecycle-hooks.md#environment-variables)).
+
 ### Auto Port Bumping
 
 When a port is occupied, enable `bump` to automatically find the next available port:

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -414,7 +414,7 @@ impl IpcClient {
                     error_message: None,
                 })
             }
-            IpcResponse::DaemonFailedWithCode { exit_code } => {
+            IpcResponse::DaemonFailedWithCode { exit_code, .. } => {
                 let code = exit_code.unwrap_or(1);
                 Ok(RunResult {
                     started: false,

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -162,6 +162,10 @@ pub enum IpcResponse {
     },
     DaemonFailedWithCode {
         exit_code: Option<i32>,
+        /// Ports resolved by the failed attempt, so in-process retry hooks
+        /// observe the attempt's actual (post-bump) ports.
+        #[serde(default)]
+        resolved_ports: Vec<u16>,
     },
     /// Process was not running but had a PID record (unexpected exit)
     DaemonWasNotRunning,

--- a/src/supervisor/adopt.rs
+++ b/src/supervisor/adopt.rs
@@ -460,6 +460,7 @@ impl Supervisor {
             .clone()
             .unwrap_or_else(|| crate::env::CWD.clone());
         let hook_env = daemon.env.clone();
+        let hook_resolved_ports = daemon.resolved_port.clone();
         let hook_retry = daemon.retry;
         let hook_retry_count = daemon.retry_count;
 
@@ -632,6 +633,7 @@ impl Supervisor {
                     daemon_dir.clone(),
                     hook_retry_count,
                     hook_env.clone(),
+                    hook_resolved_ports.clone(),
                     hook_extra_env.clone(),
                 )
                 .await;

--- a/src/supervisor/hooks.rs
+++ b/src/supervisor/hooks.rs
@@ -79,6 +79,26 @@ fn hook_command(cmd: &str) -> Result<tokio::process::Command> {
     }
 }
 
+/// Inject port env vars (`PORT` / `PORT0..N`) resolved for the daemon,
+/// using the same naming as the daemon's own spawn environment
+/// (`apply_runtime_env` in lifecycle.rs).
+async fn inject_port_env(command: &mut tokio::process::Command, daemon_id: &DaemonId) {
+    let resolved_ports = {
+        let state_file = SUPERVISOR.state_file.lock().await;
+        state_file
+            .daemons
+            .get(daemon_id)
+            .map(|d| d.resolved_port.clone())
+            .unwrap_or_default()
+    };
+    if let Some(port) = resolved_ports.first() {
+        command.env("PORT", port.to_string());
+        for (index, port) in resolved_ports.iter().enumerate() {
+            command.env(format!("PORT{index}"), port.to_string());
+        }
+    }
+}
+
 /// Fire a hook command as a fire-and-forget tokio task.
 ///
 /// Reads the hook command from fresh config rooted at the daemon's directory,
@@ -146,6 +166,7 @@ pub(crate) async fn fire_hook(
             .env("PITCHFORK_DAEMON_ID", daemon_id.qualified())
             .env("PITCHFORK_DAEMON_NAMESPACE", daemon_id.namespace())
             .env("PITCHFORK_RETRY_COUNT", retry_count.to_string());
+        inject_port_env(&mut command, &daemon_id).await;
 
         for (key, value) in &extra_env {
             command.env(key, value);
@@ -226,6 +247,7 @@ pub(crate) async fn fire_output_hook(
             .env("PITCHFORK_DAEMON_NAMESPACE", daemon_id.namespace())
             .env("PITCHFORK_RETRY_COUNT", retry_count.to_string())
             .env("PITCHFORK_MATCHED_LINE", &matched_line);
+        inject_port_env(&mut command, &daemon_id).await;
 
         match command.status().await {
             Ok(status) => {

--- a/src/supervisor/hooks.rs
+++ b/src/supervisor/hooks.rs
@@ -79,19 +79,11 @@ fn hook_command(cmd: &str) -> Result<tokio::process::Command> {
     }
 }
 
-/// Inject port env vars (`PITCHFORK_PORT` / `PITCHFORK_PORT0..N`) resolved
-/// for the daemon, mirroring the daemon's own spawn environment (`PORT` /
-/// `PORT0..N`, see `apply_runtime_env` in lifecycle.rs) but namespaced to
-/// match the other hook env vars.
-async fn inject_port_env(command: &mut tokio::process::Command, daemon_id: &DaemonId) {
-    let resolved_ports = {
-        let state_file = SUPERVISOR.state_file.lock().await;
-        state_file
-            .daemons
-            .get(daemon_id)
-            .map(|d| d.resolved_port.clone())
-            .unwrap_or_default()
-    };
+/// Inject port env vars (`PITCHFORK_PORT` / `PITCHFORK_PORT0..N`) for the
+/// daemon, mirroring the daemon's own spawn environment (`PORT` / `PORT0..N`,
+/// see `apply_runtime_env` in lifecycle.rs) but namespaced to match the other
+/// hook env vars.
+fn inject_port_env(command: &mut tokio::process::Command, resolved_ports: &[u16]) {
     if let Some(port) = resolved_ports.first() {
         command.env("PITCHFORK_PORT", port.to_string());
         for (index, port) in resolved_ports.iter().enumerate() {
@@ -105,6 +97,10 @@ async fn inject_port_env(command: &mut tokio::process::Command, daemon_id: &Daem
 /// Reads the hook command from fresh config rooted at the daemon's directory,
 /// then spawns it in the background. Errors are logged but never block the caller.
 ///
+/// `resolved_ports` must be snapshotted by the caller before spawning this
+/// task, so the hook observes the triggering attempt's ports even if a retry
+/// or restart replaces the daemon's state afterwards.
+///
 /// The spawned task is also registered in `SUPERVISOR.hook_tasks` so that
 /// supervisor shutdown (`close()`) can await all in-flight hooks before calling
 /// `exit(0)`, ensuring hooks are not silently dropped during shutdown.
@@ -114,6 +110,7 @@ pub(crate) async fn fire_hook(
     daemon_dir: PathBuf,
     retry_count: u32,
     daemon_env: Option<IndexMap<String, String>>,
+    resolved_ports: Vec<u16>,
     extra_env: Vec<(String, String)>,
 ) {
     let handle = tokio::spawn(async move {
@@ -167,7 +164,7 @@ pub(crate) async fn fire_hook(
             .env("PITCHFORK_DAEMON_ID", daemon_id.qualified())
             .env("PITCHFORK_DAEMON_NAMESPACE", daemon_id.namespace())
             .env("PITCHFORK_RETRY_COUNT", retry_count.to_string());
-        inject_port_env(&mut command, &daemon_id).await;
+        inject_port_env(&mut command, &resolved_ports);
 
         for (key, value) in &extra_env {
             command.env(key, value);
@@ -200,11 +197,14 @@ pub(crate) async fn fire_hook(
 ///
 /// `cmd` is the hook command string resolved at call time (from `on_output.run`).
 /// `matched_line` is exposed to the command via `PITCHFORK_MATCHED_LINE`.
+/// `resolved_ports` must be snapshotted by the caller before spawning this task
+/// (same contract as `fire_hook`).
 pub(crate) async fn fire_output_hook(
     daemon_id: DaemonId,
     daemon_dir: PathBuf,
     retry_count: u32,
     daemon_env: Option<IndexMap<String, String>>,
+    resolved_ports: Vec<u16>,
     cmd: String,
     matched_line: String,
 ) {
@@ -248,7 +248,7 @@ pub(crate) async fn fire_output_hook(
             .env("PITCHFORK_DAEMON_NAMESPACE", daemon_id.namespace())
             .env("PITCHFORK_RETRY_COUNT", retry_count.to_string())
             .env("PITCHFORK_MATCHED_LINE", &matched_line);
-        inject_port_env(&mut command, &daemon_id).await;
+        inject_port_env(&mut command, &resolved_ports);
 
         match command.status().await {
             Ok(status) => {

--- a/src/supervisor/hooks.rs
+++ b/src/supervisor/hooks.rs
@@ -79,9 +79,10 @@ fn hook_command(cmd: &str) -> Result<tokio::process::Command> {
     }
 }
 
-/// Inject port env vars (`PORT` / `PORT0..N`) resolved for the daemon,
-/// using the same naming as the daemon's own spawn environment
-/// (`apply_runtime_env` in lifecycle.rs).
+/// Inject port env vars (`PITCHFORK_PORT` / `PITCHFORK_PORT0..N`) resolved
+/// for the daemon, mirroring the daemon's own spawn environment (`PORT` /
+/// `PORT0..N`, see `apply_runtime_env` in lifecycle.rs) but namespaced to
+/// match the other hook env vars.
 async fn inject_port_env(command: &mut tokio::process::Command, daemon_id: &DaemonId) {
     let resolved_ports = {
         let state_file = SUPERVISOR.state_file.lock().await;
@@ -92,9 +93,9 @@ async fn inject_port_env(command: &mut tokio::process::Command, daemon_id: &Daem
             .unwrap_or_default()
     };
     if let Some(port) = resolved_ports.first() {
-        command.env("PORT", port.to_string());
+        command.env("PITCHFORK_PORT", port.to_string());
         for (index, port) in resolved_ports.iter().enumerate() {
-            command.env(format!("PORT{index}"), port.to_string());
+            command.env(format!("PITCHFORK_PORT{index}"), port.to_string());
         }
     }
 }

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -309,7 +309,10 @@ impl Supervisor {
                     IpcResponse::DaemonReady { daemon } => {
                         return Ok(IpcResponse::DaemonReady { daemon });
                     }
-                    IpcResponse::DaemonFailedWithCode { exit_code } => {
+                    IpcResponse::DaemonFailedWithCode {
+                        exit_code,
+                        resolved_ports,
+                    } => {
                         if attempt < opts.retry.count() {
                             let backoff_secs = 2u64.saturating_pow(attempt).min(3600);
                             info!(
@@ -324,12 +327,7 @@ impl Supervisor {
                                 opts.dir.0.clone(),
                                 attempt + 1,
                                 opts.env.clone(),
-                                // In-process retry: the attempt's resolved ports are not
-                                // in scope here, so fall back to the configured expectation.
-                                opts.port
-                                    .as_ref()
-                                    .map(|p| p.expect.clone())
-                                    .unwrap_or_default(),
+                                resolved_ports,
                                 vec![],
                             )
                             .await;
@@ -337,7 +335,10 @@ impl Supervisor {
                             continue;
                         } else {
                             info!("daemon {id} failed after {max_attempts} attempts");
-                            return Ok(IpcResponse::DaemonFailedWithCode { exit_code });
+                            return Ok(IpcResponse::DaemonFailedWithCode {
+                                exit_code,
+                                resolved_ports,
+                            });
                         }
                     }
                     other => return Ok(other),
@@ -1786,7 +1787,10 @@ impl Supervisor {
                     if using_sink && last_attempt {
                         super::log_sink::wait_for_output(id, spawn_time, SINK_OUTPUT_TIMEOUT).await;
                     }
-                    Ok(IpcResponse::DaemonFailedWithCode { exit_code })
+                    Ok(IpcResponse::DaemonFailedWithCode {
+                        exit_code,
+                        resolved_ports: daemon.resolved_port.clone(),
+                    })
                 }
                 Err(_) => {
                     error!("readiness channel closed unexpectedly for daemon {id}");

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -756,7 +756,7 @@ impl Supervisor {
                             expected_ports,
                             opts.port.as_ref().map(|p| p.bump).unwrap_or_default(),
                         );
-                        o.resolved_port = resolved_ports;
+                        o.resolved_port = Some(resolved_ports);
                     })
                     .build(),
             )

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -324,6 +324,12 @@ impl Supervisor {
                                 opts.dir.0.clone(),
                                 attempt + 1,
                                 opts.env.clone(),
+                                // In-process retry: the attempt's resolved ports are not
+                                // in scope here, so fall back to the configured expectation.
+                                opts.port
+                                    .as_ref()
+                                    .map(|p| p.expect.clone())
+                                    .unwrap_or_default(),
                                 vec![],
                             )
                             .await;
@@ -770,6 +776,9 @@ impl Supervisor {
         let hook_retry_count = opts.retry_count;
         let hook_retry = opts.retry;
         let hook_daemon_env = opts.env.clone();
+        // Ports of THIS attempt, snapshotted before the monitor starts: a retry
+        // or restart may replace state.resolved_port before a hook task runs.
+        let hook_resolved_ports = daemon.resolved_port.clone();
         let readiness_daemon_env = opts.env.clone();
         let readiness_resolved_ports = daemon.resolved_port.clone();
         let on_output_hook = opts.on_output_hook.clone();
@@ -1177,7 +1186,7 @@ impl Supervisor {
                             if let Some(tx) = ready_tx.take() {
                                 let _ = tx.send(Ok(()));
                             }
-                            fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), vec![]).await;
+                            fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), hook_resolved_ports.clone(), vec![]).await;
                             stop_cmd_probe_state(&mut cmd_probe);
                             http_deadline = None;
                             cmd_deadline = None;
@@ -1211,7 +1220,7 @@ impl Supervisor {
                                 let elapsed = on_output_last_fired.map(|t| now.duration_since(t));
                                 if elapsed.is_none_or(|e| e >= on_output_debounce) {
                                     on_output_last_fired = Some(now);
-                                    hooks::fire_output_hook(id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), hook.run.clone(), line_clean.clone()).await;
+                                    hooks::fire_output_hook(id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), hook_resolved_ports.clone(), hook.run.clone(), line_clean.clone()).await;
                                 }
                             }
                         }
@@ -1297,7 +1306,7 @@ impl Supervisor {
                                     if let Some(tx) = ready_tx.take() {
                                         let _ = tx.send(Ok(()));
                                     }
-                                    fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), vec![]).await;
+                                    fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), hook_resolved_ports.clone(), vec![]).await;
                                     http_check_interval = None;
                                     http_deadline = None;
                                     stop_cmd_probe_state(&mut cmd_probe);
@@ -1365,7 +1374,7 @@ impl Supervisor {
                                     if let Some(tx) = ready_tx.take() {
                                         let _ = tx.send(Ok(()));
                                     }
-                                    fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), vec![]).await;
+                                    fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), hook_resolved_ports.clone(), vec![]).await;
                                     // Stop checking once ready
                                     port_check_interval = None;
                                     port_deadline = None;
@@ -1443,7 +1452,7 @@ impl Supervisor {
                                 if let Some(tx) = ready_tx.take() {
                                     let _ = tx.send(Ok(()));
                                 }
-                                fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), vec![]).await;
+                                fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), hook_resolved_ports.clone(), vec![]).await;
                                 cmd_respawn_delay = None;
                                 cmd_deadline = None;
                                 http_deadline = None;
@@ -1518,7 +1527,7 @@ impl Supervisor {
                                     if let Some(tx) = ready_tx.take() {
                                         let _ = tx.send(Ok(()));
                                     }
-                                    fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), vec![]).await;
+                                    fire_hook(HookType::OnReady, id.clone(), daemon_dir.clone(), hook_retry_count, hook_daemon_env.clone(), hook_resolved_ports.clone(), vec![]).await;
                                 }
                             }
                             // Clear all deadlines — no other checks are configured
@@ -1747,6 +1756,7 @@ impl Supervisor {
                     daemon_dir.clone(),
                     hook_retry_count,
                     hook_daemon_env.clone(),
+                    hook_resolved_ports.clone(),
                     hook_extra_env.clone(),
                 )
                 .await;

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -734,6 +734,13 @@ impl Supervisor {
         {
             pipe.supervise(id.clone(), monitor_token, child);
         }
+        // The attempt's actual resolved ports, captured before the upsert
+        // moves them into state. Hooks, readiness probes, and the failure
+        // response must reflect this attempt: the state merge keeps the
+        // existing resolved_port when an update is empty, so a no-port
+        // attempt would otherwise inherit a previous run's stale ports
+        // through the upserted record.
+        let attempt_resolved_ports = resolved_ports.clone();
         let daemon = self
             .upsert_daemon(
                 UpsertDaemonOpts::from_run_options(&opts, DaemonStatus::Running)
@@ -779,9 +786,11 @@ impl Supervisor {
         let hook_daemon_env = opts.env.clone();
         // Ports of THIS attempt, snapshotted before the monitor starts: a retry
         // or restart may replace state.resolved_port before a hook task runs.
-        let hook_resolved_ports = daemon.resolved_port.clone();
+        // Sourced from the attempt's local value, not the upserted record —
+        // the state merge inherits stale ports for a no-port attempt.
+        let hook_resolved_ports = attempt_resolved_ports.clone();
         let readiness_daemon_env = opts.env.clone();
-        let readiness_resolved_ports = daemon.resolved_port.clone();
+        let readiness_resolved_ports = attempt_resolved_ports.clone();
         let on_output_hook = opts.on_output_hook.clone();
         // Whether this daemon has any port-related config — used to skip the
         // active_port detection task for daemons that never bind a port (e.g. `sleep 60`).
@@ -1789,7 +1798,7 @@ impl Supervisor {
                     }
                     Ok(IpcResponse::DaemonFailedWithCode {
                         exit_code,
-                        resolved_ports: daemon.resolved_port.clone(),
+                        resolved_ports: attempt_resolved_ports,
                     })
                 }
                 Err(_) => {

--- a/src/supervisor/retry.rs
+++ b/src/supervisor/retry.rs
@@ -77,6 +77,9 @@ impl Supervisor {
                 dir.clone(),
                 daemon.retry_count + 1,
                 daemon.env.clone(),
+                // Per-attempt value: run_once clears the record when an
+                // attempt resolves no ports, so a port-less child's retry
+                // hook receives no port vars.
                 daemon.resolved_port.clone(),
                 vec![],
             )

--- a/src/supervisor/retry.rs
+++ b/src/supervisor/retry.rs
@@ -77,6 +77,7 @@ impl Supervisor {
                 dir.clone(),
                 daemon.retry_count + 1,
                 daemon.env.clone(),
+                daemon.resolved_port.clone(),
                 vec![],
             )
             .await;

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -76,8 +76,10 @@ pub(crate) struct UpsertDaemonOpts {
     pub ready_cmd: Option<ReadyCmd>,
     /// Port configuration
     pub port: Option<PortConfig>,
-    /// Resolved ports actually used after auto-bump (may differ from expected)
-    pub resolved_port: Vec<u16>,
+    /// Resolved ports actually used after auto-bump (may differ from expected).
+    /// `None` inherits the existing record's value; `Some` sets it explicitly,
+    /// including an empty vec, which clears ports left by a previous run.
+    pub resolved_port: Option<Vec<u16>>,
     /// The first port the process is actually listening on (detected at runtime).
     pub active_port: Option<u16>,
     /// Optional stable slug alias for this daemon.
@@ -266,12 +268,11 @@ impl Supervisor {
                 .ready_cmd
                 .or(existing.and_then(|d| d.ready_cmd.clone())),
             port: opts.port.or_else(|| existing.and_then(|d| d.port.clone())),
-            resolved_port: if opts.resolved_port.is_empty() {
-                existing
+            resolved_port: match opts.resolved_port {
+                Some(ports) => ports,
+                None => existing
                     .map(|d| d.resolved_port.clone())
-                    .unwrap_or_default()
-            } else {
-                opts.resolved_port
+                    .unwrap_or_default(),
             },
             depends: opts
                 .depends

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -586,3 +586,81 @@ EOF
 
   kill_pid "$daemon_pid"
 }
+
+# ---------------------------------------------------------------------------
+# PORT / PORTN env vars in hooks
+# ---------------------------------------------------------------------------
+
+@test "on_ready hook receives PORT and PORT0 from resolved ports" {
+  local marker="$TEST_TEMP_DIR/hook_port_env"
+
+  create_pitchfork_toml <<EOF
+[daemons.porthy]
+run = "sleep 60"
+port = 18191
+
+[daemons.porthy.hooks]
+on_ready = "echo \$PORT > $marker"
+EOF
+
+  pitchfork supervisor start
+  pitchfork start porthy
+
+  wait_for_status porthy running
+  wait_for_file "$marker"
+  run cat "$marker"
+  assert_output "18191"
+
+  pitchfork stop porthy
+}
+
+@test "hooks receive PORT0 and PORT1 for multi-port daemons" {
+  local marker0="$TEST_TEMP_DIR/hook_port0"
+  local marker1="$TEST_TEMP_DIR/hook_port1"
+
+  create_pitchfork_toml <<EOF
+[daemons.multiport]
+run = "sleep 60"
+port = [18191, 18192]
+
+[daemons.multiport.hooks]
+on_ready = "echo \$PORT0 > $marker0; echo \$PORT1 > $marker1"
+EOF
+
+  pitchfork supervisor start
+  pitchfork start multiport
+
+  wait_for_status multiport running
+  wait_for_file "$marker0"
+  wait_for_file "$marker1"
+  run cat "$marker0"
+  assert_output "18191"
+  run cat "$marker1"
+  assert_output "18192"
+
+  pitchfork stop multiport
+}
+
+@test "on_stop hook receives PORT after daemon stops" {
+  local marker="$TEST_TEMP_DIR/hook_stop_port"
+
+  create_pitchfork_toml <<EOF
+[daemons.porthalt]
+run = "sleep 60"
+port = 18191
+
+[daemons.porthalt.hooks]
+on_stop = "echo \$PORT > $marker"
+EOF
+
+  pitchfork supervisor start
+  pitchfork start porthalt
+  wait_for_status porthalt running
+
+  pitchfork stop porthalt
+  wait_for_status porthalt stopped
+
+  wait_for_file "$marker"
+  run cat "$marker"
+  assert_output "18191"
+}

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -588,10 +588,10 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# PORT / PORTN env vars in hooks
+# PITCHFORK_PORT / PITCHFORK_PORTN env vars in hooks
 # ---------------------------------------------------------------------------
 
-@test "on_ready hook receives PORT and PORT0 from resolved ports" {
+@test "on_ready hook receives PITCHFORK_PORT and PITCHFORK_PORT0 from resolved ports" {
   local marker="$TEST_TEMP_DIR/hook_port_env"
 
   create_pitchfork_toml <<EOF
@@ -600,7 +600,7 @@ run = "sleep 60"
 port = 18191
 
 [daemons.porthy.hooks]
-on_ready = "echo \$PORT > $marker"
+on_ready = "echo \$PITCHFORK_PORT > $marker"
 EOF
 
   pitchfork supervisor start
@@ -614,7 +614,7 @@ EOF
   pitchfork stop porthy
 }
 
-@test "hooks receive PORT0 and PORT1 for multi-port daemons" {
+@test "hooks receive PITCHFORK_PORT0 and PITCHFORK_PORT1 for multi-port daemons" {
   local marker0="$TEST_TEMP_DIR/hook_port0"
   local marker1="$TEST_TEMP_DIR/hook_port1"
 
@@ -624,7 +624,7 @@ run = "sleep 60"
 port = [18191, 18192]
 
 [daemons.multiport.hooks]
-on_ready = "echo \$PORT0 > $marker0; echo \$PORT1 > $marker1"
+on_ready = "echo \$PITCHFORK_PORT0 > $marker0; echo \$PITCHFORK_PORT1 > $marker1"
 EOF
 
   pitchfork supervisor start
@@ -641,7 +641,7 @@ EOF
   pitchfork stop multiport
 }
 
-@test "on_stop hook receives PORT after daemon stops" {
+@test "on_stop hook receives PITCHFORK_PORT after daemon stops" {
   local marker="$TEST_TEMP_DIR/hook_stop_port"
 
   create_pitchfork_toml <<EOF
@@ -650,7 +650,7 @@ run = "sleep 60"
 port = 18191
 
 [daemons.porthalt.hooks]
-on_stop = "echo \$PORT > $marker"
+on_stop = "echo \$PITCHFORK_PORT > $marker"
 EOF
 
   pitchfork supervisor start


### PR DESCRIPTION
Closes #797

## Summary

Lifecycle hooks now receive the daemon's resolved ports as `PITCHFORK_PORT` (first resolved port, same as `PITCHFORK_PORT0`) and `PITCHFORK_PORT0..N` (one variable per resolved port). This enables hooks like `kill -9 $(lsof -t -i:$PITCHFORK_PORT)` in `on_exit`.

## Implementation

- New `inject_port_env` helper in `src/supervisor/hooks.rs`: reads the daemon's `resolved_port` from the state file at fire time and injects `PITCHFORK_PORT`/`PITCHFORK_PORT0..N` — the same values the daemon's own spawn environment gets as `PORT`/`PORT0..N` (via `apply_runtime_env`), namespaced to match every other supervisor-injected hook variable (`PITCHFORK_DAEMON_ID`, `PITCHFORK_EXIT_CODE`, ...).
- Called from both `fire_hook` (all hook types) and `fire_output_hook`, after user env so it cannot be overwritten.
- Bare names are deliberately avoided for hooks: unlike the daemon's own environment (12-factor `PORT` contract, documented), a bare `PORT` in hook env would overwrite user-configured `env` variables.
- Omitted when the daemon has no port config.

## Timing note

`active_port` is cleared before `on_exit`/`on_stop` fire, so exit-time hooks get the resolved port. That is the value wanted for cleanup use cases (the port the daemon was assigned).

## Docs

- `docs/guides/lifecycle-hooks.md`: added `PITCHFORK_PORT`/`PITCHFORK_PORT0..N` rows to the hook env table.
- `docs/guides/port-management.md`: hook env section now references the namespaced names.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo nextest run`: 715 passed
- `bats test/hooks.bats`: 26 passed, including 3 new e2e cases (`on_ready` single port, multi-port `PITCHFORK_PORT0`/`PITCHFORK_PORT1`, `on_stop` receives `PITCHFORK_PORT`)

*AI-assisted — Tool: opencode; model: astra/GLM-5.3-Flash-astra; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lifecycle hooks now receive resolved daemon ports through `PITCHFORK_PORT` and `PITCHFORK_PORT0..N`.
  - Port values are preserved across retries and lifecycle events, including single-port, multi-port, stopped, adopted, and failed daemons.
  - Failure responses now carry resolved port information for subsequent processing.
  - Explicitly clearing resolved ports is now supported.

- **Documentation**
  - Updated lifecycle hook and port management guides with the new environment variable names.

- **Tests**
  - Added coverage for port environment variables across supported daemon configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->