### PR TITLE
test(health): give the unhealthy daemons a ready_delay under the health grace

### DIFF
--- a/test/health.bats
+++ b/test/health.bats
@@ -11,10 +11,16 @@ teardown() {
 }
 
 @test "health cmd failure kills daemon and retry restarts it" {
+  # ready_delay has to stay under the health grace period. Health checks begin
+  # as soon as the daemon is running, and `retries * interval` doubles as the
+  # grace a starting daemon gets (see `run_health_checks`), so at the default
+  # 3s delay the kill and the ready both land around the same moment and
+  # `pitchfork start` reports a failure to start whenever the kill wins.
   create_pitchfork_toml <<EOF
 [daemons.unhealthy]
 run = "echo started; sleep 300"
 retry = 1
+ready_delay = 1
 health_cmd = { run = "exit 1", interval = "1s", retries = 2 }
 EOF
 
@@ -93,10 +99,14 @@ EOF
   local http_script
   http_script="$(script_path http_server.py)"
 
+  # ready_delay under the health grace period, as in the health_cmd test above.
+  # An HTTP probe costs no process spawn, so the two failures land a second
+  # apart and the kill arrives earlier here than it does there.
   create_pitchfork_toml <<EOF
 [daemons.webhealth]
 run = "python3 -u $http_script 0 $port 500"
 retry = 1
+ready_delay = 1
 health_http = { url = "http://127.0.0.1:$port/health", interval = "1s", retries = 2 }
 EOF
 


### PR DESCRIPTION
## Problem

Health checks begin as soon as a daemon is `running`, and `retries * interval` doubles as the grace
period a starting daemon gets before the first kill — as `run_health_checks` puts it, "a restart
resets the failure budget, so the `retries * interval` window doubles as the grace period for a
daemon that is still becoming ready".

The two intentionally-unhealthy daemons in `test/health.bats` leave `ready_delay` at its 3s default
while their grace is 2s. Readiness and the kill therefore land on top of each other, and when the
kill wins, `pitchfork start` reports a failure to start before the test's own polling loop is ever
reached:

```
not ok 3 health http failure kills daemon and retry restarts it
# (from function `assert_success' ... in test file test/health.bats, line 111)
#   `assert_success' failed
# status : 1
# output (58 lines):
#   • [.../webhealth] Server listening on http://localhost:2391      <- first run
#   ...
#   • [.../webhealth] Server listening on http://localhost:2391      <- the retry
#   ERROR Daemon .../webhealth failed to start
```

This is upstream of the loop conditions #850 tightened, so it survives that change.

## Change

Set `ready_delay = 1` on `unhealthy` and `webhealth`, putting readiness inside the grace period, with
a comment recording why the two values are coupled.

`health_port` is left alone: its probe passes while the daemon is starting, so it never races.

## Verification

Measured on Windows 11 with the same probe kind the failing test uses — the `500`-returning
`http_server.py`, `health_http` at `interval = "1s", retries = 2` — varying only `ready_delay`, eight
runs each, reading the supervisor log for when readiness and the first health kill were recorded:

| `ready_delay` | ready vs. kill | `pitchfork start` failures |
| --- | --- | --- |
| 1s (this change) | kill not yet logged when `start` returned | **0 / 8** |
| 3s (today's default) | same second in 6 of 8, +1s in the other 2 | 0 / 8 |
| 5s | readiness never reached, kill first | **7 / 8** |

At the default the margin is below the log's one-second resolution, which is why this passes on one
machine and fails on another rather than failing outright. The 5s arm is the direction check: push
`ready_delay` past the grace and the failure becomes the norm, which is what identifies the pair of
values as the controlling variable rather than machine speed on its own.

Pulling the delay under the grace also holds up under load. Readiness is a wall-clock deadline that
does not move, while the kill is gated on an interval tick plus two probes; a slower machine pushes
the kill later and widens the margin instead of closing it.

Five whole-file runs of `test/health.bats` after the change, all green.

## Note on `health_cmd`

`unhealthy` gets the same treatment even though it is the less flaky of the two. Its probe spawns a
shell per attempt, which on Windows costs about a second each and pushes its kill past readiness:

```
03:34:12  starting health checks
03:34:14  is ready
03:34:16  killing daemon ... due to health check failure
```

That margin is a side effect of the probe being slow, not something the configuration guarantees, so
it is worth closing rather than relying on.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated health-check test scenarios to account for daemon readiness timing.
  * Added configuration guidance ensuring the daemon becomes ready before health checks can terminate it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->