### PR TITLE
fix(proxy): rejoin cookie header fields split by an HTTP/2 client

### DIFF
--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -13,9 +13,9 @@ use std::sync::Arc;
 use axum::Router;
 use axum::body::Body;
 use axum::extract::{Request, State};
-use axum::http::{HeaderValue, StatusCode, Uri};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
-use hyper::header::HOST;
+use hyper::header::{COOKIE, HOST};
 
 /// Response header used to identify a pitchfork proxy (for health checks and debugging).
 const PITCHFORK_HEADER: &str = "x-pitchfork";
@@ -1012,6 +1012,26 @@ fn get_request_host(req: &Request) -> Option<String> {
     })
 }
 
+/// Rejoin a `cookie` header that arrived split across several fields.
+///
+/// An HTTP/2 client may send each cookie as its own header field (RFC 9113
+/// §8.2.3). An HTTP/1.1 backend joins repeated fields with `", "`, which
+/// corrupts every cookie value, so they must be joined with `"; "` first.
+fn join_cookie_fields(headers: &mut HeaderMap) {
+    let fields: Vec<&[u8]> = headers
+        .get_all(COOKIE)
+        .iter()
+        .map(HeaderValue::as_bytes)
+        .collect();
+    if fields.len() < 2 {
+        return;
+    }
+
+    let joined = HeaderValue::from_bytes(&fields.join(b"; ".as_slice()))
+        .expect("valid header values joined with \"; \" form a valid header value");
+    headers.insert(COOKIE, joined);
+}
+
 /// Inject `X-Forwarded-*` headers into a proxied request.
 ///
 /// Because the proxy is a **first-hop** dev tool (not a mid-tier forwarder),
@@ -1219,6 +1239,8 @@ async fn proxy_handler(State(state): State<ProxyState>, mut req: Request) -> Res
     for key in pseudo_headers {
         req.headers_mut().remove(&key);
     }
+
+    join_cookie_fields(req.headers_mut());
 
     // Downgrade the forwarded request to HTTP/1.1. TLS connections negotiate
     // HTTP/2 inbound via ALPN, but the upstream forward client speaks HTTP/1 to
@@ -1925,5 +1947,61 @@ mod tests {
             key_pem.contains("BEGIN") && key_pem.contains("PRIVATE KEY"),
             "should be PEM key"
         );
+    }
+
+    /// The raw `cookie` field values, in the order the map holds them.
+    fn cookie_fields(headers: &HeaderMap) -> Vec<&[u8]> {
+        headers
+            .get_all(COOKIE)
+            .iter()
+            .map(HeaderValue::as_bytes)
+            .collect()
+    }
+
+    /// Several fields become one, joined with `"; "`, and a comma inside a
+    /// value is left alone.
+    #[test]
+    fn test_join_cookie_fields_joins_with_semicolon_space() {
+        let mut headers = HeaderMap::new();
+        headers.append(COOKIE, HeaderValue::from_static("_session=abc123"));
+        headers.append(COOKIE, HeaderValue::from_static("consent=ads,stats"));
+        headers.append(COOKIE, HeaderValue::from_static("theme=dark"));
+
+        join_cookie_fields(&mut headers);
+
+        assert_eq!(
+            cookie_fields(&headers),
+            vec![&b"_session=abc123; consent=ads,stats; theme=dark"[..]]
+        );
+    }
+
+    /// A UTF-8 cookie value is joined like any other, since the join works on
+    /// bytes rather than on visible ASCII.
+    #[test]
+    fn test_join_cookie_fields_joins_bytes_outside_ascii() {
+        let mut headers = HeaderMap::new();
+        headers.append(COOKIE, HeaderValue::from_static("_session=abc123"));
+        headers.append(
+            COOKIE,
+            HeaderValue::from_bytes(b"name=Jos\xc3\xa9").unwrap(),
+        );
+
+        join_cookie_fields(&mut headers);
+
+        assert_eq!(
+            cookie_fields(&headers),
+            vec![&b"_session=abc123; name=Jos\xc3\xa9"[..]]
+        );
+    }
+
+    /// A request without cookies gains none.
+    #[test]
+    fn test_join_cookie_fields_without_cookies() {
+        let mut headers = HeaderMap::new();
+        headers.insert(HOST, HeaderValue::from_static("app.localhost"));
+
+        join_cookie_fields(&mut headers);
+
+        assert!(headers.get(COOKIE).is_none());
     }
 }

--- a/test/proxy.bats
+++ b/test/proxy.bats
@@ -402,3 +402,53 @@ EOF
   rm -rf "$PITCHFORK_STATE_DIR"
   export PITCHFORK_STATE_DIR="$orig_state_dir"
 }
