### PR TITLE
chore(ci): use self-repository workflow references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
-    uses: ./.github/workflows/ci-impl.yml
+    uses: $/.github/workflows/ci-impl.yml
     with:
       trusted: true
 
@@ -22,7 +22,7 @@ jobs:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
-    uses: ./.github/workflows/ci-impl.yml
+    uses: $/.github/workflows/ci-impl.yml
     with:
       trusted: false
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -80,7 +80,7 @@ jobs:
       # the packslip's signing and attestation permissions are granted here.
       id-token: write
       attestations: write
-    uses: ./.github/workflows/release.yml
+    uses: $/.github/workflows/release.yml
     with:
       tag: ${{ inputs.tag != '' && inputs.tag || needs.release-plz-release.outputs.tag }}
     secrets:


### PR DESCRIPTION
Use GitHub's `$/` self-repository syntax for the reusable CI and release workflow calls so zizmor 1.30.0 accepts them. Their workflow targets, inputs, permissions, secrets, and conditions are unchanged.

Pitchfork does not configure actionlint, so this PR remains focused on the zizmor migration. The branch was rebased onto current `main` after the earlier unrelated Pkl download failure.

Validation:
- zizmor 1.30.0 passed with online audits enabled
- `mise lock --dry-run --json` returned `[]`
- `git diff --check origin/main...HEAD` passed

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*