### PR TITLE
ci(release): bump packslip to v1.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
           tar -xzf dist/pitchfork-x86_64-unknown-linux-gnu.tar.gz -C bin
           bin/pitchfork usage > pitchfork.usage.kdl
           gh release upload "$TAG" pitchfork.usage.kdl --repo "$REPO" --clobber
-      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
+      - uses: jdx/packslip@5c1cced7cfa661140dbc972a0de55b2b6bd81522 # v1.0.2
         with:
           tag: ${{ inputs.tag }}
           artifacts: dist/pitchfork-*.tar.gz dist/pitchfork-*.zip


### PR DESCRIPTION
v1.0.1 uploaded the packslip with `gh release upload "$TAG" "$BUNDLE" --clobber` and no `--repo`, so `gh` fell back to asking git which repository it was in. The job that runs it only downloads artifacts and has no checkout, so the upload failed with

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

after the packslip had already been created and verified.
The packslip job here has not run on a tag yet, so the next release would be the first to hit it. jdx/mr-boxington and jdx/tak hit exactly this today.


v1.0.2 carries jdx/packslip#71, which passes `--repo`. Pinned to the release commit `5c1cced`, which is what the `v1.0.2` tag points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin in the release workflow; no application or runtime behavior changes.
> 
> **Overview**
> **Bumps the release workflow’s `jdx/packslip` action from v1.0.1 to v1.0.2** (pinned to commit `5c1cced`).
> 
> v1.0.1 could fail on the `packslip` job because it uploaded the bundle with `gh release upload` without `--repo`, so `gh` tried to infer the repository from git even though that job only downloads release assets and never checks out the repo. v1.0.2 includes the fix that passes `--repo`, so packslip publication should succeed on tag releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c263603d36348b19eb7c27298166b8aaa7cd789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release packaging process to use a newer, more current version of its packaging tooling.
  * No changes were made to the application’s features, user experience, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->