### PR TITLE
ci: route mbx caching by runner provider

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -18,6 +18,25 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Mount the local mbx store on the Namespace cache volume
+      if: inputs.backend == 'local'
+      uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+      with:
+        path: ${{ runner.os == 'macOS' && '~/Library/Caches/mbx' || '~/.cache/mbx' }}
+    - name: Install mbx for local caching
+      if: inputs.backend == 'local'
+      shell: bash
+      env:
+        CACHE_LINKS: ${{ inputs.cache-links }}
+      run: |
+        mise install mr-boxington
+        echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
+        echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
+        if [[ "$CACHE_LINKS" == true || ( "$CACHE_LINKS" == auto && "$RUNNER_OS" == Linux ) ]]; then
+          echo "MBX_CACHE_LINKS=1" >> "$GITHUB_ENV"
+        elif [[ "$CACHE_LINKS" == false ]]; then
+          echo "MBX_CACHE_LINKS=0" >> "$GITHUB_ENV"
+        fi
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -18,6 +18,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up mise for the local mbx install
+      if: inputs.backend == 'local'
+      uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      with:
+        install: false
+        cache: false
     - name: Mount the local mbx store on the Namespace cache volume
       if: inputs.backend == 'local'
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
@@ -28,7 +34,8 @@ runs:
       shell: bash
       env:
         CACHE_LINKS: ${{ inputs.cache-links }}
-      run: | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
+      run:
+        | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,25 +1,18 @@
 name: Set up mbx
-description: Use the local Namespace volume or fork-safe GitHub cache backend
+description: Install mbx with a local Namespace, remote server, or ephemeral store
 
 inputs:
   backend:
-    description: Backend selected by the structurally trusted caller; local skips transport
+    description: Store selected by the structurally trusted caller
     default: github
-  mirror-github-cache:
-    description: Mirror a trusted main build into the restore-only cache used by fork PRs
-    default: "false"
   cache-links:
     description: Cache native links; "auto" enables this on Linux
     default: auto
-  toolchain:
-    description: Rust toolchain named explicitly by the build
-    required: false
 
 runs:
   using: composite
   steps:
-    - name: Set up mise for the local mbx install
-      if: inputs.backend == 'local'
+    - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       with:
         install: false
@@ -29,37 +22,25 @@ runs:
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
       with:
         path: ${{ runner.os == 'macOS' && '~/Library/Caches/mbx' || '~/.cache/mbx' }}
-    - name: Install mbx for local caching
-      if: inputs.backend == 'local'
+    - name: Install and configure mbx
       shell: bash
       env:
+        MBX_BACKEND: ${{ inputs.backend }}
         CACHE_LINKS: ${{ inputs.cache-links }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         mise reshim -f
-        echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
-        echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
-        if [[ "$CACHE_LINKS" == true || ( "$CACHE_LINKS" == auto && "$RUNNER_OS" == Linux ) ]]; then
-          echo "MBX_CACHE_LINKS=1" >> "$GITHUB_ENV"
-        elif [[ "$CACHE_LINKS" == false ]]; then
-          echo "MBX_CACHE_LINKS=0" >> "$GITHUB_ENV"
-        fi
-    - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
-      with:
-        backend: github
-        cache-generation: v2
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}
-    - if: inputs.backend != 'local'
-      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
-      with:
-        cache-generation: v2
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}
-        backend: ${{ inputs.backend }}
-        server-url: https://cache.mise.jdx.dev
-        namespace: jdx/pitchfork
-        oidc-audience: https://cache.mise.jdx.dev
+        mise where mr-boxington >> "$GITHUB_PATH"
+        {
+          if [[ "$MBX_BACKEND" == server ]]; then
+            echo "MBX_REMOTE_URL=https://cache.mise.jdx.dev"
+            echo "MBX_REMOTE_NAMESPACE=jdx/pitchfork"
+            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.mise.jdx.dev"
+          fi
+          if [[ "$CACHE_LINKS" == true || ( "$CACHE_LINKS" == auto && "$RUNNER_OS" == Linux ) ]]; then
+            echo "MBX_CACHE_LINKS=1"
+          elif [[ "$CACHE_LINKS" == false ]]; then
+            echo "MBX_CACHE_LINKS=0"
+          fi
+        } >> "$GITHUB_ENV"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -27,6 +27,8 @@ runs:
       with:
         install: false
         cache: false
