### PR TITLE
ci: diagnose mbx prediction handoff

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -13,6 +13,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  MBX_DIAGNOSTICS: true
   MISE_EXPERIMENTAL: true
 
 jobs:
@@ -37,6 +38,14 @@ jobs:
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
           mirror-github-cache: "true"
+      - name: Install diagnostic mbx
+        if: ${{ inputs.trusted }}
+        shell: bash
+        run: |
+          cargo install --git https://github.com/jdx/mr-boxington.git \
+            --rev 94674126e3a6ba63a22c7e7c77bbabb3e4da6da6 \
+            --locked --root "$RUNNER_TEMP/mbx-diagnostic" mbx
+          echo "$RUNNER_TEMP/mbx-diagnostic/bin" >> "$GITHUB_PATH"
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - run: mise run build:ui


### PR DESCRIPTION
Temporary diagnostic run for the mbx remote prediction handoff. This installs an instrumented mbx build in the trusted Linux job and will be closed without merging after two measurements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to trusted CI workflow env and an extra diagnostic binary install; no application or production runtime behavior is modified.
> 
> **Overview**
> **Temporary CI instrumentation** to debug mbx remote prediction handoff (intended to be reverted after measurements).
> 
> The shared `ci-impl` workflow now sets **`MBX_DIAGNOSTICS=true`** for all jobs in that workflow. On **trusted** Linux `build` runs only, a new step **`cargo install`s** a pinned revision of **`mbx` from `jdx/mr-boxington`** into the runner temp dir and prepends that bin dir to **`GITHUB_PATH`**, so later steps use the instrumented CLI instead of whatever the `./.github/actions/mbx` setup provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f44c36be9dffeadde99a481c2f04a2b21cfb020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration checks to include enhanced diagnostics during trusted builds.
  * No changes to the application’s public features or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->