+
+# ============================================================================
+# Header handling tests
+# ============================================================================
+
+@test "proxy rejoins split cookie header fields before forwarding" {
+  local proj="$TEST_TEMP_DIR/split-cookie"
+  mkdir -p "$proj"
+  cd "$proj"
+
+  local echo_script daemon_port proxy_port
+  echo_script="$(to_shell_path "$(script_path cookie_echo_server.py)")"
+  daemon_port=$(_free_port)
+  proxy_port=$(_free_port)
+
+  create_pitchfork_toml <<EOF
+[daemons.cookie-echo]
+run = 'python3 -u $echo_script $daemon_port'
+port = $daemon_port
+ready_http = "http://127.0.0.1:$daemon_port/"
+EOF
+
+  run pitchfork proxy add cookies --daemon cookie-echo
+  assert_success
+
+  # The supervisor owns the proxy listener, so it needs the settings in its own
+  # environment. The one common_setup started predates them. `supervisor start`
+  # returns once the socket accepts, and the supervisor binds the proxy before
+  # it opens the socket, so no sleep is needed.
+  PITCHFORK_PROXY_ENABLE=true \
+    PITCHFORK_PROXY_HTTPS=false \
+    PITCHFORK_PROXY_TLD=localhost \
+    PITCHFORK_PROXY_PORT=$proxy_port \
+    pitchfork supervisor start --force >/dev/null 2>&1
+
+  run pitchfork start cookie-echo
+  assert_success
+
+  # An HTTP/2 client is allowed to send each cookie as its own field, and
+  # browsers do. This sends the two fields over HTTP/1.1, which lands in the
+  # proxy's header map in the same shape; the HTTP/2 decoding itself is
+  # hyper's and is not exercised here.
+  run curl -s -H "Host: cookies.localhost" \
+    -H "Cookie: _session=abc123" \
+    -H "Cookie: theme=dark" \
+    "http://127.0.0.1:$proxy_port/"
+  assert_success
+  assert_output --partial "fields=1"
+  assert_output --partial "cookie=_session=abc123; theme=dark"
+}

--- a/test/scripts/cookie_echo_server.py
+++ b/test/scripts/cookie_echo_server.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""HTTP server that reports the Cookie header fields it received.
+
+A backend behind the proxy must see one Cookie field, whatever the client sent.
+Reporting the field count separately from the values is what makes a split
+header visible: joined wrongly, the values still look plausible.
+
+Usage: cookie_echo_server.py <port>
+"""
+import sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+port = int(sys.argv[1]) if len(sys.argv) > 1 else 18090
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        """Reply with the number of Cookie fields received, then each one."""
+        fields = self.headers.get_all("Cookie", [])
+        body = f"fields={len(fields)}\n"
+        for field in fields:
+            body += f"cookie={field}\n"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(body.encode())
+
+    def log_message(self, format, *args):
+        """Keep request logging out of the daemon's output."""
+
+
+server = HTTPServer(("127.0.0.1", port), Handler)
+print(f"Server listening on http://localhost:{port}")
+server.serve_forever()


### PR DESCRIPTION
An HTTP/2 client may send each cookie as its own `cookie` header field (RFC 9113 §8.2.3), and browsers do. The proxy forwarded those fields untouched to the HTTP/1.1 daemon, which joined them with `", "` under the generic rule for repeated fields, so every cookie after the first became part of the previous cookie's value. A signed session cookie then stopped verifying, and an app that redirects to a login flow looped forever. The proxy now joins the fields with `"; "`, as raw bytes so a UTF-8 cookie value is handled too, at the point where it already strips HTTP/2 pseudo-headers and downgrades the request to HTTP/1.1.

Verified with unit tests for the join and a bats test that runs a daemon echoing the `Cookie` fields it receives through the proxy and asserts one joined field arrives. The automated tests do not exercise hyper's HTTP/2 decoding; that path was verified manually against a Rails app behind the HTTPS proxy over HTTP/2, where a request carrying two `cookie` fields now reaches the app as one joined header and the session cookie verifies again.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5-1; version: 2.1.267.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed proxy handling of requests with multiple `Cookie` headers.
  * Cookies are now combined into a single semicolon-separated header before being forwarded, improving compatibility with HTTP/1.1 backends.
  * Requests containing split cookie fields are forwarded with their cookie values preserved.

* **Tests**
  * Added coverage verifying that split cookie headers are correctly combined and forwarded.
  * Added end-to-end validation against a cookie-reporting backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
