### PR TITLE
chore(release): bump packslip action to v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
           tar -xzf dist/pitchfork-x86_64-unknown-linux-gnu.tar.gz -C bin
           bin/pitchfork usage > pitchfork.usage.kdl
           gh release upload "$TAG" pitchfork.usage.kdl --repo "$REPO" --clobber
-      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
         with:
           tag: ${{ inputs.tag }}
           artifacts: dist/pitchfork-*.tar.gz dist/pitchfork-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
           tar -xzf dist/pitchfork-x86_64-unknown-linux-gnu.tar.gz -C bin
           bin/pitchfork usage > pitchfork.usage.kdl
           gh release upload "$TAG" pitchfork.usage.kdl --repo "$REPO" --clobber
-      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
+      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
         with:
           tag: ${{ inputs.tag }}
           artifacts: dist/pitchfork-*.tar.gz dist/pitchfork-*.zip


### PR DESCRIPTION
## Summary
- Bumps the pinned `jdx/packslip` action from v0.3.0 to v1.0.0.
- v1.0.0 declares the manifest format stable, fixes the `packslip.dev/releases/v1` predicate URL that previously 404d, and requires every artifact to declare a format (already satisfied here — every artifact is an archive, which infers its format from the file name).

## Test plan
- [ ] Next tagged release runs the packslip step successfully and uploads `packslip.sigstore.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency bump on the post-release packslip step; no application or auth logic changes, with main risk being a failed release if the new action behaves differently.
> 
> **Overview**
> Updates the release workflow’s **packslip** job to pin `jdx/packslip` from **v0.3.0** to **v1.0.1** (new commit SHA). Inputs (`tag`, `artifacts`, `bin`, `resources`) are unchanged.
> 
> This moves release packaging/signing to the newer packslip major line (stable manifest format, fixed predicate URL, stricter artifact format rules that this workflow already satisfies via archive filenames).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578a79e27767628c686f3655774240dd21695c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow’s packaging automation action from version 1.0.0 to 1.0.1, supporting more reliable release generation without changing the product’s user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: unavailable.*
