### PR TITLE
fix: make clippy pass on windows and check it in ci

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -108,6 +108,14 @@ jobs:
         run: |
           cargo build --all-features
           cargo nextest run --all-features
+      # Not a duplicate of the Linux lint: `#[cfg]` decides whether code exists,
+      # so an unused import or dead function can be real on Windows and absent
+      # on Linux. Nothing else in this workflow runs clippy on Windows.
+      - name: Install Rust components
+        run: rustup component add clippy
+      - name: Run clippy
+        shell: bash
+        run: cargo clippy --all-targets --all-features -- -D warnings
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pitchfork-windows

--- a/src/env.rs
+++ b/src/env.rs
@@ -95,7 +95,10 @@ pub static PITCHFORK_LOG_FILE: Lazy<PathBuf> =
     Lazy::new(|| PITCHFORK_LOGS_DIR.join("pitchfork").join("pitchfork.log"));
 // pub static PITCHFORK_EXEC: Lazy<bool> = Lazy::new(|| var_true("PITCHFORK_EXEC"));
 
+// Unix domain sockets only; Windows IPC uses named pipes, see `ipc::fs_name`.
+#[cfg(unix)]
 pub static IPC_SOCK_DIR: Lazy<PathBuf> = Lazy::new(|| PITCHFORK_STATE_DIR.join("sock"));
+#[cfg(unix)]
 pub static IPC_SOCK_MAIN: Lazy<PathBuf> = Lazy::new(|| IPC_SOCK_DIR.join("main.sock"));
 
 // Capture the PATH at startup so daemons can find user tools

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -220,9 +220,9 @@ fn fs_name(name: &str) -> Result<Name<'_>> {
             hash = hash.wrapping_mul(0x100000001b3);
         }
         let pipe_name = format!("pitchfork-{hash:016x}-{name}");
-        Ok(pipe_name
+        pipe_name
             .to_ns_name::<GenericNamespaced>()
-            .into_diagnostic()?)
+            .into_diagnostic()
     }
 }
 

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -1,6 +1,8 @@
+use crate::Result;
+#[cfg(unix)]
+use crate::env;
 use crate::ipc::{IpcRequest, IpcResponse, deserialize, fs_name, serialize};
 use crate::settings::settings;
-use crate::{Result, env};
 use interprocess::local_socket::ListenerOptions;
 use interprocess::local_socket::tokio::{RecvHalf, SendHalf};
 use interprocess::local_socket::traits::tokio::Listener;

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -98,7 +98,7 @@ impl Procs {
         process_start_token(pid)
     }
 
-    #[cfg(any(unix, windows))]
+    #[cfg(not(windows))]
     fn start_time_matches(&self, pid: u32, expected: u64) -> bool {
         self.start_time(pid) == Some(expected)
     }
