### PR TITLE
chore(ci): update mbx to 1.3.2

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -20,13 +20,13 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
+      uses: jdx/mr-boxington-action@v1.2.0
       with:
         backend: github
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
+    - uses: jdx/mr-boxington-action@v1.2.0
       with:
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -20,13 +20,13 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@v1.2.0
+      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         backend: github
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@v1.2.0
+    - uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}

--- a/mise.lock
+++ b/mise.lock
@@ -214,44 +214,44 @@ url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-pc-windows-
 url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632118"
 
 [[tools.mr-boxington]]
-version = "1.3.1"
+version = "1.3.2"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:a8750807b2881f4d74ec69a416222b03bc417a6ddf6751cc1e8a1fbb900131e0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539461140"
+checksum = "sha256:18aabfdfaced4316b9e9fd488d65df0915b241aa3af8e761b4df0fc0bdc1a4f7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849887"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:b3f423804d1e39a738590b237d6eeea12cb13b579e1280ba6e79964452855f59"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.1/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539461137"
+checksum = "sha256:abbbcc8cc7c080febc5f6c77e1ae7af89faf15476248282f7bf4c331e836ee1b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849885"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:ca9bd7f92b08561a978840fa8c67b74457771b0b9deb621163b76e5b685f6dc2"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539461155"
+checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:575abd66aa7cd47cb7b1d6c6f6a7cae61848222b3d59bdd740b05aa250f5fbf8"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.1/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539461156"
+checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:bcebd1523de989b8606d04d5b916d33eef8137771a5fcdb76fb8d52fa61c38b4"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.1/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539461139"
+checksum = "sha256:3a91ecb2d6ff4ad84662e79599d11e79eff4738c222a35ed432db4b15ade4d1e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849886"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:d92a4749bb5b6563220c23b3348c42107c6a538dc36926f730415b5ef0f9d351"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.1/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539461150"
+checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -95,7 +95,7 @@ run = [
 ]
 
 [tools]
-mr-boxington = "1.3.1"
+mr-boxington = "1.3.2"
 usage = "6.6.1"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change


### PR DESCRIPTION
## Summary

- use mr-boxington-action v1.2.0, pinned to its release commit
- use the project-installed mbx instead of installing a separate copy in CI
- update the project mbx pin and lockfile to 1.3.2
- keep explicit benchmark or specialized workflow installs on mbx 1.3.2 where applicable

## Validation

- mise lock mr-boxington
- git diff --check
- GitHub Actions

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only CI and mise tooling updates with no application code changes; main risk is transient cache or workflow breakage if the new action or mbx release regresses.
> 
> **Overview**
> Follow-up to #799: CI now uses the **released** `jdx/mr-boxington-action` at **v1.2.0** (commit `adc5c234…`) instead of a temporary commit SHA in both steps of the composite **Set up mbx** action (fork cache mirror restore and main cache setup).
> 
> Local/dev tooling is bumped in lockstep: **`mr-boxington` goes from 1.3.1 → 1.3.2** in `mise.toml` with regenerated `mise.lock` checksums and download URLs across platforms. Workflow behavior is unchanged aside from these version pins—the action still uses project-installed `mbx` from PATH via the existing `mbx` cargo wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e19c24b156b96836e24b8405c7df25f1bcd2d778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflow tooling to newer stable releases.
  - Improved workflow reliability by pinning automation components to a specific immutable release.
  - No changes to product functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->