### PR TITLE
ci: enforce conventional commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,27 @@
+name: conventional-commits
+
+on: # zizmor: ignore[dangerous-triggers] reads only the PR title and executes no untrusted code
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(chore|ci|docs|feat|fix|perf|refactor|revert|security|style|test)(\([[:alnum:]][[:alnum:]./_-]*\))?!?: [[:lower:]](.*[[:graph:]])?$'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "::error title=Invalid pull request title::The title does not match the required format."
+            printf 'Received title: %q\n' "$PR_TITLE"
+            echo "Use: <type>[optional scope][optional !]: <description starting lowercase>"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,8 @@ Configs merge in order (later overrides earlier):
 
 ## Conventional Commits
 
-All commit messages and PR titles MUST follow conventional commit format:
+PR titles MUST follow conventional commit format. Intermediate commit subjects
+SHOULD use the same format:
 
 **Format:** `<type>(<scope>): <description>`
 
@@ -137,13 +138,15 @@ All commit messages and PR titles MUST follow conventional commit format:
 - `test:` - Testing changes
 - `chore:` - Maintenance tasks, releases, dependency updates, CI/infrastructure changes
 - `security:` - Security-related changes
+- `ci:` - CI and automation changes
+- `revert:` - Reverting a previous change
 
 **Scopes:**
 - For command-specific changes, use the command name: `start`, `stop`, `status`, `logs`, `run`, etc.
 - For subsystem changes: `supervisor`, `ipc`, `config`, `state`, `daemon`, `cron`, `deps`
 
 **Description Style:**
-- Use lowercase after the colon
+- Start the description with a lowercase character
 - Use imperative mood ("add feature" not "added feature")
 - Keep it concise but descriptive
 
@@ -155,6 +158,11 @@ All commit messages and PR titles MUST follow conventional commit format:
 - `chore: release 0.2.0`
 - `chore(ci): fix linting in CI pipeline`
 - `chore(deps): update dependencies`
+
+CI validates the pull request title and re-runs when it is edited. Intermediate
+commit subjects are not checked because pull requests are squash-merged. CI
+mechanically checks the allowed type, syntax, and lowercase-leading description;
+imperative mood remains a review rule.
 
 ## GitHub Interactions
 


### PR DESCRIPTION
## Summary

- document or connect the repository’s Conventional Commits policy for pull request titles
- validate the title on creation and every edit with the repository’s allowed types
- use a permissionless `pull_request_target` workflow with no checkout, so pull request code cannot bypass the check
- intentionally ignore intermediate commit subjects because pull requests are squash-merged using their titles

## Testing

- `actionlint .github/workflows/conventional-commits.yml`
- exercised valid, breaking-change, invalid-type, uppercase-description, and trailing-space title cases locally

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Automation and documentation only; no application runtime or data-path changes, with a minimal-permission workflow design.
> 
> **Overview**
> Adds a **GitHub Actions check** that rejects pull request titles unless they match the repo’s Conventional Commits pattern (allowed types including `ci` and `revert`, optional scope and `!`, description starting with a lowercase letter). The job runs on `pull_request_target` with **empty permissions** and **no checkout**, reading only `github.event.pull_request.title`, and re-runs when the PR is opened, edited, reopened, or synchronized.
> 
> **Contributor docs** in `AGENTS.md` are updated to require PR titles (intermediate commit subjects recommended only), document the new `ci`/`revert` types, and note that CI enforces syntax mechanically while imperative mood stays a human review rule—aligned with squash-merge using the PR title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54ebf96d544616ff3cc9afc787034495228f5049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull request title validation using Conventional Commits formatting.
  * Validation runs when pull requests are opened, edited, reopened, or updated.
  * Invalid titles receive guidance on the required format and lowercase descriptions.

* **Documentation**
  * Updated contributor guidance to clarify title requirements, supported types, validation behavior, and commit subject recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->