### PR TITLE
chore(ci): use project-installed mbx

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -20,16 +20,14 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+      uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
       with:
-        version: 1.3.1
         backend: github
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+    - uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
       with:
-        version: 1.3.1
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}


### PR DESCRIPTION
## Summary

- update the local mbx wrapper to the action change in jdx/mr-boxington-action#27
- omit the action version so CI reuses the project-pinned mbx already installed by mise

## Testing

- `mise run ci-dev` (715 Rust tests and 308 Bats tests passed)
- `git diff --check`

Depends on https://github.com/jdx/mr-boxington-action/pull/27

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only wrapper changes with no application runtime impact; risk is limited to cache setup behavior if mise and the action get out of sync.
> 
> **Overview**
> Updates the local **Set up mbx** composite action to pin `jdx/mr-boxington-action` at a newer commit and **drops the explicit `version: 1.3.1` input** on both cache steps (fork mirror restore and main setup).
> 
> CI should run **mbx from the project’s mise pin** (`mr-boxington` in `mise.toml`) instead of letting the action install its own binary, matching the upstream action change in `jdx/mr-boxington-action#27`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab0c78bb47093888a6c9ce4764457cbb229ec0c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release workflow to use a newer action version.
  * Removed the fixed tool version setting so the workflow can follow the updated action configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->