### PR TITLE
chore: release v2.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.1](https://github.com/jdx/pitchfork/compare/v2.24.0...v2.24.1) - 2026-09-02
+
+### Other
+
+- *(deps)* update rust crate usage_rs to v6.4.1 ([#804](https://github.com/jdx/pitchfork/pull/804))
+
 ## [2.24.0](https://github.com/jdx/pitchfork/compare/v2.23.0...v2.24.0) - 2026-08-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,7 +2759,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.24.0"
+version = "2.24.1"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.24.0"
+version = "2.24.1"
 edition = "2024"
 resolver = "3"
 rust-version = "1.91"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6728,7 +6728,7 @@
       }
     ]
   },
-  "version": "2.24.0",
+  "version": "2.24.1",
   "usage": "",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `pitchfork <SUBCOMMAND>`
 
-**Version:** 2.24.0
+**Version:** 2.24.1
 
 - **Usage:** `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,7 +1,7 @@
 // @generated from usage-rs metadata
 name pitchfork
 bin pitchfork
-version "2.24.0"
+version "2.24.1"
 about "Daemons with DX"
 unknown_flags error
 external_subcommand #true


### PR DESCRIPTION



## 🤖 New release

* `pitchfork-cli`: 2.24.0 -> 2.24.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.24.1](https://github.com/jdx/pitchfork/compare/v2.24.0...v2.24.1) - 2026-09-02

### Other

- *(deps)* update rust crate usage_rs to v6.4.1 ([#804](https://github.com/jdx/pitchfork/pull/804))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch release with version and documentation sync only; functional change is a minor CLI dependency bump already captured in the changelog.
> 
> **Overview**
> **Release v2.24.1** bumps `pitchfork-cli` from **2.24.0** to **2.24.1** across `Cargo.toml`, `Cargo.lock`, generated CLI docs (`docs/cli/commands.json`, `docs/cli/index.md`, `pitchfork.usage.kdl`), and **CHANGELOG**.
> 
> The new changelog entry (2026-09-02) records the only user-facing note for this patch: dependency **usage_rs** updated to **v6.4.1** ([#804](https://github.com/jdx/pitchfork/pull/804)). No application source changes appear in this diff—it's a **release-plz** metadata release aligning version strings with that dependency work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 822ecb9b97c40c0ab9eec84ef8bb1876ba5f0620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->