### PR TITLE
fix(supervisor): prevent nested pitchfork call from starting a second supervisor

### DIFF
--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -68,17 +68,29 @@ impl IpcServerHandle {
 }
 
 impl IpcServer {
-    pub fn new() -> Result<(Self, IpcServerHandle)> {
-        // Unix: create the socket directory and remove any stale socket file.
-        // Windows: named pipes exist in a flat kernel namespace — no files to create or clean up.
+    pub async fn new() -> Result<(Self, IpcServerHandle)> {
+        // Unix: bind to a per-process claim path first, then hard-link it onto
+        // the canonical socket path (see `publish_claim`) — that link is the
+        // atomic ownership claim. Windows: named pipes exist in a flat kernel
+        // namespace — no files to create or clean up.
+        #[cfg(unix)]
+        // No dots: `fs_name` passes the name through `with_extension`, which
+        // would replace anything after a dot instead of appending the suffix.
+        let bind_name = format!("main-claim-{}", std::process::id());
+        #[cfg(windows)]
+        let bind_name = "main".to_string();
+        #[cfg(unix)]
+        let claim_path = env::IPC_SOCK_DIR.join(format!("{bind_name}.sock"));
+
         #[cfg(unix)]
         {
             xx::file::mkdirp(&*env::IPC_SOCK_DIR)?;
-            let _ = xx::file::remove_file(&*env::IPC_SOCK_MAIN);
+            // Only a crashed predecessor with this exact pid can have left a
+            // claim file behind; clear it so the bind below succeeds.
+            let _ = xx::file::remove_file(&claim_path);
         }
-        let opts = ListenerOptions::new().name(fs_name("main")?);
-        #[cfg(unix)]
-        debug!("Listening on {}", env::IPC_SOCK_MAIN.display());
+
+        let opts = ListenerOptions::new().name(fs_name(&bind_name)?);
         #[cfg(windows)]
         debug!("Listening on named pipe");
         let (tx, rx) = tokio::sync::mpsc::channel(1);
@@ -100,6 +112,15 @@ impl IpcServer {
         }
 
         let listener = listener_result.into_diagnostic()?;
+
+        // Publish the bound claim socket onto the canonical path. Failing here
+        // (a live supervisor owns the path) aborts startup before the caller
+        // records anything in the state file.
+        #[cfg(unix)]
+        {
+            Self::publish_claim(&claim_path).await?;
+            debug!("Listening on {}", env::IPC_SOCK_MAIN.display());
+        }
 
         // When the supervisor is started as root, the socket file and directory
         // are owned by root with restrictive permissions (0600/0700). Non-root CLI
@@ -314,6 +335,134 @@ impl IpcServer {
         tx
     }
 
+    /// Hard-link the freshly bound claim socket onto the canonical IPC socket
+    /// path, atomically claiming supervisor ownership.
+    ///
+    /// `link(2)` fails with `EEXIST` when any file already owns the path,
+    /// which is the mutual exclusion against a concurrent fresh claim. A live
+    /// incumbent is detected through that failure plus a connection probe —
+    /// a socket on the canonical path always belongs to a listening process,
+    /// because the link only happens after bind + listen — and startup
+    /// refuses to take over. Only a refused connection proves an incumbent
+    /// dead, and the stale-file replacement (probe → remove → link retry)
+    /// runs under an inter-process lock: the probe/remove pair is not atomic,
+    /// so without serialization a contender suspended between its own probe
+    /// and its removal could unlink a live socket another contender published
+    /// in between.
+    ///
+    /// The protocol runs on the blocking pool via `spawn_blocking`: the
+    /// inter-process lock blocks until the holder releases, which must never
+    /// stall a Tokio worker thread.
+    #[cfg(unix)]
+    async fn publish_claim(claim_path: &std::path::Path) -> Result<()> {
+        let claim_path = claim_path.to_owned();
+        let main_sock = env::IPC_SOCK_MAIN.to_path_buf();
+        tokio::task::spawn_blocking(move || Self::publish_claim_blocking(claim_path, main_sock))
+            .await
+            .into_diagnostic()?
+    }
+
+    #[cfg(unix)]
+    fn publish_claim_blocking(
+        claim_path: std::path::PathBuf,
+        main_sock: std::path::PathBuf,
+    ) -> Result<()> {
+        fn discard_claim(claim_path: &std::path::Path) {
+            let _ = xx::file::remove_file(claim_path);
+        }
+
+        enum Owner {
+            Live,
+            Dead,
+            Unknown(std::io::Error),
+        }
+
+        fn probe_owner(main_sock: &std::path::Path) -> Owner {
+            match std::os::unix::net::UnixStream::connect(main_sock) {
+                Ok(_) => Owner::Live,
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound
+                    ) =>
+                {
+                    Owner::Dead
+                }
+                Err(e) => Owner::Unknown(e),
+            }
+        }
+
+        // Fast path: the canonical path is free, and link(2) claims it
+        // atomically against every contender.
+        match std::fs::hard_link(&claim_path, &main_sock) {
+            Ok(()) => {
+                discard_claim(&claim_path);
+                return Ok(());
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(e) => {
+                discard_claim(&claim_path);
+                return Err(e).into_diagnostic();
+            }
+        }
+
+        // The path is owned. Serialize the replacement protocol across
+        // contenders (same flock scheme as the state file). The lock is held
+        // for a few syscalls only.
+        let _claim_lock =
+            xx::fslock::get(&main_sock, false)?.expect("fslock::get returns a lock unless forced");
+
+        for _ in 0..3 {
+            match probe_owner(&main_sock) {
+                // Never silently take over a socket owned by a live
+                // supervisor: unlinking the file would strand the running
+                // instance while we steal new clients (split brain).
+                Owner::Live => {
+                    discard_claim(&claim_path);
+                    bail!(
+                        "another pitchfork supervisor is listening on {}; refusing to take over \
+                         (use `pitchfork supervisor stop` first, or `--force` to replace it)",
+                        main_sock.display()
+                    );
+                }
+                // e.g. permission denied: the owner cannot be proven dead, so
+                // leave the file alone and fail startup.
+                Owner::Unknown(e) => {
+                    discard_claim(&claim_path);
+                    bail!(
+                        "cannot probe existing IPC socket {}: {e}",
+                        main_sock.display()
+                    );
+                }
+                Owner::Dead => {
+                    // Refused connection (or no file at all) proves the path
+                    // stale; replace it.
+                    debug!("removing stale IPC socket file {}", main_sock.display());
+                    let _ = xx::file::remove_file(&main_sock);
+                    match std::fs::hard_link(&claim_path, &main_sock) {
+                        Ok(()) => {
+                            discard_claim(&claim_path);
+                            return Ok(());
+                        }
+                        // A lock-free fresh claimer won the freed path in
+                        // between; the next iteration's probe decides
+                        // whether it is live.
+                        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+                        Err(e) => {
+                            discard_claim(&claim_path);
+                            return Err(e).into_diagnostic();
+                        }
+                    }
+                }
+            }
+        }
+        discard_claim(&claim_path);
+        bail!(
+            "failed to claim IPC socket path {} after repeated attempts",
+            main_sock.display()
+        );
+    }
+
     pub async fn read(&mut self) -> Result<(IpcRequest, Sender<IpcResponse>)> {
         self.rx
             .recv()
@@ -323,6 +472,9 @@ impl IpcServer {
 
     pub fn close(&self) {
         debug!("Closing IPC server");
+        // Synchronous by necessity: this runs from `Drop` and signal-handler
+        // contexts, which cannot await. The graceful shutdown path removes
+        // the socket inside the accept task instead.
         #[cfg(unix)]
         let _ = std::fs::remove_file(&*env::IPC_SOCK_MAIN);
     }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -368,6 +368,19 @@ impl Supervisor {
         // reading it too late.
         let unclean = supervisor_exited_uncleanly(self).await;
 
+        // Claim the IPC socket and start accepting requests before anything
+        // else can observe or mutate shared state. The socket claim is the
+        // single ownership proof for the supervisor role: a competing
+        // `supervisor run` loses the claim here and bails out before it ever
+        // upserts its own PID below, so a contender can no longer overwrite
+        // the live supervisor's persisted record on its way down.
+        let (ipc, ipc_handle) = IpcServer::new().await?;
+        *self.ipc_shutdown.lock().await = Some(ipc_handle);
+        // The request loop runs in the background so the rest of startup
+        // (watchers, web/proxy servers, boot daemons) can proceed; the main
+        // task parks at the end of this function instead.
+        tokio::spawn(async move { SUPERVISOR.conn_watch(ipc).await });
+
         self.upsert_daemon(
             UpsertDaemonOpts::builder(DaemonId::pitchfork())
                 .set(|o| {
@@ -379,6 +392,15 @@ impl Supervisor {
         .await?;
         #[cfg(unix)]
         fix_state_dir_permissions();
+
+        // Publish our record to disk only after the socket claim succeeded,
+        // and *before* any boot daemons can start below. A boot daemon whose
+        // command invokes pitchfork again (e.g. `pitchfork start`) detects an
+        // existing supervisor by reading the state file and connecting to the
+        // socket bound above; having both in place up front guarantees the
+        // nested call attaches to us instead of spawning a second supervisor
+        // (split brain).
+        self.flush_state().await;
 
         // Self-heal: if the boot registration points to a stale binary path
         // (e.g. after a brew/mise upgrade), re-register with the current path.
@@ -565,10 +587,10 @@ impl Supervisor {
             crate::proxy::server::get_cached_slugs().await;
         });
 
-        let (ipc, ipc_handle) = IpcServer::new()?;
-        *self.ipc_shutdown.lock().await = Some(ipc_handle);
         self.start_state_flush_task();
-        self.conn_watch(ipc).await
+        // Startup is complete: park forever. Shutdown is driven entirely by
+        // the signal handlers spawned above, which run close() and exit().
+        std::future::pending::<Result<()>>().await
     }
 
     /// Start mDNS publishing for LAN mode (called after the proxy binds successfully).


### PR DESCRIPTION
## Problem

From discussion #812: a boot daemon whose command invokes pitchfork again could spawn a second supervisor while the first was still booting.

Two gaps combined:

1. **Detection gap** — In `Supervisor::start`, the IPC socket was bound last in the startup sequence, after boot daemons were already spawned as background tasks, and daemon records were only persisted by the 1s debounce task. A nested `pitchfork start` saw no state record and no bound socket, concluded no supervisor existed, and spawned one.
2. **Takeover gap** — `IpcServer::new` unconditionally `remove_file`'d the socket file before binding, silently stealing IPC from a live supervisor. Two supervisors then shared one state file and overwrote each other.

## Fixes

**A. Ownership before visibility (`src/supervisor/mod.rs`)**

`Supervisor::start` now claims the IPC socket and publishes the supervisor record (upsert + synchronous `flush_state`) *before* spawning boot daemons or cleanup tasks, so any nested call attaches to the booting supervisor instead of spawning one. The IPC accept loop runs in a background task so startup ordering is unaffected.

**B. Atomic socket claim (`src/ipc/server.rs`)**

- The listener binds a per-process claim path (`main-claim-<pid>.sock`) and is **hard-linked** onto `main.sock`; `link(2)` fails with `EEXIST` when any file already owns the path, which mutually excludes two supervisors starting at once.
- A live incumbent is detected through that failure plus an async connection probe, and startup refuses to take over — a live socket is never unlinked.
- Only a refused connection proves an incumbent dead. The **probe → stale-removal → link retry** runs under an **inter-process flock** (the same `xx::fslock` scheme the state file uses): the probe/remove pair is not atomic on its own, so without serialization a contender suspended between its probe and its removal could unlink a live socket another contender published in between. The probe is redone under the lock, so a contender queued behind the winner re-verifies liveness and never executes its pending removal.
- The claim happens before the supervisor PID is upserted, so a contender that loses bails out before writing anything to the shared state file.

## Verification (real binaries, isolated `PITCHFORK_STATE_DIR`)

| Scenario | Result |
|---|---|
| Discussion repro: boot daemon running `pitchfork start web` | exactly 1 supervisor; nested call attaches via IPC |
| Contender `supervisor run` next to a live supervisor | exits via existing-supervisor path; state.toml byte-identical; socket intact |
| Live socket owner with empty state (split-brain simulation) | bails exit 1, "refusing to take over"; **state file never created**; socket intact; zero claim leftovers |
| Stale socket file (bound-then-released) | recognized stale, removed, claimed; supervisor stop works |
| Two simultaneous `supervisor run` on a stale socket (10 rounds) | exactly 1 winner + 1 refusing loser + 0 leftover claim files every round |
| External process holding the claim flock | contender blocks without publishing; claims and serves IPC after release |
| `supervisor start --force` | kills the old supervisor, replaces it, exactly 1 after |
| `cargo nextest` | 831/831 |

Fixes: https://github.com/jdx/pitchfork/discussions/812

*AI-assisted — Tool: OpenCode; model: zhipuai/GLM-5.3-astra; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an active supervisor from being replaced when its IPC socket is already in use.
  * Improved handling of stale, unavailable, and inaccessible IPC socket files during startup.
  * Ensured the supervisor claims its IPC endpoint and begins handling requests before recording its process or launching boot services.
  * Improved startup behavior for nested invocations by making supervisor readiness available earlier.
  * Kept IPC monitoring responsive during startup while supporting signal-driven shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->