### PR TITLE
perf(ci): reuse appliance-local mbx cache

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -72,7 +72,7 @@ jobs:
 
   measure:
     env:
-      # Persistent appliance-local store; no remote backend is configured.
+      # Job-local appliance volume; no remote backend is configured.
       MBX_CACHE_DIR: /var/cache/mbx
       MBX_REMOTE_URL: ""
     name: Compare instruction counts
@@ -85,7 +85,7 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
-      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx-pr,dst=/var/cache/mbx
+      options: --cpuset-cpus 0-7 --mount type=volume,dst=/var/cache/mbx
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it
@@ -95,6 +95,8 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Initialize isolated build cache
+        run: sudo chown "$(id -u):$(id -g)" "$MBX_CACHE_DIR"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The branch commit, not the merge commit actions/checkout defaults to

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -74,6 +74,7 @@ jobs:
     env:
       # Persistent appliance-local store; no remote backend is configured.
       MBX_CACHE_DIR: /var/cache/mbx
+      MBX_REMOTE_URL: ""
     name: Compare instruction counts
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'
@@ -84,7 +85,7 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
-      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx
+      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx-pr,dst=/var/cache/mbx
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -85,6 +85,7 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      # Anonymous by design; perf-runner#10 prunes it after this container stops.
       options: --cpuset-cpus 0-7 --mount type=volume,dst=/var/cache/mbx
     timeout-minutes: 40
     permissions:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -29,6 +29,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  # Persistent appliance-local store; no remote backend is configured.
+  MBX_CACHE_DIR: /var/cache/mbx
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-pitchfork-rust1.97.1
 
 jobs:
@@ -81,7 +83,7 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
-      options: --cpuset-cpus 0-7
+      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it
@@ -104,8 +106,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Compile inside the pinned job container. Restoring target/ could relabel
-      # a binary built on another runner class as a jdx-perf-v1 measurement.
+      # Compile inside the pinned job container. mise's cache remains disabled:
+      # mbx uses the appliance-local content-addressed store mounted above.
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
@@ -122,6 +124,8 @@ jobs:
             uname -a
             lscpu
             mise --version
+            mbx --version
+            mbx cache dir
             rustc --version
             cargo --version
             valgrind --version
@@ -139,7 +143,7 @@ jobs:
       - name: Measure this pull request
         run: |
           mise run build:ui
-          cargo build --release
+          mbx build --release
           taskset -c 0-3 mise run perf:record
 
       - name: Find the base commit

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -142,8 +142,6 @@ jobs:
       # `tak push` in this workflow and there should never be one.
       - name: Measure this pull request
         run: |
-          mise run build:ui
-          mbx build --release
           taskset -c 0-3 mise run perf:record
 
       - name: Find the base commit

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -29,8 +29,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  # Persistent appliance-local store; no remote backend is configured.
-  MBX_CACHE_DIR: /var/cache/mbx
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-pitchfork-rust1.97.1
 
 jobs:
@@ -73,6 +71,9 @@ jobs:
           echo "pr_number=$PR_NUMBER" >&3
 
   measure:
+    env:
+      # Persistent appliance-local store; no remote backend is configured.
+      MBX_CACHE_DIR: /var/cache/mbx
     name: Compare instruction counts
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -34,6 +34,7 @@ jobs:
     env:
       # Persistent appliance-local store; no remote backend is configured.
       MBX_CACHE_DIR: /var/cache/mbx
+      MBX_REMOTE_URL: ""
     name: Measure
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -87,8 +87,6 @@ jobs:
 
       - name: Measure and record
         run: |
-          mise run build:ui
-          mbx build --release
           taskset -c 0-3 mise run perf:record
       - name: Package measurement note
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,12 +27,13 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  # Persistent appliance-local store; no remote backend is configured.
-  MBX_CACHE_DIR: /var/cache/mbx
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-pitchfork-rust1.97.1
 
 jobs:
   measure:
