### PR TITLE
chore(release): publish native completions in packslip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,11 @@ jobs:
       # A consumer that has this file can generate completions, a man page,
       # and documentation with its own copy of usage, so nothing of
       # pitchfork's runs on the machine it is installed on.
-      - name: Publish the CLI specification
+      - name: Install completion syntax checkers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh fish
+      - name: Publish the CLI specification and completions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}
@@ -227,10 +231,23 @@ jobs:
           mkdir -p bin
           tar -xzf dist/pitchfork-x86_64-unknown-linux-gnu.tar.gz -C bin
           bin/pitchfork usage > pitchfork.usage.kdl
-          gh release upload "$TAG" pitchfork.usage.kdl --repo "$REPO" --clobber
+          for shell in bash zsh fish; do
+            bin/pitchfork completion "$shell" > pitchfork.$shell
+            test -s pitchfork.$shell
+            grep -Fq '__complete_word__' pitchfork.$shell
+            bin/pitchfork __complete_word__ --shell "$shell" --line 'pitchfork st' | grep -Fq -- 'status'
+          done
+          bash -n pitchfork.bash
+          zsh -n pitchfork.zsh
+          fish --no-execute pitchfork.fish
+          gh release upload "$TAG" pitchfork.usage.kdl pitchfork.bash pitchfork.zsh pitchfork.fish --repo "$REPO" --clobber
       - uses: jdx/packslip@a0d434ad57571c62dbd0ab5095b4eff607a71fd3 # v1.1.1
         with:
           tag: ${{ inputs.tag }}
           artifacts: dist/pitchfork-*.tar.gz dist/pitchfork-*.zip
           bin: pitchfork
-          resources: cli-spec/usage=asset:pitchfork.usage.kdl
+          resources: |
+            cli-spec/usage=asset:pitchfork.usage.kdl
+            completion/bash=asset:pitchfork.bash
+            completion/zsh=asset:pitchfork.zsh
+            completion/fish=asset:pitchfork.fish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,13 +215,16 @@ jobs:
           gh release download "$TAG" --repo "$REPO" --dir dist --clobber \
             --pattern 'pitchfork-*.tar.gz' --pattern 'pitchfork-*.zip'
           ls -la dist
-      # A consumer that has this file can generate completions, a man page,
-      # and documentation with its own copy of usage, so nothing of
-      # pitchfork's runs on the machine it is installed on.
+      # The spec supports documentation generation without running the binary.
+      # Native completion scripts call the installed binary on each completion.
       - name: Install completion syntax checkers
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y zsh fish
+          if [[ -f /etc/apt/apt-mirrors.txt ]]; then
+            sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt
+          fi
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 install -y zsh fish
       - name: Publish the CLI specification and completions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Publish native Bash, Zsh, and Fish completion scripts alongside Pitchfork's usage specification and declare them as signed Packslip resources. The scripts call Pitchfork itself, so an installer can register completions without another usage executable.

Release publishing checks every script with its native shell parser and exercises the callback for each supported shell. `mise run ci-dev` passes: 831 Rust tests, the 315-case Bats suite (with its normal platform/slow-test skips), lint, UI/docs builds, and generated references. Workflow lint and native script/callback checks pass.

Local test note: after all Bats assertions completed, three test supervisors retained the suite's output pipe. Stopping those test processes let the unchanged suite and CI task exit successfully.

Companion installer support: https://github.com/jdx/mise/pull/12848. Registry adoption: https://github.com/jdx/mise/pull/12845.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the release workflow (artifact generation, validation, and Packslip metadata) with no runtime or auth/data-path changes.
> 
> **Overview**
> The release **packslip** job now builds **Bash, Zsh, and Fish** completion scripts from the Linux release binary, validates them in CI, uploads them to the GitHub release, and registers them as Packslip resources alongside the existing usage KDL.
> 
> A new step installs **zsh** and **fish** (with apt mirror/timeout hardening) so each script can be syntax-checked with `bash -n`, `zsh -n`, and `fish --no-execute`. The publish step also asserts scripts are non-empty, reference **`__complete_word__`**, and that the callback returns **`status`** for `pitchfork st` before **`gh release upload`** ships all four assets.
> 
> Packslip **`resources`** expands from `cli-spec/usage` only to also map **`completion/bash`**, **`completion/zsh`**, and **`completion/fish`** to the uploaded completion files, so installers can wire tab completion without a separate usage tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4add0b6b319567302764bd338cd82f9fea1054a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release packages now include shell completion files for Bash, Zsh, and Fish.
  * Shell completion files are syntax-checked and validated during release creation to help ensure they work correctly.
  * Completion files are available alongside the command usage documentation in release downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->