+        env: false
+        add_shims_to_path: false
     - name: Mount the local mbx store on the Namespace cache volume
       if: inputs.backend == 'local'
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -37,6 +37,7 @@ runs:
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
+        mise reshim -f
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
         if [[ "$CACHE_LINKS" == true || ( "$CACHE_LINKS" == auto && "$RUNNER_OS" == Linux ) ]]; then

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -15,8 +15,8 @@ runs:
     - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       env:
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       with:
         install: false
         cache: false
@@ -30,8 +30,8 @@ runs:
       env:
         MBX_BACKEND: ${{ inputs.backend }}
         CACHE_LINKS: ${{ inputs.cache-links }}
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,10 +1,10 @@
 name: Set up mbx
-description: Install mbx with a local Namespace, remote server, or ephemeral store
+description: Install mbx with a local Namespace store or the GitHub Actions cache server
 
 inputs:
   backend:
-    description: Store selected by the structurally trusted caller
-    default: github
+    description: Use local on Namespace runners and server on GitHub-hosted runners
+    default: server
   cache-links:
     description: Cache native links; "auto" enables this on Linux
     default: auto
@@ -49,10 +49,12 @@ runs:
         mise reshim -f
         mise where mr-boxington >> "$GITHUB_PATH"
         {
-          if [[ "$MBX_BACKEND" == server ]]; then
-            echo "MBX_REMOTE_URL=https://cache.mise.jdx.dev"
+          if [[ "$MBX_BACKEND" == server && -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+            echo "MBX_REMOTE_URL=https://cache.jdx.dev"
             echo "MBX_REMOTE_NAMESPACE=jdx/pitchfork"
-            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.mise.jdx.dev"
+            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.jdx.dev"
+          elif [[ "$MBX_BACKEND" == server ]]; then
+            echo "::notice::GitHub OIDC is unavailable; using an ephemeral local mbx store"
           fi
           if [[ "$CACHE_LINKS" == true || ( "$CACHE_LINKS" == auto && "$RUNNER_OS" == Linux ) ]]; then
             echo "MBX_CACHE_LINKS=1"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -13,10 +13,17 @@ runs:
   using: composite
   steps:
     - name: Set up mise for the mbx install
+      if: runner.os != 'Windows'
+      uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      with:
+        install: false
+        cache: false
+    - name: Set up mise for the mbx install on Windows
+      if: runner.os == 'Windows'
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       env:
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ format('{0}/mise-data', runner.tool_cache) }}
+        MISE_CACHE_DIR: ${{ format('{0}/mise-cache', runner.tool_cache) }}
       with:
         install: false
         cache: false
@@ -30,10 +37,12 @@ runs:
       env:
         MBX_BACKEND: ${{ inputs.backend }}
         CACHE_LINKS: ${{ inputs.cache-links }}
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
+        if [[ "$RUNNER_OS" == Windows ]]; then
+          export MISE_DATA_DIR="$RUNNER_TOOL_CACHE/mise-data"
+          export MISE_CACHE_DIR="$RUNNER_TOOL_CACHE/mise-cache"
+        fi
         mise install mr-boxington
         mise reshim -f
         mise where mr-boxington >> "$GITHUB_PATH"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -28,7 +28,7 @@ runs:
       shell: bash
       env:
         CACHE_LINKS: ${{ inputs.cache-links }}
-      run: |
+      run: | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,6 +14,9 @@ runs:
   steps:
     - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      env:
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
       with:
         install: false
         cache: false
@@ -27,6 +30,8 @@ runs:
       env:
         MBX_BACKEND: ${{ inputs.backend }}
         CACHE_LINKS: ${{ inputs.cache-links }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -49,12 +49,14 @@ runs:
         mise reshim -f
         mise where mr-boxington >> "$GITHUB_PATH"
         {
-          if [[ "$MBX_BACKEND" == server && -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+          if [[ "$MBX_BACKEND" == server ]]; then
             echo "MBX_REMOTE_URL=https://cache.jdx.dev"
             echo "MBX_REMOTE_NAMESPACE=jdx/pitchfork"
-            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.jdx.dev"
-          elif [[ "$MBX_BACKEND" == server ]]; then
-            echo "::notice::GitHub OIDC is unavailable; using an ephemeral local mbx store"
+            if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+              echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.jdx.dev"
+            else
+              echo "::notice::GitHub OIDC is unavailable; using public read-only cache access" >&2
+            fi
           fi
           if [[ "$CACHE_LINKS" == true || ( "$CACHE_LINKS" == auto && "$RUNNER_OS" == Linux ) ]]; then
             echo "MBX_CACHE_LINKS=1"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,9 +1,9 @@
 name: Set up mbx
-description: Select the trusted jdx server or fork-safe GitHub cache backend
+description: Use the local Namespace volume or fork-safe GitHub cache backend
 
 inputs:
   backend:
-    description: Backend selected by the structurally trusted caller
+    description: Backend selected by the structurally trusted caller; local skips transport
     default: github
   mirror-github-cache:
     description: Mirror a trusted main build into the restore-only cache used by fork PRs
@@ -19,14 +19,15 @@ runs:
   using: composite
   steps:
     - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         backend: github
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
+    - if: inputs.backend != 'local'
+      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
     timeout-minutes: 20
     steps:
       - name: Assert OIDC is unavailable to untrusted CI
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         tranche: [0, 1]
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -36,7 +36,6 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'local' || 'github' }}
-          mirror-github-cache: "true"
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - run: mise run build:ui
@@ -103,7 +102,6 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: github
-          mirror-github-cache: "true"
       - name: Build UI assets
         working-directory: ui
         run: |

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -102,7 +102,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: github
           mirror-github-cache: "true"
       - name: Build UI assets
         working-directory: ui

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -20,11 +20,6 @@ jobs:
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
     timeout-minutes: 20
     steps:
-      - name: Assert OIDC is unavailable to untrusted CI
-        if: ${{ !inputs.trusted }}
-        run: |
-          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
-          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
@@ -35,7 +30,7 @@ jobs:
       - run: rm -rf .cargo
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - run: mise run build:ui
@@ -101,7 +96,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: server
       - name: Build UI assets
         working-directory: ui
         run: |

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -35,7 +35,7 @@ jobs:
       - run: rm -rf .cargo
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
           mirror-github-cache: "true"
       - name: Install Rust components
         run: rustup component add rustfmt clippy
@@ -102,7 +102,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
           mirror-github-cache: "true"
       - name: Build UI assets
         working-directory: ui

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -30,7 +30,7 @@ jobs:
       - run: rm -rf .cargo
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'server' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - run: mise run build:ui

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -30,7 +30,7 @@ jobs:
       - run: rm -rf .cargo
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - name: Install Rust components
         run: rustup component add rustfmt clippy
       - run: mise run build:ui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: true
@@ -22,6 +23,7 @@ jobs:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24

--- a/mise.lock
+++ b/mise.lock
@@ -45,7 +45,6 @@ provenance = "github-attestations"
 checksum = "sha256:5383e428dc7ab02853bb37ceec1a5d72894b6455471c8d02ce9d84ed82430ab6"
 url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525700617"
-provenance = "github-attestations"
 
 [[tools.cargo-binstall]]
 version = "1.22.0"

--- a/mise.lock
+++ b/mise.lock
@@ -214,44 +214,44 @@ url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-pc-windows-
 url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632118"
 
 [[tools.mr-boxington]]
-version = "1.4.1"
+version = "1.5.0"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:7ca1deeb64ad22bd5ddc9f45c749c78d3eb32608562c363727de3f0c595df0f0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505948"
+checksum = "sha256:3782db0c07a47334d01d426896e9f6af2480b311def2d0f0a3ab1327b57247b2"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628921"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:3113dfce87c8ee6d3485f7eb99f87ae130b9b9f2c73224720edf2cef7279b5d1"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505946"
+checksum = "sha256:95e189127cf22f6586b0e7337893896dfb18b2018c7226e60844955e237234b8"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628922"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:5bc7434333a941f664bbe73ae229edf6111c9fb5f771f959ca411a11358baf8a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505965"
+checksum = "sha256:83a5f4cb83a62cf028256c482a9f579911cc0793f79f1c2c06b83291c5c723d0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629161"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:7277ceabefae1b444b39200c2cb944018a87da628ff77aa94291a8cc338546e6"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505964"
+checksum = "sha256:8ffd1ffc4b53ce10ed1d0271e24d9d264e843b7be3f0a076389c4475a16e4132"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629170"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:57f1cac111d9972ad675aa80cbedf4c86b3423dfb11091383175db0f6341847e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505945"
+checksum = "sha256:d88ebea6ebf1a5b8b4a51a440a91baeb1214fdea49a6013dfe9b56e4bd4a6c84"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628925"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:346cb0405129bbca4f7a24fc916b036cfd806d497d52ba47fc8bb0a0531b4382"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505963"
+checksum = "sha256:970f974d3ee56b089c34a4b03fdb80dfcc0b260b3de950009a77240c9187a4c7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629146"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -95,7 +95,7 @@ run = [
 ]
 
 [tools]
-mr-boxington = "1.4.1"
+mr-boxington = "1.5.0"
 usage = "6.6.1"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change


### PR DESCRIPTION
Route mbx storage according to the runner provider.

- Namespace jobs keep the local backend on the shared Namespace cache volume.
- GitHub-hosted Linux, macOS, and Windows jobs use the Azure-backed cache at `https://cache.jdx.dev` with GitHub OIDC.
- GitHub-hosted fork jobs use public, namespace-scoped read access when GitHub withholds OIDC; they receive no cache credential and cannot write.
- Authenticated pull requests and tags are also read-only; only protected `main` pushes may publish.
- No mbx cache tarballs are mirrored through GitHub Actions Cache.

Validation: actionlint; git diff --check

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI cache authentication and write paths (OIDC vs read-only forks) and removes GitHub Cache mirroring, so build speed and cache poisoning/write access depend on the new routing behaving correctly.
> 
> **Overview**
> Reworks **mbx** setup in CI so cache storage follows the runner: **Namespace** jobs use a **local** store on a mounted cache volume, while **GitHub-hosted** jobs talk to **`https://cache.jdx.dev`** via the **server** backend (OIDC when available, otherwise a logged public read-only path).
> 
> The composite **`.github/actions/mbx`** action no longer wraps **`jdx/mr-boxington-action`** or mirrors tarballs through **GitHub Actions Cache**. It installs **`mr-boxington` 1.5.0** with **mise**, optionally mounts the Namespace cache path, and writes **`MBX_*`** env vars (remote URL/namespace, OIDC audience, cache links). Inputs drop **`mirror-github-cache`**, **`toolchain`**, and the old **`github`** backend default in favor of **`local`** / **`server`**.
> 
> **`ci-impl.yml`** flips trusted vs untrusted wiring (**`local`** on trusted Namespace, **`server`** on untrusted GitHub), adds **`overrides.cache-tag=cache`** on Namespace runners, removes the untrusted OIDC assertion step, and pins the test job to **`backend: server`**. **`mise.toml`** / lockfile bump **mr-boxington**; **`docs.yml`** only updates the **`deploy-pages`** action comment pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af31cedc935f3c4417e2de63121784aae475501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->