### PR TITLE
fix(supervisor): stop daemons from removed git worktrees

### DIFF
--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -52,6 +52,14 @@ The [shell hook](/guides/shell-hook) tracks project sessions. With
 stopping when the last session leaves. Without that configuration, moving
 between directories does not stop a manually started service.
 
+Daemons started inside a linked Git worktree are also stopped when that worktree
+is removed, independently of session activity and `auto`. The supervisor checks
+on its regular refresh interval and uses the normal graceful stop behavior.
+It remembers the worktree's Git metadata, so leftover build-cache directories do
+not keep the daemon alive. This tracking is recorded when a daemon starts;
+daemons already running when you upgrade need to be restarted to enable it.
+Main checkouts, submodules, and directories outside Git are unaffected.
+
 ## Choose what to automate
 
 Start with the commands you already run locally, then add only the behavior you

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -56,6 +56,8 @@ pub struct Daemon {
     pub status: DaemonStatus,
     pub dir: Option<PathBuf>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub linked_worktree: Option<crate::linked_worktree::LinkedWorktree>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cmd: Option<Vec<String>>,
     /// Original shell command string, persisted for retry/watch restarts.
     #[serde(skip_serializing_if = "Option::is_none", default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod deps;
 pub mod env;
 pub mod error;
 pub mod ipc;
+pub mod linked_worktree;
 pub mod log_jq;
 pub mod log_parse;
 pub mod log_store;

--- a/src/linked_worktree.rs
+++ b/src/linked_worktree.rs
@@ -1,0 +1,118 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Persisted at spawn so removal can be detected even if a daemon recreates
+/// build-cache directories inside its former worktree.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LinkedWorktree {
+    git_file: PathBuf,
+    git_dir: PathBuf,
+}
+
+impl LinkedWorktree {
+    pub(crate) async fn discover(dir: &Path) -> io::Result<Option<Self>> {
+        let dir = tokio::fs::canonicalize(dir).await?;
+        for root in dir.ancestors() {
+            let git_file = root.join(".git");
+            let metadata = match tokio::fs::metadata(&git_file).await {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error),
+            };
+            // Main checkouts and submodules have different lifecycles. Stop at
+            // the nearest repository boundary rather than adopting an outer one.
+            if !metadata.is_file() {
+                return Ok(None);
+            }
+            let contents = tokio::fs::read_to_string(&git_file).await?;
+            let Some(target) = contents.trim().strip_prefix("gitdir: ") else {
+                return Ok(None);
+            };
+            let git_dir = tokio::fs::canonicalize(root.join(target)).await?;
+            if tokio::fs::try_exists(git_dir.join("commondir")).await?
+                && tokio::fs::try_exists(git_dir.join("gitdir")).await?
+            {
+                return Ok(Some(Self { git_file, git_dir }));
+            }
+            return Ok(None);
+        }
+        Ok(None)
+    }
+
+    pub(crate) async fn is_removed(&self) -> io::Result<bool> {
+        Ok(!tokio::fs::try_exists(&self.git_file).await?
+            || !tokio::fs::try_exists(&self.git_dir).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn detects_removal_despite_recreated_cache_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("checkout");
+        let git_dir = temp.path().join("metadata");
+        tokio::fs::create_dir_all(root.join("app")).await.unwrap();
+        tokio::fs::create_dir_all(&git_dir).await.unwrap();
+        tokio::fs::write(root.join(".git"), "gitdir: ../metadata\n")
+            .await
+            .unwrap();
+        tokio::fs::write(git_dir.join("commondir"), "..\n")
+            .await
+            .unwrap();
+        tokio::fs::write(git_dir.join("gitdir"), "../../checkout/.git\n")
+            .await
+            .unwrap();
+
+        let worktree = LinkedWorktree::discover(&root.join("app"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!worktree.is_removed().await.unwrap());
+        let saved = toml::to_string(&worktree).unwrap();
+        let restored: LinkedWorktree = toml::from_str(&saved).unwrap();
+
+        tokio::fs::remove_dir_all(&root).await.unwrap();
+        tokio::fs::create_dir_all(root.join("app/.vite"))
+            .await
+            .unwrap();
+        assert!(restored.is_removed().await.unwrap());
+
+        tokio::fs::write(root.join(".git"), "gitdir: ../metadata\n")
+            .await
+            .unwrap();
+        tokio::fs::remove_dir_all(&git_dir).await.unwrap();
+        assert!(restored.is_removed().await.unwrap());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn filesystem_errors_are_not_treated_as_removal() {
+        let temp = tempfile::tempdir().unwrap();
+        let git_file = temp.path().join(".git");
+        std::os::unix::fs::symlink(".git", &git_file).unwrap();
+        let worktree = LinkedWorktree {
+            git_file,
+            git_dir: temp.path().to_path_buf(),
+        };
+        assert!(worktree.is_removed().await.is_err());
+        assert!(LinkedWorktree::discover(temp.path()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn ignores_main_checkouts_submodules_and_non_git_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        assert!(LinkedWorktree::discover(root).await.unwrap().is_none());
+        tokio::fs::create_dir(root.join(".git")).await.unwrap();
+        assert!(LinkedWorktree::discover(root).await.unwrap().is_none());
+        tokio::fs::remove_dir(root.join(".git")).await.unwrap();
+        tokio::fs::create_dir(root.join("metadata")).await.unwrap();
+        tokio::fs::write(root.join(".git"), "gitdir: metadata\n")
+            .await
+            .unwrap();
+        assert!(LinkedWorktree::discover(root).await.unwrap().is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod deps;
 mod env;
 mod error;
 mod ipc;
+mod linked_worktree;
 mod log_jq;
 mod log_parse;
 mod log_store;

--- a/src/supervisor/autostop.rs
+++ b/src/supervisor/autostop.rs
@@ -43,6 +43,59 @@ fn canonicalize_pair(a: &Path, b: &Path) -> Option<(PathBuf, PathBuf)> {
 }
 
 impl Supervisor {
+    pub(crate) async fn stop_removed_worktrees(&self) {
+        for daemon in self.active_daemons().await {
+            if !daemon.status.is_running() {
+                continue;
+            }
+            let Some(worktree) = daemon.linked_worktree.as_ref() else {
+                continue;
+            };
+            match worktree.is_removed().await {
+                Ok(true) => {}
+                Ok(false) => continue,
+                Err(error) => {
+                    warn!("could not check worktree for {}: {error}", daemon.id);
+                    continue;
+                }
+            }
+            // Serialize with starts, then recheck the snapshot so deletion of
+            // an old checkout cannot stop a replacement process under this ID.
+            let lock = self.stop_lock(&daemon.id).await;
+            let Ok(guard) = lock.try_lock_owned() else {
+                continue;
+            };
+            // Stops can take the full stop budget. Keep the interval watcher
+            // responsive and hold the lock to avoid scheduling duplicate stops.
+            tokio::spawn(async move {
+                let _guard = guard;
+                let Some(current) = SUPERVISOR.get_daemon(&daemon.id).await else {
+                    return;
+                };
+                if !current.status.is_running()
+                    || current.pid != daemon.pid
+                    || current.start_time != daemon.start_time
+                    || current.linked_worktree != daemon.linked_worktree
+                {
+                    return;
+                }
+                let Some(worktree) = current.linked_worktree.as_ref() else {
+                    return;
+                };
+                if !worktree.is_removed().await.unwrap_or(false) {
+                    return;
+                }
+                info!("stopping {}: its Git worktree was removed", daemon.id);
+                if let Err(error) = SUPERVISOR.stop_locked(&daemon.id).await {
+                    error!(
+                        "failed to stop {} after worktree removal: {error}",
+                        daemon.id
+                    );
+                }
+            });
+        }
+    }
+
     /// Handle shell leaving a directory - schedule autostops for daemons
     pub(crate) async fn leave_dir(&self, dir: &Path) -> Result<()> {
         debug!("left dir {}", dir.display());

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -383,6 +383,14 @@ impl Supervisor {
     ) -> Result<IpcResponse> {
         let id = &opts.id;
         let original_cmd = opts.cmd.clone(); // Save original command for persistence
+        let linked_worktree =
+            match crate::linked_worktree::LinkedWorktree::discover(&opts.dir.0).await {
+                Ok(worktree) => worktree,
+                Err(error) => {
+                    warn!("could not identify worktree for {id}: {error}");
+                    None
+                }
+            };
 
         // Create channel for readiness notification if wait_ready is true
         let (ready_tx, ready_rx) = if opts.wait_ready {
@@ -762,6 +770,7 @@ impl Supervisor {
                 UpsertDaemonOpts::from_run_options(&opts, DaemonStatus::Running)
                     .set(|o| {
                         o.pid = Some(pid);
+                        o.linked_worktree = Some(linked_worktree);
                         o.cmd = Some(original_cmd);
                         o.ready_port = effective_ready_port.map(|p| ReadyPort {
                             port: Some(p),
@@ -1854,7 +1863,7 @@ impl Supervisor {
     }
 
     /// Stop implementation. Caller must hold the daemon's stop lock.
-    async fn stop_locked(&self, id: &DaemonId) -> Result<IpcResponse> {
+    pub(super) async fn stop_locked(&self, id: &DaemonId) -> Result<IpcResponse> {
         let pitchfork_id = DaemonId::pitchfork();
         if *id == pitchfork_id {
             return Ok(IpcResponse::Error(

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -845,6 +845,7 @@ impl Supervisor {
         // errored here is retried on this same tick.
         self.reconcile_unmonitored_daemons().await;
 
+        self.stop_removed_worktrees().await;
         self.check_retry().await?;
         self.process_pending_autostops().await?;
 

--- a/src/supervisor/retry.rs
+++ b/src/supervisor/retry.rs
@@ -5,6 +5,7 @@
 use super::Supervisor;
 use super::hooks::{HookType, fire_hook};
 use crate::daemon_id::DaemonId;
+use crate::daemon_status::DaemonStatus;
 use crate::supervisor::state::UpsertDaemonOpts;
 use crate::{Result, env};
 
@@ -45,6 +46,29 @@ impl Supervisor {
                     _ => continue, // Daemon was removed or no longer needs retry
                 }
             };
+            // A daemon may exit before the worktree-removal sweep observes
+            // it. Do not resurrect it from leftover cache directories.
+            if let Some(worktree) = daemon.linked_worktree.as_ref()
+                && worktree.is_removed().await.unwrap_or(false)
+            {
+                let lock = self.stop_lock(&id).await;
+                let _guard = lock.lock().await;
+                if let Some(current) = self.get_daemon(&id).await
+                    && current.status.is_errored()
+                    && current.pid.is_none()
+                    && current.linked_worktree == daemon.linked_worktree
+                    && worktree.is_removed().await.unwrap_or(false)
+                {
+                    info!("stopping {id}: its Git worktree was removed");
+                    self.upsert_daemon(
+                        UpsertDaemonOpts::builder(id.clone())
+                            .set(|o| o.status = DaemonStatus::Stopped)
+                            .build(),
+                    )
+                    .await?;
+                }
+                continue;
+            }
             info!(
                 "retrying daemon {} ({}/{} attempts)",
                 id,

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -63,6 +63,7 @@ pub(crate) struct UpsertDaemonOpts {
     pub status: DaemonStatus,
     pub shell_pid: Option<u32>,
     pub dir: Option<PathBuf>,
+    pub linked_worktree: Option<Option<crate::linked_worktree::LinkedWorktree>>,
     pub cmd: Option<Vec<String>>,
     pub run: Option<String>,
     pub autostop: bool,
@@ -242,6 +243,9 @@ impl Supervisor {
             shell_pid: opts.shell_pid,
             autostop: opts.autostop || existing.is_some_and(|d| d.autostop),
             dir: opts.dir.or(existing.and_then(|d| d.dir.clone())),
+            linked_worktree: opts
+                .linked_worktree
+                .unwrap_or_else(|| existing.and_then(|d| d.linked_worktree.clone())),
             cmd: opts.cmd.or(existing.and_then(|d| d.cmd.clone())),
             run: opts.run.or(existing.and_then(|d| d.run.clone())),
             cron_schedule: opts

--- a/test/worktree_cleanup.bats
+++ b/test/worktree_cleanup.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+setup() {
+  load test_helper/common_setup
+  bats_require_minimum_version 1.5.0
+  export PITCHFORK_INTERVAL=200ms
+  _common_setup
+}
+
+teardown() {
+  _common_teardown
+}
+
+@test "removed worktrees stop their daemons even with live sessions and leftover caches" {
+  git init --quiet "$TEST_TEMP_DIR/repo"
+  git -C "$TEST_TEMP_DIR/repo" -c user.name=Test -c user.email=test@example.com commit --quiet --allow-empty -m initial
+  local worktree="$TEST_TEMP_DIR/linked"
+  git -C "$TEST_TEMP_DIR/repo" worktree add --quiet --detach "$worktree"
+  cat >"$worktree/pitchfork.toml" <<EOF
+namespace = "linked"
+[daemons.worker]
+run = "sleep 120"
+ready_delay = 0
+retry = true
+EOF
+  cd "$worktree"
+  run pitchfork project enter --pid $$
+  assert_success
+  run pitchfork start worker
+  assert_success
+  local pid
+  pid="$(get_daemon_pid linked/worker)"
+  wait_for_status linked/worker running
+
+  cd "$TEST_TEMP_DIR/repo"
+  run pitchfork run control --delay 0 -- sleep 120
+  assert_success
+  git worktree remove --force "$worktree"
+  mkdir -p "$worktree/app/.vite"
+
+  wait_for_status linked/worker stopped 15
+  run pitchfork status linked/worker
+  refute_output --partial "errored"
+  if pid_alive "$pid"; then
+    echo "Removed worktree's process is still alive: $pid" >&2
+    return 1
+  fi
+  wait_for_status global/control running
+}
+
+@test "worktree identity survives supervisor restart and deletion of the working directory" {
+  git init --quiet "$TEST_TEMP_DIR/repo"
+  git -C "$TEST_TEMP_DIR/repo" -c user.name=Test -c user.email=test@example.com commit --quiet --allow-empty -m initial
+  local worktree="$TEST_TEMP_DIR/linked"
+  git -C "$TEST_TEMP_DIR/repo" worktree add --quiet --detach "$worktree"
+  echo 'namespace = "linked"' >"$worktree/pitchfork.toml"
+  cd "$worktree"
+  run pitchfork run worker --delay 0 -- sleep 120
+  assert_success
+  wait_for_status linked/worker running
+
+  local supervisor_pid
+  supervisor_pid="$(get_daemon_pid global/pitchfork)"
+  [[ -n "$supervisor_pid" ]]
+  kill_pid "$supervisor_pid"
+  sleep 1
+  pitchfork supervisor start >/dev/null 2>&1
+  wait_for_status linked/worker running
+  cd "$TEST_TEMP_DIR/repo"
+  git worktree remove --force "$worktree"
+  wait_for_status linked/worker stopped 15
+}
+
+@test "an exited daemon is not retried from a removed worktree's cache directory" {
+  git init --quiet "$TEST_TEMP_DIR/repo"
+  git -C "$TEST_TEMP_DIR/repo" -c user.name=Test -c user.email=test@example.com commit --quiet --allow-empty -m initial
+  local worktree="$TEST_TEMP_DIR/linked"
+  git -C "$TEST_TEMP_DIR/repo" worktree add --quiet --detach "$worktree"
+  cat >"$worktree/pitchfork.toml" <<EOF
+namespace = "linked"
+[daemons.worker]
+run = "exec sleep 120"
+ready_delay = 0
+retry = true
+EOF
+  cd "$worktree"
+  run pitchfork start worker
+  assert_success
+  local daemon_pid supervisor_pid
+  daemon_pid="$(get_daemon_pid linked/worker)"
+  supervisor_pid="$(get_daemon_pid global/pitchfork)"
+  [[ -n "$daemon_pid" && -n "$supervisor_pid" ]]
+  kill_pid "$supervisor_pid"
+  kill_pid "$daemon_pid"
+  sleep 1
+  cd "$TEST_TEMP_DIR/repo"
+  git worktree remove --force "$worktree"
+  mkdir -p "$worktree/.vite"
+  pitchfork supervisor start >/dev/null 2>&1
+  wait_for_status linked/worker stopped 15
+  sleep 1
+  wait_for_status linked/worker stopped
+}


### PR DESCRIPTION
Removing a linked Git worktree can leave its supervised development servers running indefinitely. Build watchers may recreate cache directories, so checking only the working directory would miss these processes.

Record the linked worktree's Git paths when a daemon starts and persist them with its state. The supervisor checks for removal on its normal refresh interval and stops the daemon through the existing process-group shutdown path, independent of project sessions and `auto`. Stops run outside the interval watcher and revalidate the daemon generation under its stop lock. Filesystem errors do not trigger a stop. The retry path also stops an already-exited daemon instead of resurrecting it from leftover cache directories.

Main checkouts, submodules, and non-Git directories are unaffected. Existing daemons must be restarted after upgrading to record this metadata.

Validation:
- Build, formatting, generated references, documentation build, and documentation link checks pass.
- Three focused Bats regressions cover deletion with live sessions and recreated caches, persisted tracking after supervisor restart, and suppression of retries after a crash.
- Rust suite: 837/839 pass. Both failures are the library/binary copies of `identity_checked_group_kill_reverifies_inside_blocking_op`; both reproduce on unmodified base `772fe72` on macOS.
- Clippy stops on an existing `collapsible_if` in `src/procs.rs:268`, also reproduced on the unmodified base with Rust 1.98.1.
- The full Bats run encountered macOS path assumptions, the system Bash version, a missing `setsid` utility, timing failures, and cron/migration runners that remained alive after printing their last test result. The path, Bash, and timing failures passed targeted reruns with a canonical TMPDIR and current Bash; the missing `setsid` case remains unavailable locally.
- `mise run ci-dev` was attempted, but the cargo wrapper invokes the system mise 2026.8.8 despite running mise 2026.8.16. Used the documented equivalent Cargo checks after building the UI, plus the render/docs tasks. No permanent tooling changes are included.

Opening as a draft pending complete CI validation.

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Daemons started inside linked Git worktrees are now automatically stopped when those worktrees are removed.
  - Cleanup occurs during regular supervisor refreshes and uses graceful shutdown.
  - Removed worktrees no longer trigger daemon retries, even when related build-cache directories remain.

- **Bug Fixes**
  - Worktree tracking persists across supervisor restarts.
  - Main checkouts, submodules, and non-Git directories remain unaffected.

- **Tests**
  - Added coverage for worktree cleanup, restart persistence, and stale-cache handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->