### PR TITLE
chore: release v2.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.2](https://github.com/jdx/pitchfork/compare/v2.24.1...v2.24.2) - 2026-09-05
+
+### Other
+
+- publish a patch release with the current packaged contents
+
 ## [2.24.1](https://github.com/jdx/pitchfork/compare/v2.24.0...v2.24.1) - 2026-09-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,7 +2759,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitchfork-cli"
-version = "2.24.1"
+version = "2.24.2"
 dependencies = [
  "async-stream",
  "auto-launcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pitchfork-cli"
 description = "Daemons with DX"
 license = "MIT"
-version = "2.24.1"
+version = "2.24.2"
 edition = "2024"
 resolver = "3"
 rust-version = "1.91"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -7116,7 +7116,7 @@
       }
     ]
   },
-  "version": "2.24.1",
+  "version": "2.24.2",
   "usage": "",
   "complete": {
     "id": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `pitchfork <SUBCOMMAND>`
 
-**Version:** 2.24.1
+**Version:** 2.24.2
 
 - **Usage:** `pitchfork <SUBCOMMAND>`
 

--- a/pitchfork.usage.kdl
+++ b/pitchfork.usage.kdl
@@ -1,7 +1,7 @@
 // @generated from usage-rs metadata
 name pitchfork
 bin pitchfork
-version "2.24.1"
+version "2.24.2"
 about "Daemons with DX"
 unknown_flags error
 external_subcommand #true


### PR DESCRIPTION
Explicitly bump pitchfork-cli from 2.24.1 to 2.24.2 so release-plz publishes the requested patch version when this PR merges. The empty `fix: trigger patch release` commit left the manifest at the already-published version and produced no release.

Update Cargo.toml, the package entry in Cargo.lock, the changelog, and regenerated CLI documentation. This releases current main; no application code or dependency versions change.

Validation:
- Build, docs build, and render completed; the built CLI reports `pitchfork 2.24.2`.
- Ran required `mise run ci-dev`; it stopped on Rust test failures. Excluded an unrelated source edit made by lint-fix.
- Full Rust rerun with a canonical TMPDIR: 831/833 passed. `identity_checked_group_kill_reverifies_inside_blocking_op` failed in both library and binary suites on macOS.
- Shell suite: 309/315 passed; failures cover daemon working directories, circular dependencies, log tailing (missing `timeout`), and recycled-PID handling.
- `git diff --check` passed.

The existing 2.25.0 release PR #827 is unchanged; merge this PR to request 2.24.2.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata-only version and documentation sync with no application logic or dependency updates.
> 
> **Overview**
> Bumps **`pitchfork-cli`** from **2.24.1** to **2.24.2** so release automation can publish a new patch tag; the prior empty release attempt left the manifest at an already-shipped version.
> 
> Adds a **2.24.2** changelog entry (patch release of current packaged contents) and aligns the version string in **`Cargo.toml`**, **`Cargo.lock`**, **`pitchfork.usage.kdl`**, and generated CLI docs (`docs/cli/index.md`, `docs/cli/commands.json`). **No runtime or dependency changes** beyond the crate version field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5552499582278c602b2e37c62f7f230ec8347b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->