+    env:
+      # Persistent appliance-local store; no remote backend is configured.
+      MBX_CACHE_DIR: /var/cache/mbx
     name: Measure
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,6 +27,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  # Persistent appliance-local store; no remote backend is configured.
+  MBX_CACHE_DIR: /var/cache/mbx
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-pitchfork-rust1.97.1
 
 jobs:
@@ -38,7 +40,7 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
-      options: --cpuset-cpus 0-7
+      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx
     timeout-minutes: 30
     permissions:
       contents: read
@@ -47,8 +49,8 @@ jobs:
         with:
           persist-credentials: false
 
-      # Compile inside the pinned job container. Restoring target/ could relabel
-      # a binary built on another runner class as a jdx-perf-v1 measurement.
+      # Compile inside the pinned job container. mise's cache remains disabled:
+      # mbx uses the appliance-local content-addressed store mounted above.
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
@@ -69,6 +71,8 @@ jobs:
             uname -a
             lscpu
             mise --version
+            mbx --version
+            mbx cache dir
             rustc --version
             cargo --version
             valgrind --version
@@ -84,7 +88,7 @@ jobs:
       - name: Measure and record
         run: |
           mise run build:ui
-          cargo build --release
+          mbx build --release
           taskset -c 0-3 mise run perf:record
       - name: Package measurement note
         if: github.ref == 'refs/heads/main'

--- a/mise.toml
+++ b/mise.toml
@@ -122,7 +122,7 @@ env = { MBX_CARGO_SHIM_MODE = "1" }
 [tasks.perf]
 depends = ["build:ui"]
 dir = "{{config_root}}"
-run = ["cargo build --release", "tak run"]
+run = ["mbx build --release", "tak run"]
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
 # `perf` workflow on every push to main; the notes are the history. Safe to run
@@ -130,4 +130,4 @@ run = ["cargo build --release", "tak run"]
 [tasks."perf:record"]
 depends = ["build:ui"]
 dir = "{{config_root}}"
-run = ["cargo build --release", "tak run --record"]
+run = ["mbx build --release", "tak run --record"]


### PR DESCRIPTION
## Summary

- build performance-test source once with the released `mbx`
- persist trusted-main build outputs on `jdx-perf-01`; use a fresh appliance-local volume for each PR comparison
- discard each PR volume after cleanup so code under test cannot affect a later job
- explicitly disable remote mbx backends and report the mbx version and cache directory

Depends on jdx/perf-runner#10. Benchmark-refresh jobs remain release-artifact-only and do not use this source-build cache. Tak remains on its deliberate GitHub-hosted built-in Rust build.

## Validation

- `actionlint` on changed workflows
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated performance testing workflows to use isolated local build caching and dedicated cache storage.
  - Added build-tool version and cache-location details to performance diagnostics.
  - Streamlined performance measurements so builds run through the configured build process.
  - Updated the documentation deployment workflow’s version annotation without changing deployment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how perf gates compile code and introduces shared vs isolated cache boundaries on self-hosted runners, which could affect measurement fidelity or build trust if cache isolation regresses.
> 
> **Overview**
> Performance CI now builds release binaries through **`mbx`** with an appliance-local content-addressed cache instead of bare **`cargo build --release`**, and the **`perf`** / **`perf:record`** mise tasks were updated to match.
> 
> On **main** (`perf.yml`), the job bind-mounts a persistent host path into **`/var/cache/mbx`**. On **PR comparison** (`perf-pr.yml`), each run gets an anonymous volume at the same path (initialized with **`chown`**), with **`MBX_REMOTE_URL`** cleared so no remote cache backend is used. Workflow steps no longer duplicate **`build:ui`** / **`cargo build`** before **`mise run perf:record`**—that path is owned by the mise task. Runner summaries now log **`mbx --version`** and **`mbx cache dir`**.
> 
> **`docs.yml`** only re-labels the pinned **`deploy-pages`** action comment; the SHA is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79f1e6cb74b57a3353c120c49b76ca7e25c4c9ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->