### PR TITLE
test(supervisor): wait for both health failures before asserting status

### DIFF
--- a/test/health.bats
+++ b/test/health.bats
@@ -27,16 +27,18 @@ EOF
   # The daemon must be killed through the crash path (health check named as
   # the reason in the supervisor log), then restarted by the retry checker
   # ("started" once per run), then killed again. End state: errored with
-  # exactly two runs.
+  # exactly two runs. Observe both health-triggered kills before reading
+  # status, so the first run's transient error cannot end the wait early.
   while true; do
-    local sup_log status logs count
+    local sup_log failures status logs count
     sup_log="$PITCHFORK_LOGS_DIR/pitchfork/pitchfork.log"
-    status=$(get_daemon_status unhealthy)
     logs=$(read_logs unhealthy)
+    failures=$(grep -c "killing daemon .* due to health check failure" "$sup_log" || true)
+    status=$(get_daemon_status unhealthy)
     count=$(grep -c "started" <<< "$logs" || true)
     if [[ "$status" == *"errored"* ]] \
       && [[ $count -ge 2 ]] \
-      && grep -q "health check failure" "$sup_log" 2>/dev/null; then
+      && [[ $failures -ge 2 ]]; then
       break
     fi
     if [[ $(date +%s) -ge $deadline ]]; then
@@ -104,12 +106,15 @@ EOF
   local deadline
   deadline=$(($(date +%s) + 40))
 
+  # Observe both health-triggered kills before checking the terminal status.
   while true; do
-    local status logs count
-    status=$(get_daemon_status webhealth)
+    local sup_log failures status logs count
+    sup_log="$PITCHFORK_LOGS_DIR/pitchfork/pitchfork.log"
     logs=$(read_logs webhealth)
+    failures=$(grep -c "killing daemon .* due to health check failure" "$sup_log" || true)
+    status=$(get_daemon_status webhealth)
     count=$(grep -c "Server listening on" <<< "$logs" || true)
-    if [[ "$status" == *"errored"* ]] && [[ $count -ge 2 ]]; then
+    if [[ "$status" == *"errored"* ]] && [[ $count -ge 2 ]] && [[ $failures -ge 2 ]]; then
       break
     fi
     if [[ $(date +%s) -ge $deadline ]]; then
@@ -157,12 +162,15 @@ EOF
   # twice in a row, kill the daemon through the crash path, and the retry
   # checker starts it once more ("Listening on" per run). End state: errored
   # with exactly two runs.
+  # Observe both health-triggered kills before checking the terminal status.
   while true; do
-    local status logs count
-    status=$(get_daemon_status porthealth)
+    local sup_log failures status logs count
+    sup_log="$PITCHFORK_LOGS_DIR/pitchfork/pitchfork.log"
     logs=$(read_logs porthealth)
+    failures=$(grep -c "killing daemon .* due to health check failure" "$sup_log" || true)
+    status=$(get_daemon_status porthealth)
     count=$(grep -c "Listening on" <<< "$logs" || true)
-    if [[ "$status" == *"errored"* ]] && [[ $count -ge 2 ]]; then
+    if [[ "$status" == *"errored"* ]] && [[ $count -ge 2 ]] && [[ $failures -ge 2 ]]; then
       break
     fi
     if [[ $(date +%s) -ge $deadline ]]; then


### PR DESCRIPTION
The Windows health-retry test in #838 can read `errored` from the first run, then read the second run's startup output and exit its polling loop while the retry is still running. Startup output can also arrive before the new running state is persisted.

Require both health-triggered kills to appear in the supervisor log before reading and accepting the terminal status. Apply this to the command, HTTP, and port health tests, retaining the assertions that exactly two runs occurred.

Validation:
- All four tests in `test/health.bats` pass locally.
- A controlled shell reproduction using the original and changed polling loops reproduces both timing windows: the original exits before the second kill; the changed loop waits for it.
- `mise run ci-dev` was run; it stopped on macOS failures in `test_find_project_root_resolves_symlinked_start_dir` (`/var` versus `/private/var`) and `identity_checked_group_kill_reverifies_inside_blocking_op` (process group still present). No Rust code changes are included.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to Bats wait loops; no production supervisor or health-check behavior is modified.
> 
> **Overview**
> **Hardens health-retry Bats polling** so flaky timing (especially on Windows) cannot finish the wait loop after the first run’s transient `errored` state while a retry is still in flight.
> 
> In the command, HTTP, and port health failure tests, each polling loop now **counts supervisor log lines** matching health-check kills and only exits when **`failures >= 2`** alongside the existing checks (terminal `errored`, two run markers in daemon logs). Status is read after that kill count, with comments documenting why.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b694566c92d5d2f9bce4e8ead67700d30a72aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Strengthened health-check failure coverage for command, HTTP, and port checks.
  - Tests now verify that multiple health-triggered process terminations are recorded before confirming failure handling.
  - Improved polling validation helps reduce false positives and provides more reliable verification of supervisor health behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->