@@ -513,8 +513,6 @@ impl Procs {
         stop_signal: i32,
         stop_timeout: Option<std::time::Duration>,
     ) -> Result<bool> {
-        let sysinfo_pid = sysinfo::Pid::from_u32(pid);
-
         debug!("killing process {pid}");
 
         #[cfg(windows)]
@@ -561,6 +559,7 @@ impl Procs {
 
         #[cfg(unix)]
         {
+            let sysinfo_pid = sysinfo::Pid::from_u32(pid);
             let signal_name = signal_name(stop_signal);
             // Send stop signal for graceful shutdown using libc::kill directly
             // so we can distinguish EPERM (permission denied) from ESRCH

--- a/src/proxy/lan_ip.rs
+++ b/src/proxy/lan_ip.rs
@@ -180,11 +180,10 @@ fn fallback_interface_ip() -> Option<Ipv4Addr> {
     None
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
     #[test]
     fn test_is_virtual_interface_loopback() {
         let iface = InterfaceInfo {
@@ -195,7 +194,6 @@ mod tests {
         assert!(is_virtual_interface(&iface));
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_is_virtual_interface_docker() {
         for name in &["veth1234", "br-abc", "docker0"] {
@@ -211,7 +209,6 @@ mod tests {
         }
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_is_virtual_interface_normal() {
         let iface = InterfaceInfo {
@@ -222,7 +219,6 @@ mod tests {
         assert!(!is_virtual_interface(&iface));
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_is_virtual_interface_link_local() {
         let iface = InterfaceInfo {

--- a/src/state_file.rs
+++ b/src/state_file.rs
@@ -318,6 +318,7 @@ impl StateFile {
 
     /// Remove a shell working directory and mark the state dirty.
     /// Returns true if the entry existed.
+    #[cfg(unix)]
     pub fn remove_shell_dir(&mut self, shell_pid: u32) -> bool {
         let removed = self.shell_dirs.remove(&shell_pid.to_string()).is_some();
         if removed {
@@ -362,6 +363,7 @@ impl StateFile {
     }
 
     /// Look up a project session for the given host PID and directory.
+    #[cfg(any(unix, test))]
     pub fn get_project_session(&self, pid: u32, dir: &Path) -> Option<&ProjectSession> {
         self.project_sessions
             .get(&pid.to_string())

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -32,7 +32,9 @@ use crate::procs::PROCS;
 use crate::settings::settings;
 use crate::state_file::StateFile;
 use crate::{Result, env};
+#[cfg(unix)]
 use duct::cmd;
+#[cfg(unix)]
 use miette::IntoDiagnostic;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
@@ -282,6 +284,7 @@ pub fn start_in_background() -> Result<()> {
 /// PID/dir but a new title), we must skip removal to avoid deleting the new
 /// session. The host PID lives in the session key now, so there is no
 /// `liveness_pid` field to compare against.
+#[cfg(any(unix, test))]
 fn should_remove_liveness_session(
     session: &crate::state_file::ProjectSession,
     recorded_title: &Option<String>,
@@ -783,6 +786,7 @@ impl Supervisor {
         let mut last_refreshed_at = self.last_refreshed_at.lock().await;
         *last_refreshed_at = time::Instant::now();
 
+        #[cfg_attr(not(unix), allow(unused_mut))]
         let mut dirs_to_leave: Vec<PathBuf> = Vec::new();
 
         // Prune shell PIDs that are no longer running. This is essential on

--- a/src/supervisor/state.rs
+++ b/src/supervisor/state.rs
@@ -400,6 +400,7 @@ impl Supervisor {
     }
 
     /// Remove a shell PID from tracking
+    #[cfg(unix)]
     pub(crate) async fn remove_shell_pid(&self, shell_pid: u32) -> Result<()> {
         let mut state_file = self.state_file.lock().await;
         state_file.remove_shell_dir(shell_pid);


### PR DESCRIPTION
## Problem

`cargo clippy --all-targets --all-features -- -D warnings` fails on a Windows checkout — 9 errors in
the lib target, then 3 more in the bin target once those are fixed. CI runs clippy on Linux only,
so none of them show up there, but `mise run lint` cannot pass on Windows.

All but one have the same shape: an item used only inside `#[cfg(unix)]` code is itself
unconditional, so on Windows it is an unused import, an unused variable, or dead code. The other is
a `needless_question_mark` (`Ok(x.into_diagnostic()?)`) in the Windows-only named-pipe path.

## Change

Gate each item the same way its only users are gated:

| item | gate | why |
| --- | --- | --- |
| `use crate::env` (ipc/server.rs), `duct::cmd`, `miette::IntoDiagnostic` (supervisor/mod.rs) | `#[cfg(unix)]` | only used in Unix-only blocks |
| `IPC_SOCK_DIR`, `IPC_SOCK_MAIN` | `#[cfg(unix)]` | Unix domain socket paths; Windows uses named pipes |
| `remove_shell_pid`, `remove_shell_dir` | `#[cfg(unix)]` | called only from the Unix-only shell-PID pruning |
| `start_time_matches` | `#[cfg(not(windows))]` | matches its callers' gating |
| `should_remove_liveness_session`, `get_project_session` | `#[cfg(any(unix, test))]` | Unix-only callers, plus unit tests |
| `sysinfo_pid` in `Procs::kill` | moved into the `#[cfg(unix)]` block | its only reads are there |
| `let mut dirs_to_leave` | `#[cfg_attr(not(unix), allow(unused_mut))]` | pushed to only on Unix |
| `lan_ip::tests` | `#[cfg(all(test, unix))]` on the module | every test in it was already `#[cfg(unix)]` |

## CI

The Windows `rust-tests` job now runs `cargo clippy --all-targets --all-features -- -D warnings`
after the tests — the same shape as usage's `test-windows` job. Not a duplicate of the Linux lint:
`#[cfg]` decides whether code exists, so a warning can be real on one platform and absent on the
other. `final` already gates on `rust-tests`.

No behaviour change.

## Verification

- Windows 11: `cargo clippy --all-targets --all-features -- -D warnings` exits 0; `cargo fmt --check` passes.
- The CI step detects the problem: on unfixed `main` it fails at exactly the 13 sites this PR
  touches ([fork run](https://github.com/JamBalaya56562/pitchfork/actions/runs/34624402312)), and
  passes with the fix ([fork run](https://github.com/JamBalaya56562/pitchfork/actions/runs/34624405907),
  all jobs green on Linux and Windows).

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
