### PR TITLE
chore(ci): disable zizmor self-repository audit

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths: [".github/workflows/**"]
+    paths: [".github/workflows/**", ".github/zizmor.yml"]
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor configuration, discovered automatically from .github/.
+rules:
+  # `self-repository` asks for GitHub's `$/` self-repository `uses:` syntax in
+  # place of `./`. GitHub accepts `$/`, but actionlint does not yet
+  # (rhysd/actionlint#711; support sits in the unmerged #732), so adopting it
+  # fails the lint job.
+  #
+  # Disabled rather than ignored per location: the audit is only about which
+  # spelling of a local reference is used and carries no security signal, and
+  # a per-location ignore would need an entry for every reusable workflow call.
+  # Revisit once actionlint ships `$/` support.
+  self-repository:
+    disable: true


### PR DESCRIPTION
Supersedes #846.

zizmor's `self-repository` audit asks for GitHub's `$/` self-repository `uses:` syntax in place of `./` — that is the failing `zizmor` check on `main`, and why #846 switches the references over.

GitHub accepts `$/` (it resolved the path in #846 and the tests ran), but **actionlint rejects it**: `not following the format "owner/repo/path/to/workflow.yml@ref" nor "./path/to/workflow.yml"`. That fails the lint step, which takes `trusted` and `final` down with it. actionlint support is rhysd/actionlint#711, implemented in #732, which is unmerged.

So this keeps `./` and disables the audit in `.github/zizmor.yml` instead. zizmor's docs call disabling a last resort because it can hide new findings, but this audit only ever concerns which spelling of a local reference is used — there is no security signal in it to lose. A per-location ignore would need an entry for every reusable workflow call. The file says to revisit once actionlint ships support.

**Verified locally with zizmor 1.30.1:** 3 `self-repository` findings were the only unsuppressed ones in this repo; with the file, `No findings to report`, exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated automated repository checks to accommodate accepted GitHub workflow reference syntax.
  - Checks now also run when their configuration changes.
  - No changes to product functionality, user experience, or publicly available features.
  - The configuration will be revisited when the related validation tooling supports this syntax natively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->