### PR TITLE
fix(supervisor): create child processes without a console window on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,11 @@ libc = "0.2"
 nix = { version = "0.31", features = ["signal", "process", "user", "net", "ioctl"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_System_Console",
+  "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/log_store/sqlite.rs
+++ b/src/log_store/sqlite.rs
@@ -264,6 +264,7 @@ impl SqliteLogStore {
         daemon_id: &DaemonId,
         reason: &str,
     ) -> Result<()> {
+        use crate::shell::HideConsoleWindow;
         use std::process::{Command, Stdio};
 
         if entries.is_empty() {
@@ -279,6 +280,7 @@ impl SqliteLogStore {
                 .stderr(Stdio::piped())
                 .env("PITCHFORK_DAEMON_ID", daemon_id.qualified())
                 .env("PITCHFORK_ARCHIVE_REASON", reason)
+                .hide_console_window()
                 .spawn()
                 .into_diagnostic()
                 .map_err(|e| miette::miette!("failed to spawn archive hook: {e}"))?;

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -1,13 +1,13 @@
 use crate::Result;
 #[cfg(unix)]
 use crate::settings::settings;
+#[cfg(windows)]
+use crate::shell::HideConsoleWindow;
 use miette::IntoDiagnostic;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 #[cfg(target_os = "linux")]
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
-#[cfg(windows)]
-use std::os::windows::process::CommandExt;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use sysinfo::ProcessesToUpdate;
@@ -527,7 +527,7 @@ impl Procs {
             let output = std::process::Command::new("taskkill")
                 .args(["/F", "/T", "/PID"])
                 .arg(pid.to_string())
-                .creation_flags(0x08000000) // CREATE_NO_WINDOW
+                .hide_console_window()
                 .output();
             let taskkill_succeeded = match output {
                 Ok(o) if o.status.success() => {

--- a/src/proxy/worktree.rs
+++ b/src/proxy/worktree.rs
@@ -4,6 +4,7 @@
 //! Each entry carries the path, branch/workspace name, and a sanitized
 //! name suitable for use as a URL subdomain prefix.
 
+use crate::shell::HideConsoleWindow;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -33,6 +34,7 @@ fn discover_jj_workspaces(project_dir: &Path) -> Vec<WorktreeEntry> {
     let output = match Command::new("jj")
         .args(["--ignore-working-copy", "workspace", "list"])
         .current_dir(project_dir)
+        .hide_console_window()
         .output()
     {
         Ok(o) if o.status.success() => o.stdout,
@@ -161,6 +163,7 @@ fn get_jj_workspace_root(project_dir: &Path, name: &str) -> Option<PathBuf> {
     let output = Command::new("jj")
         .args(["--ignore-working-copy", "workspace", "root", "--name", name])
         .current_dir(project_dir)
+        .hide_console_window()
         .output()
         .ok()?;
 
@@ -220,6 +223,7 @@ fn discover_git_worktrees(project_dir: &Path) -> Vec<WorktreeEntry> {
     let output = match Command::new("git")
         .args(["worktree", "list", "--porcelain"])
         .current_dir(project_dir)
+        .hide_console_window()
         .output()
     {
         Ok(o) if o.status.success() => o.stdout,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -96,6 +96,103 @@ impl Shell {
     }
 }
 
+/// Prevents a spawned command from creating a console window on Windows.
+///
+/// The supervisor is created with `DETACHED_PROCESS | CREATE_NO_WINDOW`, so it
+/// has no console of its own. On Windows the loader gives every
+/// console-subsystem child of a console-less parent a brand new *visible*
+/// console. Redirecting the child's stdio to pipes or NUL does not suppress
+/// that, because the allocation is decided from the PE subsystem and the
+/// creation flags rather than from the handles, so anything spawned from
+/// inside the supervisor has to opt out explicitly.
+///
+/// Opting out does not leave the child without a console: `CREATE_NO_WINDOW`
+/// gives it one of its own that simply has no window, so console APIs keep
+/// working. Measured on Windows 11 — a child spawned with the flag reports
+/// `GetConsoleCP() = 932` and `GetConsoleProcessList() = 1`, both of which fail
+/// for a process with no console. What changes is only that the console is not
+/// drawn, and that `GetConsoleWindow` returns null for it.
+///
+/// Implemented for both `std::process::Command` and `tokio::process::Command`,
+/// and returns `&mut Self` so it drops into the existing fluent chains. The
+/// non-Windows impls are no-ops, which keeps the call sites free of `cfg`.
+///
+/// The flag is only applied when this process has no console, because that is
+/// the only case where a child would get one of its own. See
+/// `child_would_get_its_own_console`.
+///
+/// Note: `creation_flags` *replaces* a command's creation flags rather than
+/// OR-ing into them. Call this once per command, and after any other
+/// `creation_flags` call, or those flags are silently dropped.
+pub(crate) trait HideConsoleWindow {
+    fn hide_console_window(&mut self) -> &mut Self;
+}
+
+/// Whether a console-subsystem child of this process would be given a console
+/// of its own rather than inheriting one.
+///
+/// A child inherits the parent's console whenever the parent has one, and no
+/// new window appears, so `CREATE_NO_WINDOW` is unnecessary there. It would
+/// also be a behaviour change: the child would be put on a separate console
+/// instead of the shared one, so a console control event sent to the parent's
+/// console would no longer reach it. Detached processes such as the background
+/// supervisor have no console, and only there does a child get a new — and
+/// visible — one.
+///
+/// `GetConsoleWindow` reports the absence of a console *window*, which is not
+/// quite the same as the absence of a console: it also returns null for a
+/// console that has no window, such as a ConPTY session or a process started
+/// with `CREATE_NO_WINDOW` itself. Those cases are counted as "no console"
+/// here, and that costs nothing — the child is then given a console of its own
+/// instead of sharing a console nobody can see, which is what every one of
+/// these spawns did unconditionally before this check existed. What the check
+/// is for is the case it does detect precisely: a supervisor running in the
+/// foreground on a real console, whose children should keep sharing it.
+#[cfg(windows)]
+fn child_would_get_its_own_console() -> bool {
+    let console = unsafe { windows_sys::Win32::System::Console::GetConsoleWindow() };
+    console.is_null()
+}
+
+#[cfg(windows)]
+impl HideConsoleWindow for std::process::Command {
+    fn hide_console_window(&mut self) -> &mut Self {
+        use std::os::windows::process::CommandExt;
+        if child_would_get_its_own_console() {
+            self.creation_flags(windows_sys::Win32::System::Threading::CREATE_NO_WINDOW)
+        } else {
+            self
+        }
+    }
+}
+
+#[cfg(windows)]
+impl HideConsoleWindow for tokio::process::Command {
+    fn hide_console_window(&mut self) -> &mut Self {
+        // tokio exposes `creation_flags` as an inherent method on Windows;
+        // `CommandExt` is not implemented for this type.
+        if child_would_get_its_own_console() {
+            self.creation_flags(windows_sys::Win32::System::Threading::CREATE_NO_WINDOW)
+        } else {
+            self
+        }
+    }
+}
+
+#[cfg(not(windows))]
+impl HideConsoleWindow for std::process::Command {
+    fn hide_console_window(&mut self) -> &mut Self {
+        self
+    }
+}
+
+#[cfg(not(windows))]
+impl HideConsoleWindow for tokio::process::Command {
+    fn hide_console_window(&mut self) -> &mut Self {
+        self
+    }
+}
+
 impl std::fmt::Display for Shell {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -177,5 +274,33 @@ mod tests {
         assert_eq!(default, Shell::Sh);
         #[cfg(windows)]
         assert_eq!(default, Shell::Cmd);
+    }
+
+    /// Checks that `hide_console_window` is available for both command types,
+    /// chains inside a builder expression, and leaves spawning intact.
+    ///
+    /// This does not assert that no console window appears: the reliable
+    /// oracles for that are version-dependent Windows behaviour, so the
+    /// absence of a window is verified manually instead.
+    #[test]
+    fn test_hide_console_window() {
+        let program = if cfg!(windows) { "cmd" } else { "echo" };
+        let args: Vec<&str> = if cfg!(windows) {
+            vec!["/C", "echo hi"]
+        } else {
+            vec!["hi"]
+        };
+
+        let output = std::process::Command::new(program)
+            .args(&args)
+            .hide_console_window()
+            .output()
+            .expect("spawning the child should succeed");
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "hi");
+
+        // Building a tokio command needs no runtime, so this pins the second
+        // impl without making the test async.
+        let mut async_command = tokio::process::Command::new(program);
+        async_command.args(&args).hide_console_window();
     }
 }

--- a/src/supervisor/hooks.rs
+++ b/src/supervisor/hooks.rs
@@ -8,6 +8,7 @@ use crate::Result;
 use crate::daemon_id::DaemonId;
 use crate::pitchfork_toml::PitchforkToml;
 use crate::settings::settings;
+use crate::shell::HideConsoleWindow;
 use crate::supervisor::SUPERVISOR;
 use crate::{env, pitchfork_toml, template};
 use indexmap::IndexMap;
@@ -68,6 +69,7 @@ fn hook_command(cmd: &str) -> Result<tokio::process::Command> {
             let mut command = tokio::process::Command::new(program);
             command.args(args);
             command.arg(cmd);
+            command.hide_console_window();
             Ok(command)
         }
         Ok(_) => Err(miette::miette!(

--- a/src/supervisor/lifecycle.rs
+++ b/src/supervisor/lifecycle.rs
@@ -14,7 +14,7 @@ use crate::log_store::sqlite::LOG_STORE;
 use crate::pitchfork_toml::{ReadyCmd, ReadyHttp, ReadyOutput, ReadyPort};
 use crate::procs::PROCS;
 use crate::settings::settings;
-use crate::shell::Shell;
+use crate::shell::{HideConsoleWindow, Shell};
 use crate::supervisor::state::UpsertDaemonOpts;
 use crate::{Result, env};
 use indexmap::IndexMap;
@@ -159,7 +159,8 @@ pub(crate) fn spawn_cmd_probe(
         .current_dir(dir)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
-        .kill_on_drop(true);
+        .kill_on_drop(true)
+        .hide_console_window();
     apply_runtime_env(&mut command, id, retry_count, daemon_env, resolved_ports);
     let mut child = match command.spawn() {
         Ok(child) => child,
@@ -651,7 +652,7 @@ impl Supervisor {
                 .stderr(std::process::Stdio::piped());
         }
 
-        cmd.args(&args).current_dir(&opts.dir);
+        cmd.args(&args).current_dir(&opts.dir).hide_console_window();
 
         #[cfg(unix)]
         if pty_pair.is_none() {

--- a/src/supervisor/log_sink.rs
+++ b/src/supervisor/log_sink.rs
@@ -31,6 +31,7 @@ use crate::Result;
 use crate::daemon::RunOptions;
 use crate::daemon_id::DaemonId;
 use crate::log_store::LogStore;
+use crate::shell::HideConsoleWindow;
 use crate::supervisor::SUPERVISOR;
 use miette::IntoDiagnostic;
 use std::io::PipeReader;
@@ -472,6 +473,7 @@ impl SinkPipe {
         cmd.stdin(std::process::Stdio::from(reader))
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
+            .hide_console_window()
             .spawn()
             .into_diagnostic()
     }


### PR DESCRIPTION
## Problem

`pitchfork supervisor start` creates the supervisor with `DETACHED_PROCESS | CREATE_NO_WINDOW`
(`src/supervisor/mod.rs`), so the supervisor has no console of its own. On Windows the loader gives
every console-subsystem child of a console-less parent a brand new **visible** console. Redirecting
the child's stdio to pipes or `NUL` does not suppress that — allocation is decided from the PE
subsystem and the creation flags, not from the handles.

None of the spawns that run inside the supervisor passed `CREATE_NO_WINDOW`, so console windows
appear on the desktop during ordinary use. Starting one daemon leaves two behind:

```
> pitchfork run wintest -- ping -n 30 127.0.0.1

   Id ProcessName MainWindowTitle
   -- ----------- ---------------
12120 cmd         C:\WINDOWS\system32\cmd.exe      <- the daemon's shell
20048 pitchfork   ...\pitchfork.exe                <- its `pitchfork log-sink` sibling
```

#602 introduced `CREATE_NO_WINDOW` for the supervisor's own `CreateProcessW` and for the `taskkill`
call in `src/procs.rs`, but the daemon-side spawns were not covered.

## Change

A `HideConsoleWindow` extension trait in `src/shell.rs`, implemented for both
`std::process::Command` and `tokio::process::Command` so it drops into the existing fluent chains,
called at every spawn that executes inside the supervisor. Three of the call sites are chokepoints,
so eight edits cover nine spawn sites:

| Site | Covers |
| --- | --- |
| `lifecycle.rs` daemon spawn | the daemon itself |
| `lifecycle.rs` `spawn_cmd_probe` | `ready_cmd` and `health_cmd`, re-spawned every interval tick |
| `log_sink.rs` `SinkPipe::spawn` | `pitchfork log-sink`, initial start and the respawn loop |
| `hooks.rs` `hook_command` | `fire_hook` and `fire_output_hook` |
| `proxy/worktree.rs` (×3) | `jj workspace list`, `jj workspace root`, `git worktree list` |
| `log_store/sqlite.rs` | the archive hook |
| `procs.rs` | `taskkill`, which already passed the flag as a bare `0x08000000` |

An extension trait rather than a helper function because the two `Command` types are distinct and
four of the sites are fluent chains ending in `.output()`; a free function would force each into a
let-bind and re-chain. The non-Windows impls are no-ops, which is what keeps the call sites free of
`cfg` — a `#[cfg]` cannot be placed inside a builder chain.

### The flag is applied only when this process has no console

A child inherits the parent's console whenever there is one, so no new window appears in that case
and the flag is unnecessary. Setting it anyway would be a behaviour change: the child would be moved
onto a console of its own, out of reach of console control events sent to the shared one. Gating on
`GetConsoleWindow` leaves a foreground `pitchfork supervisor run` behaving exactly as it does today
and confines the change to the detached supervisor, where the child already had a console of its own
and only its visibility changes.

This adds the `Win32_System_Console` feature to the existing `cfg(windows)` `windows-sys` dependency.
`Cargo.lock` is unaffected, since it does not record features.

## Resulting behaviour

No daemon, log sink, hook, readiness probe, health probe, or VCS query started by a background
supervisor puts a console window on the desktop. Unix is untouched — the impls are no-ops there.
Foreground supervisor behaviour is unchanged on every platform.

## Verification

Built on `windows-latest` in CI, then run on Windows 11 Pro 26200 against the released 2.24.2 as a
control, in the same script and on the same machine.

**Daemon and log sink**, starting one daemon:

| | new visible windows |
| --- | --- |
| 2.24.2 | **2** (`cmd.exe`, `pitchfork.exe`) |
| this branch | **0** |

The daemon reports `Status: running` in both cases.

**Readiness/health probes and hooks**, one daemon with `health_cmd` on a 2s interval and an
`on_ready` hook, watched for 40s with an `EnumWindows` + `IsWindowVisible` poll (~3ms per scan):

| | new visible windows |
| --- | --- |
| unpatched | **4** — all `ConsoleWindowClass`: the daemon's shell, the log sink, the probes, the hook |
| this branch | **0** |

The same run confirms the premise directly: the supervisor has zero `conhost.exe` children, i.e. no
console of its own.

**`proxy/worktree.rs`.** This one needs setting up, because `discover_git_worktrees` has a fast path
that reads `.git/worktrees` and skips the subprocess entirely for a main checkout with no linked
worktrees. With a linked worktree present, and a stub `git.exe` ahead on `PATH` that sleeps so no
short-lived window can be missed:

```
unpatched:  STUB GIT invocations 8, NEW VISIBLE WINDOWS 8
            class=ConsoleWindowClass pid=10956 proc=git
            class=ConsoleWindowClass pid=24568 proc=git
            ...  (7 owned by git, 1 unrelated)

this branch: STUB GIT invocations 9, NEW VISIBLE WINDOWS 0
```

These fire on a timer from the proxy slug cache and from the cron watcher, so before this change they
flash repeatedly with no daemons running at all.

**The `GetConsoleWindow` gate.** A supervisor run in the foreground under a host that does own a
console (verified: `GetConsoleWindow` returns non-zero there), then one daemon started:

| | daemon's own `conhost.exe` children | log sink's |
| --- | --- | --- |
| flag applied unconditionally | 1 — its own console | 1 |
| this branch | **0** — inherits the parent's | **0** |

So the gate does what it says: it suppresses the flag exactly when the child would have inherited a
console.

`cargo fmt --check` is clean and `mise run render` produces no diff — no user-facing settings or CLI
surface changed.

## Deliberately not changed

- `src/cli/logs.rs` — the `$PAGER` needs the console it inherits.
- `src/cli/{project.rs,completion.rs,cd.rs}` and the CLI-side spawn in `src/supervisor/mod.rs` —
  these run in a process that already has a console, so no new one is created.
- `src/proxy/trust.rs` — gated to macOS and Linux, not compiled on Windows.
- `src/log_store/sqlite.rs` hardcodes `Command::new("sh")` instead of using `general.shell`. That is
  a separate Windows bug and is left for its own change.

## Test

`src/shell.rs` gains one unit test that the helper is available for both command types, chains inside
a builder expression, and leaves spawning intact. It deliberately does not assert that no window
appears: `GetConsoleWindow`'s return under `CREATE_NO_WINDOW` has varied across Windows releases, and
an `EnumWindows`-based check would be testing conhost rather than pitchfork. The absence of a window
is verified manually, as above.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unwanted console windows from appearing on Windows when running background commands, including hooks, process management, workspace operations, readiness checks, daemon processes, and log handling.
  - Applied console suppression consistently across supported command execution paths without changing behavior on non-Windows platforms.

- **Platform Support**
  - Improved Windows console handling by enabling the required system capabilities for suppressing console windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->