### PR TITLE
ci(release): publish a signed packslip with each release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -67,6 +67,10 @@ jobs:
       ${{ always() && (inputs.tag != '' || needs.release-plz-release.outputs.tag != '') }}
     permissions:
       contents: write
+      # A called workflow's token can only be narrower than its caller's, so
+      # the packslip's signing and attestation permissions are granted here.
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ inputs.tag != '' && inputs.tag || needs.release-plz-release.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,3 +186,51 @@ jobs:
           ref: refs/tags/${{ inputs.tag }}
           token: ${{ secrets.GITHUB_TOKEN }}
           profile: serious
+
+  # The packslip is this release's signed inventory: every archive's digest,
+  # the executable inside it, the shared objects it needs from the host, and
+  # the workflow identity that signed for all of it. An installer checks a
+  # download against jdx/pitchfork's identity rather than against a key this
+  # project would have to hold. See https://packslip.dev.
+  #
+  # Its own job because the matrix above uploads straight to the release from
+  # seven runners; one document covering the whole release can only be written
+  # once every one of them has landed.
+  packslip:
+    name: Publish the packslip
+    needs: upload-assets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download the release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          mkdir -p dist
+          gh release download "$TAG" --repo "$REPO" --dir dist --clobber \
+            --pattern 'pitchfork-*.tar.gz' --pattern 'pitchfork-*.zip'
+          ls -la dist
+      # A consumer that has this file can generate completions, a man page,
+      # and documentation with its own copy of usage, so nothing of
+      # pitchfork's runs on the machine it is installed on.
+      - name: Publish the CLI specification
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          mkdir -p bin
+          tar -xzf dist/pitchfork-x86_64-unknown-linux-gnu.tar.gz -C bin
+          bin/pitchfork usage > pitchfork.usage.kdl
+          gh release upload "$TAG" pitchfork.usage.kdl --repo "$REPO" --clobber
+      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+        with:
+          tag: ${{ inputs.tag }}
+          artifacts: dist/pitchfork-*.tar.gz dist/pitchfork-*.zip
+          bin: pitchfork
+          resources: cli-spec/usage=asset:pitchfork.usage.kdl


### PR DESCRIPTION
Part of adopting [packslip](https://packslip.dev) across the jdx.dev CLIs.

Each release now publishes `packslip.sigstore.json` beside the archives — one signed document listing:

- every archive's sha256 and sha512
- the executable inside each one (`pitchfork`, `pitchfork.exe` on Windows)
- the shared objects each build needs from the host, read out of the binaries
- a build-provenance attestation per file, linked by digest
- the source repo, tag, and commit

signed keylessly with this workflow's OIDC identity, so an installer verifies a download against the identity `github.com/jdx/pitchfork` instead of a signing key this project would have to hold and rotate.

`pitchfork usage` is run against the freshly built Linux binary and uploaded as `pitchfork.usage.kdl`, listed as a `cli-spec` resource. A consumer generates completions, a man page, and docs from it with its own copy of usage — nothing of pitchfork's runs on the installing machine.

### Changes

- A new `packslip` job in `release.yml`, needing `upload-assets`. It needs to be its own job: the matrix uploads straight to the release from each runner, so no step there sees the whole release, and one document covering all of it can only be written once every target has landed. It downloads the release's own archives back, generates the CLI spec, and writes the bundle.
- `release-plz.yml` grants `upload-assets` `id-token: write` and `attestations: write`. A called workflow's token can only be equal to or narrower than its caller's, so without this the new job cannot sign or attest.

It runs while the release is still a draft, so the bundle is in place before `publish-release` undrafts it.

### Verification

Ran `pitchfork usage` against the released v2.24.0 linux-gnu binary — 1418 lines of spec, exit 0. Rehearsed `packslip create` locally against real release assets of this shape. `zizmor --offline` reports no findings on either changed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release pipeline timing and adds OIDC signing/attestation permissions; failures in the new job block publishing, but no application runtime code is touched.
> 
> **Overview**
> Each GitHub release now gets a **keyless signed [packslip](https://packslip.dev)** (`packslip.sigstore.json`) plus **`pitchfork.usage.kdl`**, generated after all platform archives are on the release.
> 
> A new **`packslip` job** in `release.yml` runs after the matrix `upload-assets` job finishes: it re-downloads the `pitchfork-*.tar.gz` / `*.zip` assets, runs `pitchfork usage` from the Linux GNU build and uploads the KDL spec, then invokes **`jdx/packslip@v0.3.0`** to attest and sign digests, binaries, host shared libraries, and the CLI spec resource. Because the release-plz **`upload-assets`** job calls this workflow, **`publish-release` implicitly waits** on packslip too while the release is still a draft.
> 
> **`release-plz.yml`** grants the callable workflow **`id-token: write`** and **`attestations: write`** on `upload-assets`, so the nested job can sign and attest via OIDC (permissions cannot exceed the caller’s).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d9c4f721ff043cc298e410df4f9434d24ae9b77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release packages now include a generated CLI usage specification for improved tooling and command discovery.
  - Published releases now include a signed inventory of their artifacts, helping users verify release contents and provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->