### PR TITLE
ci(release): stop routing release-plz's cargo through mbx

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -51,6 +51,15 @@ jobs:
       - name: Authenticate to crates.io
         id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+      # release-plz shells out to `cargo package` inside temp checkouts of the
+      # commits it diffs against the published crate. On PATH `cargo` is mise's
+      # command wrapper, which mise.toml routes to mbx — and in those checkouts
+      # it resolves the mbx version *that commit* pinned, which was never
+      # installed on this runner, so cargo dies with "mbx" couldn't exec
+      # process. Put the real cargo ahead of the wrapper. Steps that go through
+      # `mise run` keep using mbx: mise prepends its own wrapper dir there.
+      - name: Put the real cargo ahead of the mbx wrapper
+        run: dirname "$(mise which cargo)" >> "$GITHUB_PATH"
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
@@ -173,6 +182,11 @@ jobs:
       # intermediate PR revision before its CI run reaches the render check.
       - name: Warm render dependencies
         run: mise run build
+      # Same reason as the release job above: the mise `cargo` wrapper can't
+      # resolve the mbx version pinned by the checkouts release-plz diffs
+      # against. This is the job that was failing on it.
+      - name: Put the real cargo ahead of the mbx wrapper
+        run: dirname "$(mise which cargo)" >> "$GITHUB_PATH"
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131


### PR DESCRIPTION
The **Release PR** job has failed on every push to `main` since the mise `cargo` wrapper landed in ac55e03 — [run 33978949922](https://github.com/jdx/pitchfork/actions/runs/33978949922/job/101340546998) is the latest:

```
failed to check package equality for `pitchfork-cli` at commit 5aaf3e9
  cannot determine packaged files of local package "/tmp/.tmpIi6md6/pitchfork/"
  error while running `cargo package`: mise ERROR "mbx" couldn't exec process: No such file or directory
```

## Why

To decide the next version, release-plz checks the last commit that touched the crate out into a temp dir and runs `cargo package --list` there. On `PATH` that `cargo` is mise's command wrapper, which `mise.toml` routes to `mbx`:

```toml
[wrappers.cargo]
command = "mbx"
```

In the temp checkout mise reads *that commit's* `mise.toml`, so it goes looking for the `mr-boxington` version pinned back then — which the runner never installed, because it installed the version pinned at HEAD. `MBX_DISABLE: "1"` doesn't help; mbx never gets far enough to read it.

That predicts exactly the observed pattern — it fails whenever the two pins disagree:

| run | HEAD pin | compare commit pin | result |
|---|---|---|---|
| 33978949922 | 1.8.1 | 5aaf3e9 → 1.5.0 | ❌ |
| 33710307943 | 1.5.0 | e0c1d82 → 1.4.1 | ❌ |
| 33658326235 | 1.4.1 | 6030746 → 1.3.2 | ❌ |
| [33620528951](https://github.com/jdx/pitchfork/actions/runs/33620528951) | 1.3.2 | no bump in between | ✅ |

The single green run in that window ran the same `cargo package` comparison and passed — its HEAD pin was still the one the runner had installed. Every mbx bump since has re-broken it.

## Fix

Put the real cargo ahead of the wrapper on `PATH` for the two jobs that hand cargo to release-plz. Steps that go through `mise run` are untouched and still build via mbx, since mise prepends its own wrapper dir there — so the build cache keeps working where it actually helps. Routing release-plz's `cargo package --list` through mbx bought nothing anyway; it only lists files.

## Also affected

[jdx/aube](https://github.com/jdx/aube) fails identically ([run 33976635522](https://github.com/jdx/aube/actions/runs/33976635522)) — same wrapper, and its `release-plz PR` job runs `release-plz update` after `mise-action`. `jdx/mise`, `jdx/hk` and `jdx/fnox` all have the same `[wrappers.cargo]` block but are not exposed: their `release-plz` tasks are hand-rolled git-cliff scripts that never invoke the release-plz binary, so nothing runs `cargo package` inside an old checkout.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release automation reliability by ensuring packaging workflows use the installed Cargo executable.
  - Prevented release jobs from failing when temporary checkouts reference unavailable pinned tool versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->