### PR TITLE
test: kill Windows PIDs with taskkill instead of Git Bash kill

### DIFF
--- a/test/supervisor.bats
+++ b/test/supervisor.bats
@@ -778,7 +778,10 @@ EOF
   assert_output --partial "bootsvc"
   assert_output --partial "running"
 
-  kill_pid "$sup_pid"
+  # $sup_pid is a shell job id, not a PID reported by pitchfork, so signal it
+  # with `kill` the way the other foreground-supervisor tests do. `kill_pid` is
+  # for the Windows PIDs that come out of the state file or `pitchfork status`.
+  kill "$sup_pid" 2>/dev/null || true
   wait "$sup_pid" 2>/dev/null || true
 }
 

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -89,13 +89,27 @@ skip_on_windows() {
 }
 
 # Kill a process by PID, working on both Unix and Windows.
-# On Windows Git Bash, `kill -9` may not terminate native Windows processes.
-# Use taskkill //F //PID as a fallback.
+#
+# Takes a PID reported by pitchfork — the state file or `pitchfork status` —
+# which on Windows is a *Windows* PID. A PID that came from the shell instead,
+# such as a `$!` job id, belongs to the MSYS namespace and must be signalled
+# with plain `kill`; see the foreground-supervisor tests in supervisor.bats.
+#
+# Git Bash resolves `kill`'s argument in the MSYS PID namespace, and the two are
+# disjoint — `ps` reports them side by side as separate `PID` and `WINPID`
+# columns. A Windows PID passed to `kill` therefore does not signal the intended
+# process, and when the number happens to match a live MSYS process it signals
+# that one instead. One of bats' own bash processes is a candidate, and
+# SIGKILLing it tears down the run: the TAP stream stops mid-suite with no
+# failing test and the job exits 2304, which is how MSYS reports a signal death
+# (`signal << 8`). Use taskkill, which speaks Windows PIDs, and do not call
+# `kill` there at all.
 kill_pid() {
   local pid="$1"
-  kill -9 "$pid" 2>/dev/null || true
   if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
     taskkill //F //PID "$pid" 2>/dev/null || true
+  else
+    kill -9 "$pid" 2>/dev/null || true
   fi
 }
 


### PR DESCRIPTION
## Problem

`kill_pid` in `test/test_helper/common_setup.bash` passes a Windows PID to Git Bash's `kill`:

```bash
kill_pid() {
  local pid="$1"
  kill -9 "$pid" 2>/dev/null || true          # <- MSYS PID namespace
  if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
    taskkill //F //PID "$pid" 2>/dev/null || true   # <- Windows PID namespace
  fi
}
```

Every caller reachable on Windows takes its PID from pitchfork — `state.toml` or `pitchfork status`
— so the argument is a **Windows** PID. Git Bash resolves `kill`'s argument in the **MSYS** PID
namespace, and the two are disjoint. `ps` reports them side by side as separate columns:

```
      PID    PPID    PGID     WINPID   TTY         UID    STIME COMMAND
    44956   44949   36405      14560   ?        197611 00:05:28 /usr/bin/bash
```

Two consequences. The call never signals the process it was aimed at. And when the number happens to
match a live MSYS process, it signals **that** process instead — one of bats' own bash processes is a
candidate.

SIGKILLing a bats process tears down the run. The TAP stream stops mid-suite with no failing test
reported, and the job exits **2304**, which is how MSYS surfaces a signal death (`signal << 8`) to
Windows rather than an exit code of 9:

```
$ bash -c "exit 9"      ; echo $LASTEXITCODE   # 9
$ bash -c "kill -9 \$\$" ; echo $LASTEXITCODE   # 2304
```

`bats_exec_suite_status` only ever takes 0, 1 or 130, so 2304 cannot come from bats' own logic.

This is a lottery on PID collision, which is why it is rare and why it favours CI: a freshly booted
runner has both namespaces still allocating small numbers, so they overlap. On a long-lived
workstation shell they drift apart — mine was handing out MSYS PIDs around 49000 against Windows PIDs
in the low thousands, where the two can never collide and the bug is invisible.

## Change

Use `taskkill`, which speaks Windows PIDs, and do not call `kill` on Windows at all. `taskkill //F
//PID` already followed the `kill` and was the call actually doing the work, so this drops a line
rather than adding a guard. Unix is untouched.

The one caller that sources a PID from `pgrep` rather than from pitchfork — `a log sink that dies is
replaced` in `test/logs.bats` — is already `skip_on_windows`, so no caller on Windows is left holding
an MSYS PID.

## Verification

Reproduced end-to-end with a bats file that aims `kill_pid` at its own outermost process, standing in
for a collision. Before, with the current helper:

```
1..3
ok 1 first test runs normally
outermost pid in chain: 51912
exit = 2304
```

The suite is gone: no `not ok`, no `bats warning: Executed N instead of expected M`, tests 2 and 3
never run. This is the signature I originally hit in CI, where a Windows `bats-tests` shard planned
`1..72`, printed `ok 59`, and exited 2304 with nothing else — the next test was
`stopping an adopted daemon fires on_stop and on_exit hooks`, whose first action is
`kill_pid "$sup_pid"`.

After, loading the patched helper:

```
1..3
ok 1 first test runs normally
aiming kill_pid at outermost bats pid: 51972
ok 2 kill_pid aimed at a live MSYS pid must not tear down the suite
ok 3 third test must still run
exit = 0
```

The namespace claim was measured directly rather than assumed:

```
target process: MSYS PID=46392  WINPID=18316
kill -9 18316  -> bash: kill: (18316) - No such process ; target still alive
kill -9 46392  -> target died
```

Regression check on the tests that depend on `kill_pid` actually killing things, run on Windows 11
with the patched helper:

```
ok 1 supervisor run starts in foreground and can be killed
ok 2 orphan_policy=kill terminates orphaned daemons on supervisor restart
ok 3 crashed supervisor re-adopts running daemon by default
ok 4 adopted daemon death is detected and marked errored
ok 5 stopping an adopted daemon fires on_stop and on_exit hooks
ok 6 restart triggers on_stop and on_exit hooks
```

## Note

This does not address every source of Windows `bats-tests` flakiness. `health cmd failure kills
daemon and retry restarts it` has a separate race in its poll loop that fails roughly 2 runs in 10 on
Windows, independent of this change and of any pitchfork build; that one is worth its own change.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process termination on Windows to prevent unrelated MSYS processes from being stopped during test runs.
  * Preserved platform-appropriate process cleanup behavior across Windows and Unix environments.
  * Improved supervisor test shutdown handling for more reliable test execution across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->